### PR TITLE
[#PAB-231] split out type casting from validation

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -8,6 +8,7 @@ from werkzeug.datastructures import FileStorage
 
 from core.db import FakeDB
 from core.errors import ValidationError
+from core.validation.casting import cast_to_schema
 from core.validation.validate import validate
 
 EXCEL_MIMETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -26,6 +27,7 @@ def ingest(body):
 
     workbook = extract_data(excel_file=excel_file)
     schema = current_app.config["SCHEMAS"][schema_name]
+    cast_to_schema(workbook, schema)
     validation_failures = validate(workbook, schema)
 
     if validation_failures:

--- a/core/validation/README.md
+++ b/core/validation/README.md
@@ -93,6 +93,19 @@ workbook = {
     }
 ```
 
+### Cast data types to those specified in the schema
+
+This is especially necessary if the source of the data is an Excel spreadsheet, CSV or
+any other format where values are parsed as strings on ingest. This function will
+attempt to cast to the schema, but where it fails it will just continue. Any type
+differences will be picked up by the validation step.
+
+```python
+from validation.casting import cast_to_schema
+
+cast_to_schema(workbook, schema)  # modifies the workbook in place
+```
+
 ### Validate the workbook against the schema
 
 A workbook can be validated against a parsed schema using `validate`, which returns any

--- a/core/validation/casting.py
+++ b/core/validation/casting.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+
+def cast_to_schema(workbook: dict[str, pd.DataFrame], schema: dict) -> None:
+    """
+    Cast the columns in a workbook to the data types specified in the schema. This
+    process modifies workbook in-place.
+
+    This step is needed because data extracted from spreadsheets are often parsed as
+    strings by default.
+
+    :param workbook: A dictionary mapping sheet names to data frames.
+    :param schema: A dictionary specifying the data types for each column in each sheet.
+    :return: None
+    """
+    for sheet_name, sheet in workbook.items():
+        column_to_type = schema[sheet_name]["columns"]
+        sheet_types = sheet.dtypes
+
+        sheet_retyped = False
+        for column, target_type in column_to_type.items():
+            if column in sheet_types:
+                original_type = sheet_types[column]
+
+                if original_type != target_type:
+                    try:
+                        sheet[column] = sheet[column].astype(target_type)
+                        sheet_retyped = True
+                    except ValueError:
+                        continue  # this will be caught during validation
+
+        if sheet_retyped:
+            workbook[sheet_name] = sheet

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -18,24 +18,6 @@ class ValidationFailure(ABC):
 
 
 @dataclass
-class CantCastFailure(ValidationFailure):
-    """Class representing a type casting failure."""
-
-    sheet: str
-    column: str
-    original_type: str
-    target_type: str
-
-    def __str__(self):
-        """Method to get the string representation of the type casting failure."""
-        return (
-            f'Type Casting Failure: Sheet "{self.sheet}" column '
-            f'"{self.column}" couldn\'t cast type from "{self.original_type}" '
-            f'to expected type "{self.target_type}"'
-        )
-
-
-@dataclass
 class ExtraSheetFailure(ValidationFailure):
     """Class representing an extra sheet failure."""
 

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -30,53 +30,8 @@ def validate(
              found.
     """
     extra_sheets = remove_undefined_sheets(workbook, schema)
-    cant_cast = cast_types_to_schema(workbook, schema)
     validation_failures = validate_workbook(workbook, schema)
-    return [*extra_sheets, *cant_cast, *validation_failures]
-
-
-def cast_types_to_schema(
-    workbook: dict[str, pd.DataFrame], schema: dict
-) -> list[vf.CantCastFailure]:
-    """Attempts to change types to those specified in the schema.
-
-    This is necessary because pandas can parse cell values inaccurately.
-    e.g. a column of phone numbers as ints when they should be strings.
-
-    If any values cannot be cast to the type defined in the schema then fail validation
-    and capture.
-
-    :param workbook: a dictionary of pd.DataFrames (worksheets)
-    :param schema: schema containing columns and their expected types
-    :return: any captured CantCantFailures
-    """
-    cant_cast = []
-    for sheet_name, sheet in workbook.items():
-        column_to_type = schema[sheet_name]["columns"]
-        sheet_types = sheet.dtypes
-
-        sheet_retyped = False
-        for column, target_type in column_to_type.items():
-            if column in sheet_types:
-                original_type = sheet_types[column]
-
-                if original_type != target_type:
-                    try:
-                        sheet[column] = sheet[column].astype(target_type)
-                        sheet_retyped = True
-                    except ValueError:
-                        cant_cast.append(
-                            vf.CantCastFailure(
-                                sheet=sheet_name,
-                                column=column,
-                                original_type=original_type,
-                                target_type=target_type,
-                            )
-                        )
-
-        if sheet_retyped:
-            workbook[sheet_name] = sheet
-    return cant_cast
+    return [*extra_sheets, *validation_failures]
 
 
 def remove_undefined_sheets(

--- a/tests/validation_tests/test_casting.py
+++ b/tests/validation_tests/test_casting.py
@@ -1,0 +1,63 @@
+import pandas as pd
+
+from core.validation.casting import cast_to_schema
+
+
+def get_test_workbook_and_schema(values, values_type):
+    workbook = {"Test Sheet": pd.DataFrame.from_dict({"values": values})}
+    schema = {"Test Sheet": {"columns": {"values": values_type}}}
+    return workbook, schema
+
+
+def test_cast_to_schema_str_to_datetime():
+    workbook, schema = get_test_workbook_and_schema(
+        values=["10/10/10", "11/11/11", "12/12/12"], values_type="datetime64[ns]"
+    )
+
+    cast_to_schema(workbook, schema)
+
+    assert workbook["Test Sheet"]["values"].dtype == "datetime64[ns]"
+
+
+def test_cast_to_schema_str_to_int():
+    workbook, schema = get_test_workbook_and_schema(
+        values=["10", "11", "12"], values_type="int64"
+    )
+
+    cast_to_schema(workbook, schema)
+
+    assert workbook["Test Sheet"]["values"].dtype == "int64"
+
+
+def test_cast_to_schema_str_to_float():
+    workbook, schema = get_test_workbook_and_schema(
+        values=["10.10", "11.11", "12.12"], values_type="float64"
+    )
+
+    cast_to_schema(workbook, schema)
+
+    assert workbook["Test Sheet"]["values"].dtype == "float64"
+
+
+def test_cast_to_schema_str_to_bool():
+    workbook, schema = get_test_workbook_and_schema(
+        values=["True", "False", "True"], values_type="bool"
+    )
+
+    cast_to_schema(workbook, schema)
+
+    assert workbook["Test Sheet"]["values"].dtype == "bool"
+
+
+def test_cast_to_schema_continues_on_cast_failure():
+    """Tests that an exception is caught and ignored if types cannot be cast."""
+    workbook, schema = get_test_workbook_and_schema(
+        values=["CANNOT BE CAST AS DATETIME", "11/11/11", "12/12/12"],
+        values_type="datetime64[ns]",
+    )
+
+    cast_to_schema(workbook, schema)
+
+    assert (
+        workbook["Test Sheet"]["values"].dtype == "object"
+    )  # type is not cast and no exception is raised

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -99,12 +99,12 @@ def invalid_workbook():
     return {
         "Project Sheet": pd.DataFrame.from_dict(
             {
-                "Project Started": [True, "False", True],
+                "Project Started": [True, False, True],
                 "Package_ID": ["ABC001", "ABC002", "ABC002"],
-                "Funding Cost": ["1023.50", 544.30, 112339.20],
-                "Project_ID": ["PID001", "PID002", "PID002"],
-                "Amount of funds": [5, 0, 12.3],
-                "Date Started": [datetime.now(), datetime.now(), "12/10/2023"],
+                "Funding Cost": [1023.50, 544.30, 112339.20],
+                "Project_ID": ["PID001", "PID002", "PID003"],
+                "Amount of funds": [5, 0, 12],
+                "Date Started": [datetime.now(), datetime.now(), datetime.now()],
                 "Fund_ID": ["F001", "F002", "F003"],
                 "Extra Column": [0, False, "NA"],
                 "Lookup": ["Lookup1", "Lookup2", "Lookup3"],
@@ -543,7 +543,7 @@ def test_validate_workbook_invalid(valid_workbook_and_schema, invalid_workbook):
 
     assert failures
     assert all(isinstance(failure, ValidationFailure) for failure in failures)
-    assert len(failures) == 12
+    assert len(failures) == 7
 
 
 ####################################


### PR DESCRIPTION
https://trello.com/c/0aP9Yqyb/231-separate-casting-ingested-data-types-to-the-schema-and-validation

### Change description
Split out type casting from the validation function to separate concerns and simplify testing and extension.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
