### PR TITLE
PAB-297: update copilot app to deploy as a backend service

### DIFF
--- a/copilot/.workspace
+++ b/copilot/.workspace
@@ -1,1 +1,1 @@
-application: post-award-data-store
+application: post-award

--- a/copilot/data-store/addons/data-store-cluster.yml
+++ b/copilot/data-store/addons/data-store-cluster.yml
@@ -9,14 +9,14 @@ Parameters:
     Type: String
     Description: The name of the service, job, or workflow being deployed.
   # Customize your Aurora Serverless cluster by setting the default value of the following parameters.
-  postawarddatastoreclusterDBName:
+  datastoreclusterDBName:
     Type: String
     Description: The name of the initial database to be created in the Aurora Serverless v2 cluster.
-    Default: post_award_data_store_db
+    Default: data_api_db
     # Cannot have special characters
     # Naming constraints: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints
 Mappings:
-  postawarddatastoreclusterEnvScalingConfigurationMap:
+  datastoreclusterEnvScalingConfigurationMap:
     test:
       "DBMinCapacity": 0.5 # AllowedValues: from 0.5 through 128
       "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
@@ -26,27 +26,27 @@ Mappings:
       "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
 
 Resources:
-  postawarddatastoreclusterDBSubnetGroup:
+  datastoreclusterDBSubnetGroup:
     Type: 'AWS::RDS::DBSubnetGroup'
     Properties:
       DBSubnetGroupDescription: Group of Copilot private subnets for Aurora Serverless v2 cluster.
       SubnetIds:
         !Split [',', { 'Fn::ImportValue': !Sub '${App}-${Env}-PrivateSubnets' }]
-  postawarddatastoreclusterSecurityGroup:
+  datastoreclusterSecurityGroup:
     Metadata:
-      'aws:copilot:description': 'A security group for your workload to access the Aurora Serverless v2 cluster postawarddatastorecluster'
+      'aws:copilot:description': 'A security group for your workload to access the Aurora Serverless v2 cluster datastorecluster'
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: !Sub 'The Security Group for ${Name} to access Aurora Serverless v2 cluster postawarddatastorecluster.'
+      GroupDescription: !Sub 'The Security Group for ${Name} to access Aurora Serverless v2 cluster datastorecluster.'
       VpcId:
         Fn::ImportValue:
           !Sub '${App}-${Env}-VpcId'
       Tags:
         - Key: Name
           Value: !Sub 'copilot-${App}-${Env}-${Name}-Aurora'
-  postawarddatastoreclusterDBClusterSecurityGroup:
+  datastoreclusterDBClusterSecurityGroup:
     Metadata:
-      'aws:copilot:description': 'A security group for your Aurora Serverless v2 cluster postawarddatastorecluster'
+      'aws:copilot:description': 'A security group for your Aurora Serverless v2 cluster datastorecluster'
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: The Security Group for the Aurora Serverless v2 cluster.
@@ -55,14 +55,14 @@ Resources:
           FromPort: 5432
           IpProtocol: tcp
           Description: !Sub 'From the Aurora Security Group of the workload ${Name}.'
-          SourceSecurityGroupId: !Ref postawarddatastoreclusterSecurityGroup
+          SourceSecurityGroupId: !Ref datastoreclusterSecurityGroup
       VpcId:
         Fn::ImportValue:
           !Sub '${App}-${Env}-VpcId'
       Tags:
         - Key: Name
           Value: !Sub 'copilot-${App}-${Env}-${Name}-Aurora'
-  postawarddatastoreclusterAuroraSecret:
+  datastoreclusterAuroraSecret:
     Metadata:
       'aws:copilot:description': 'A Secrets Manager secret to store your DB credentials'
     Type: AWS::SecretsManager::Secret
@@ -74,7 +74,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-  postawarddatastoreclusterDBClusterParameterGroup:
+  datastoreclusterDBClusterParameterGroup:
     Metadata:
       'aws:copilot:description': 'A DB parameter group for engine configuration values'
     Type: 'AWS::RDS::DBClusterParameterGroup'
@@ -83,33 +83,33 @@ Resources:
       Family: 'aurora-postgresql14'
       Parameters:
         client_encoding: 'UTF8'
-  postawarddatastoreclusterDBCluster:
+  datastoreclusterDBCluster:
     Metadata:
-      'aws:copilot:description': 'The postawarddatastorecluster Aurora Serverless v2 database cluster'
+      'aws:copilot:description': 'The datastorecluster Aurora Serverless v2 database cluster'
     Type: 'AWS::RDS::DBCluster'
     Properties:
       MasterUsername:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref postawarddatastoreclusterAuroraSecret, ":SecretString:username}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref datastoreclusterAuroraSecret, ":SecretString:username}}" ]]
       MasterUserPassword:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref postawarddatastoreclusterAuroraSecret, ":SecretString:password}}" ]]
-      DatabaseName: !Ref postawarddatastoreclusterDBName
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref datastoreclusterAuroraSecret, ":SecretString:password}}" ]]
+      DatabaseName: !Ref datastoreclusterDBName
       Engine: 'aurora-postgresql'
       EngineVersion: '14.4'
-      DBClusterParameterGroupName: !Ref postawarddatastoreclusterDBClusterParameterGroup
-      DBSubnetGroupName: !Ref postawarddatastoreclusterDBSubnetGroup
+      DBClusterParameterGroupName: !Ref datastoreclusterDBClusterParameterGroup
+      DBSubnetGroupName: !Ref datastoreclusterDBSubnetGroup
       Port: 5432
       VpcSecurityGroupIds:
-        - !Ref postawarddatastoreclusterDBClusterSecurityGroup
+        - !Ref datastoreclusterDBClusterSecurityGroup
       ServerlessV2ScalingConfiguration:
         # Replace "All" below with "!Ref Env" to set different autoscaling limits per environment.
-        MinCapacity: !FindInMap [postawarddatastoreclusterEnvScalingConfigurationMap, All, DBMinCapacity]
-        MaxCapacity: !FindInMap [postawarddatastoreclusterEnvScalingConfigurationMap, All, DBMaxCapacity]
-  postawarddatastoreclusterDBWriterInstance:
+        MinCapacity: !FindInMap [datastoreclusterEnvScalingConfigurationMap, All, DBMinCapacity]
+        MaxCapacity: !FindInMap [datastoreclusterEnvScalingConfigurationMap, All, DBMaxCapacity]
+  datastoreclusterDBWriterInstance:
     Metadata:
-      'aws:copilot:description': 'The postawarddatastorecluster Aurora Serverless v2 writer instance'
+      'aws:copilot:description': 'The datastorecluster Aurora Serverless v2 writer instance'
     Type: 'AWS::RDS::DBInstance'
     Properties:
-      DBClusterIdentifier: !Ref postawarddatastoreclusterDBCluster
+      DBClusterIdentifier: !Ref datastoreclusterDBCluster
       DBInstanceClass: db.serverless
       Engine: 'aurora-postgresql'
       PromotionTier: 1
@@ -118,16 +118,16 @@ Resources:
         - !GetAZs
           Ref: AWS::Region
 
-  postawarddatastoreclusterSecretAuroraClusterAttachment:
+  datastoreclusterSecretAuroraClusterAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment
     Properties:
-      SecretId: !Ref postawarddatastoreclusterAuroraSecret
-      TargetId: !Ref postawarddatastoreclusterDBCluster
+      SecretId: !Ref datastoreclusterAuroraSecret
+      TargetId: !Ref datastoreclusterDBCluster
       TargetType: AWS::RDS::DBCluster
 Outputs:
-  postawarddatastoreclusterSecret: # injected as POSTAWARDDATASTORECLUSTER_SECRET environment variable by Copilot.
+  datastoreclusterSecret: # injected as datastoreCLUSTER_SECRET environment variable by Copilot.
     Description: "The JSON secret that holds the database username and password. Fields are 'host', 'port', 'dbname', 'username', 'password', 'dbClusterIdentifier' and 'engine'"
-    Value: !Ref postawarddatastoreclusterAuroraSecret
-  postawarddatastoreclusterSecurityGroup:
+    Value: !Ref datastoreclusterAuroraSecret
+  datastoreclusterSecurityGroup:
     Description: "The security group to attach to the workload."
-    Value: !Ref postawarddatastoreclusterSecurityGroup
+    Value: !Ref datastoreclusterSecurityGroup

--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -23,7 +23,7 @@ image:
 
 cpu: 256       # Number of CPU units for the task.
 memory: 512    # Amount of memory in MiB used by the task.
-platform: linux/x86_64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
+platform: linux/arm64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 network:

--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -1,29 +1,29 @@
-# The manifest for the "post-award-data-store" service.
-# Read the full specification for the "Load Balanced Web Service" type at:
-#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
+# The manifest for the "data-store" service.
+# Read the full specification for the "Backend Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/backend-service/
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
-name: post-award-data-store
-type: Load Balanced Web Service
+name: data-store
+type: Backend Service
 
-# Distribute traffic to your service.
 http:
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
   path: '/'
   # You can specify a custom health check path. The default is "/".
   healthcheck: '/healthcheck'
+# Your service is reachable at "http://data-store.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
 
 # Configuration for your containers and service.
 image:
-  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
   build: Dockerfile
   # Port exposed through your container to route traffic to it.
   port: 8080
 
 cpu: 256       # Number of CPU units for the task.
 memory: 512    # Amount of memory in MiB used by the task.
-platform: linux/x86_64  # See https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#platform
+platform: linux/x86_64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 network:


### PR DESCRIPTION
### Change description
In preparation for the Pen Test, we need to re-configure the API to be a [Backend Service](https://aws.github.io/copilot-cli/docs/manifest/backend-service/), so it is not exposed on the public internet.
This also changes the parent 'app' name to post-award to be in better keeping with copilot conventions


### How to test
Should deploy successfully after merge


### Screenshots of UI changes (if applicable)
