### PR TITLE
[#PAB-362] add download endpoint

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -1,5 +1,7 @@
 import requests
 
+from core.const import EXCEL_MIMETYPE
+
 
 def create_cli(app):
     """Create command-line interface (CLI) commands for the Flask application.
@@ -20,9 +22,7 @@ def create_cli(app):
         file_path = r"tests/controller_tests/resources/DLUCH_Data_Model_V3.4_EXAMPLE.xlsx"
 
         with open(file_path, "rb") as file:
-            files = {
-                "excel_file": (file.name, file, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-            }
+            files = {"excel_file": (file.name, file, EXCEL_MIMETYPE)}
 
             response = requests.post(url, files=files, data={"schema": "towns_fund"})
 

--- a/core/const.py
+++ b/core/const.py
@@ -1,6 +1,8 @@
 """Module of constants."""
 from enum import StrEnum
 
+EXCEL_MIMETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
 
 class StatusEnum(StrEnum):
     NOT_YET_STARTED = "1. Not yet started"

--- a/core/controllers/download.py
+++ b/core/controllers/download.py
@@ -1,0 +1,85 @@
+"""
+This module provides a Flask endpoint for downloading data from a database. The endpoint supports two file formats: JSON
+and Excel. It retrieves data from the database and returns the data in the requested format.
+"""
+import io
+
+import pandas as pd
+from flask import abort, make_response, request
+
+from core.const import EXCEL_MIMETYPE
+from core.db import db
+from core.db.entities import Package
+
+
+def download():
+    """Handle the download request and return the file in the specified format.
+
+    Supported File Formats:
+    - JSON: Returns the data as a JSON file.
+    - Excel: Returns the data as an Excel file with each table in a separate sheet.
+
+    :return: Flask response object containing the file in the requested format.
+    """
+    file_format = request.args.get("file_format")
+
+    if file_format not in ["json", "xlsx"]:
+        return abort(400), "Invalid file format. Supported formats: json, excel"
+
+    package = Package.query.first()
+    if file_format == "json":
+        file_content = package.to_dict() if package else {}
+        content_type = "application/json"
+        file_extension = "json"
+
+    else:
+        dataframes = db_to_dataframes()
+        file_content = dataframes_to_excel(dataframes)
+        content_type = EXCEL_MIMETYPE
+        file_extension = "xlsx"
+
+    response = make_response(file_content)
+    response.headers.set("Content-Type", content_type)
+    response.headers.set("Content-Disposition", "attachment", filename=f"download.{file_extension}")
+
+    return response
+
+
+def db_to_dataframes() -> dict[str, pd.DataFrame]:
+    """Retrieve data from database tables and return them as pandas DataFrames.
+
+    This function retrieves data from the tables in the database and converts them into pandas DataFrames.
+    Each table in the database is processed individually, and the resulting DataFrame is stored in a dictionary.
+    The table name is used as the key in the dictionary, and the corresponding DataFrame is the value.
+
+    :return: A dictionary where keys represent table names and values are pandas DataFrames.
+    """
+    table_names = db.metadata.tables.keys()
+    dataframes = {}
+    for table_name in table_names:
+        table = db.metadata.tables[table_name]
+        query = db.session.query(table)
+        data = [row._asdict() for row in query]  # noqa
+        df = pd.DataFrame(data)
+        dataframes[table_name] = df
+    return dataframes
+
+
+def dataframes_to_excel(dataframes: dict[str, pd.DataFrame]) -> bytes:
+    """Convert a dictionary of pandas DataFrames to an Excel file and return the file content as bytes.
+
+    This function takes a dictionary of pandas DataFrames and converts them into separate sheets in an Excel file.
+    The sheet name corresponds to the key in the dictionary, and the DataFrame content is written to each sheet.
+    The resulting Excel file content is returned as bytes.
+
+    :param dataframes: A dictionary where keys represent sheet names and values are pandas DataFrames.
+    :return: The content of the Excel file as bytes.
+    """
+    buffer = io.BytesIO()
+    writer = pd.ExcelWriter(buffer, engine="xlsxwriter")
+    for sheet_name, df in dataframes.items():
+        df.to_excel(writer, sheet_name=sheet_name, index=False)
+    writer.save()
+    buffer.seek(0)
+    file_content = buffer.getvalue()
+    return file_content

--- a/core/controllers/examples.py
+++ b/core/controllers/examples.py
@@ -1,2 +1,0 @@
-def example():
-    return [], 200

--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -7,13 +7,12 @@ import pandas as pd
 from flask import abort, current_app
 from werkzeug.datastructures import FileStorage
 
+from core.const import EXCEL_MIMETYPE
 from core.controllers.mappings import TOWNS_FUND_MAPPINGS, DataMapping
 from core.db import db
 from core.errors import ValidationError
 from core.validation.casting import cast_to_schema
 from core.validation.validate import validate
-
-EXCEL_MIMETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 def ingest(body):

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -6,20 +6,35 @@ info:
   version: 0.1.9
 
 paths:
-  /data:
+  /download:
     get:
-      operationId: core.controllers.examples.example
-      summary: Returns a list of data.
-      description: Optional extended description in CommonMark or HTML.
+      operationId: core.controllers.download.download
+      summary: Returns some data in the requested format.
+      description: Takes a file format and returns some data in that format.
+      parameters:
+        - in: query
+          name: file_format
+          schema:
+            type: string
+            enum: [ json, xlsx ]
+          required: true
+          description: Specify the desired file format (json or xlsx)
       responses:
-        '200': # status code
-          description: A JSON array of data
+        '200':
+          description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                type: object
+                properties:
+                  file_content:
+                    type: object
+                    description: The file content in json format.
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+                description: The file content in a binary format.
 
   /ingest:
     post:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -341,6 +341,8 @@ werkzeug==2.2.3
     #   -r requirements.txt
     #   connexion
     #   flask
+xlsxwriter==3.1.1
+    # via -r requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -16,10 +16,11 @@ prance==0.22.*
 openapi-spec-validator==0.5.*
 
 #-----------------------------------
-#   Excel Ingestion
+#   Excel Ingestion and Output
 #-----------------------------------
 pandas==1.5.*
 openpyxl==3.1.*
+XlsxWriter==3.1.*
 
 #-----------------------------------
 #   SQLAlchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -217,6 +217,8 @@ werkzeug==2.2.3
     # via
     #   connexion
     #   flask
+xlsxwriter==3.1.1
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/controller_tests/test_api_status.py
+++ b/tests/controller_tests/test_api_status.py
@@ -1,9 +1,0 @@
-from flask import Flask
-
-
-def test_example(flask_test_client: Flask):
-    endpoint = "/data"
-    response = flask_test_client.get(endpoint)
-
-    assert response.status_code == 200
-    assert response.data.decode().strip() == "[]"

--- a/tests/controller_tests/test_download.py
+++ b/tests/controller_tests/test_download.py
@@ -1,0 +1,64 @@
+import io
+
+import pandas as pd
+
+from core.const import EXCEL_MIMETYPE
+from core.controllers.download import dataframes_to_excel, db_to_dataframes
+from core.db import db
+
+
+def test_invalid_file_format(flask_test_client):
+    response = flask_test_client.get("/download?file_format=invalid")
+    assert response.status_code == 400
+
+
+def test_download_json_format(flask_test_client, seeded_app_ctx):
+    response = flask_test_client.get("/download?file_format=json")
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+
+
+def test_download_excel_format(flask_test_client, seeded_app_ctx):
+    response = flask_test_client.get("/download?file_format=xlsx")
+    assert response.status_code == 200
+    assert response.content_type == EXCEL_MIMETYPE
+
+
+def test_download_json_format_empty_db(flask_test_client, app_ctx):
+    response = flask_test_client.get("/download?file_format=json")
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+
+
+def test_download_excel_format_empty_db(flask_test_client, app_ctx):
+    response = flask_test_client.get("/download?file_format=xlsx")
+    assert response.status_code == 200
+    assert response.content_type == EXCEL_MIMETYPE
+
+
+def test_db_to_dataframes(app_ctx):
+    table_names = db.metadata.tables.keys()
+
+    result = db_to_dataframes()
+
+    assert isinstance(result, dict)
+    assert len(result) == len(table_names)
+
+
+def test_dataframes_to_excel():
+    df1 = pd.DataFrame({"Column1": [1, 2, 3], "Column2": ["A", "B", "C"]})
+    df2 = pd.DataFrame({"Column3": [4, 5, 6], "Column4": ["D", "E", "F"]})
+
+    dataframes = {"Sheet1": df1, "Sheet2": df2}
+
+    file_content = dataframes_to_excel(dataframes)
+
+    assert isinstance(file_content, bytes)
+    assert len(file_content) > 0
+
+    excel_data = pd.read_excel(io.BytesIO(file_content), sheet_name=None)
+
+    assert "Sheet1" in excel_data
+    assert "Sheet2" in excel_data
+    assert excel_data["Sheet1"].equals(df1)
+    assert excel_data["Sheet2"].equals(df2)

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -7,7 +7,8 @@ import pytest
 from flask.testing import FlaskClient
 from werkzeug.datastructures import FileStorage
 
-from core.controllers.ingest import EXCEL_MIMETYPE, extract_data
+from core.const import EXCEL_MIMETYPE
+from core.controllers.ingest import extract_data
 
 resources = Path(__file__).parent / "resources"
 


### PR DESCRIPTION
https://trello.com/c/wBlZvwpn/362-create-data-as-file-api-endpoint

### Change description
Adds an endpoint that returns some data in either xlsx or json format. The data returned is just example data for now.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
