### PR TITLE
Disable pre-commit autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 repos:
 -   repo: https://github.com/psf/black
     rev: 23.1.0


### PR DESCRIPTION
Config change to disable "auto-fix" of pre-commit hooks on repo. This is to prevent discrepancies between developers' pushed code and changes made remotely upon push (forces devs to fix their problems locally before push)

### Change description
Added autofix disable flag to pre-commit config

- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)

Tested with deliberate commit with black error, screenshot from Github:

![Screenshot 2023-04-24 150828](https://user-images.githubusercontent.com/95703578/234022294-59b40365-4898-427b-8d75-7a2b31a21121.jpg)
