### PR TITLE
Revert "use arm64 platform"

### DIFF
--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -23,7 +23,7 @@ image:
 
 cpu: 256       # Number of CPU units for the task.
 memory: 512    # Amount of memory in MiB used by the task.
-platform: linux/arm64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
+platform: linux/x86_64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 network:


### PR DESCRIPTION
This reverts commit 02503bae1804c04f2fdafd81e32ea9933a98c450.

Deploying on ARM fails on Github Actions as runner is wrong architecture and copilot does not support cross platform target. See: https://github.com/communitiesuk/funding-service-design-post-award-data-store/actions/runs/5047298525/jobs/9053971909#step:5:61 for error.

Reverting for now as this is not trivial to fix without changing our current workflow significantly.


_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
