### PR TITLE
[#PAB-297] bugfix to "flask drop" CLI command

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -61,6 +61,7 @@ def create_cli(app):
             flask drop
         """
         with current_app.app_context():
+            db.session.commit()
             db.drop_all()
             db.create_all()
 


### PR DESCRIPTION
[#PAB-297]

### Change description
Bugfix, database was not dropped due to an open (cached) transaction causing a "table-lock". One -liner to fix this in the `flask drop` cli command.

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
