### PR TITLE
PAB-297: drop db prior to seed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           copilot deploy
 
-      - name: Seed data
+      - name: Recreate DB and Seed data
+      # TODO: replace with database migrations prior to production deployment
         run: |
-          copilot svc exec -n "data-store" -c "flask seed"
+          copilot svc exec -n "data-store" -c "flask drop && flask seed"


### PR DESCRIPTION
### Change description
Now we are using Postgres which persists state we need to drop tables in order to pick up schema changes between deployments Note: we will change to use proper migrations prior to production deployment

### How to test
Should deploy successfully on merge

### Screenshots of UI changes (if applicable)
