### PR TITLE
[#PAB-332] Transform round 3 PSI and Risk Register

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -405,23 +405,30 @@ class RiskRegister(BaseModel):
     project_id: Mapped[int] = sqla.orm.mapped_column(sqla.ForeignKey("project_dim.id"), nullable=True)
 
     risk_name = sqla.Column(sqla.String(), nullable=False)
-    risk_category = sqla.Column(sqla.String(), nullable=False)
-    short_desc = sqla.Column(sqla.String(), nullable=False)
-    full_desc = sqla.Column(sqla.String(), nullable=False)
-    consequences = sqla.Column(sqla.String(), nullable=False)
+    risk_category = sqla.Column(sqla.String(), nullable=True)
+    short_desc = sqla.Column(sqla.String(), nullable=True)
+    full_desc = sqla.Column(sqla.String(), nullable=True)
+    consequences = sqla.Column(sqla.String(), nullable=True)
 
-    pre_mitigated_impact = sqla.Column(sqla.Enum(const.ImpactEnum, name="risk_register_pre_mitigated_impact"))
+    pre_mitigated_impact = sqla.Column(
+        sqla.Enum(const.ImpactEnum, name="risk_register_pre_mitigated_impact"),
+        nullable=True,
+    )
     pre_mitigated_likelihood = sqla.Column(
-        sqla.Enum(const.LikelihoodEnum, name="risk_register_pre_mitigated_likelihood")
+        sqla.Enum(const.LikelihoodEnum, name="risk_register_pre_mitigated_likelihood"),
+        nullable=True,
     )
-    mitigations = sqla.Column(sqla.String(), nullable=False)
-    post_mitigated_impact = sqla.Column(sqla.Enum(const.ImpactEnum, name="risk_register_post_mitigated_impact"))
+    mitigations = sqla.Column(sqla.String(), nullable=True)
+    post_mitigated_impact = sqla.Column(
+        sqla.Enum(const.ImpactEnum, name="risk_register_post_mitigated_impact"),
+        nullable=True,
+    )
     post_mitigated_likelihood = sqla.Column(
-        sqla.Enum(const.LikelihoodEnum, name="risk_register_post_mitigated_likelihood")
+        sqla.Enum(const.LikelihoodEnum, name="risk_register_post_mitigated_likelihood"), nullable=True
     )
-    proximity = sqla.Column(sqla.Enum(const.ProximityEnum, name="risk_register_proximity"))
+    proximity = sqla.Column(sqla.Enum(const.ProximityEnum, name="risk_register_proximity"), nullable=True)
 
-    risk_owner_role = sqla.Column(sqla.String(), nullable=False)
+    risk_owner_role = sqla.Column(sqla.String(), nullable=True)
     __table_args__ = (
         # check that either programme or project id exists but not both
         CheckConstraint(

--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -273,9 +273,9 @@ class PrivateInvestment(BaseModel):
     project_id: Mapped[int] = sqla.orm.mapped_column(sqla.ForeignKey("project_dim.id"), nullable=False)
 
     total_project_value = sqla.Column(sqla.Float(), nullable=False)
-    townsfund_funding = sqla.Column(sqla.Float(), nullable=False)
-    private_sector_funding_required = sqla.Column(sqla.Float(), nullable=False)
-    private_sector_funding_secured = sqla.Column(sqla.Float(), nullable=False)
+    townsfund_funding = sqla.Column(sqla.Float(), nullable=False, default=0.0)
+    private_sector_funding_required = sqla.Column(sqla.Float(), nullable=False, default=0.0)
+    private_sector_funding_secured = sqla.Column(sqla.Float(), nullable=False, default=0.0)
     additional_comments = sqla.Column(sqla.String(), nullable=True)
 
     # Unique index for data integrity. Assumption inferred from ingest form that project should be unique per submission

--- a/core/extraction/towns_fund.py
+++ b/core/extraction/towns_fund.py
@@ -49,7 +49,7 @@ def ingest_towns_fund_data(df_ingest: pd.DataFrame) -> Tuple[Dict[str, pd.DataFr
         project_lookup,
     )
 
-    towns_fund_extracted["df_psi_extracted"] = extract_psi(df_ingest["4b - PSI"])
+    towns_fund_extracted["Private Investments"] = extract_psi(df_ingest["4b - PSI"], project_lookup)
 
     towns_fund_extracted["df_outputs_extracted"] = extract_outputs(df_ingest["5 - Project Outputs"], number_of_projects)
     towns_fund_extracted["df_outcomes_extracted"] = extract_outcomes(df_ingest["6 - Outcomes"])
@@ -441,7 +441,7 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.Dat
     return df_funding
 
 
-def extract_psi(df_psi: pd.DataFrame) -> pd.DataFrame:
+def extract_psi(df_psi: pd.DataFrame, project_lookup: dict) -> pd.DataFrame:
     """
     Extract Project PSI rows from a DataFrame.
 
@@ -449,12 +449,24 @@ def extract_psi(df_psi: pd.DataFrame) -> pd.DataFrame:
     Specifically PSI work sheet, parsed as dataframe.
 
     :param df_psi: The input DataFrame containing project data.
+    :param project_lookup: Dict of project_name / project_id mappings for this ingest.
     :return: A new DataFrame containing the extracted PSI rows.
     """
-    df_psi = df_psi.iloc[10:31, 3:]
-    df_psi = df_psi.rename(columns=df_psi.iloc[0]).iloc[1:]
+    df_psi = df_psi.iloc[11:31, 3:]
+    headers = [
+        "Project name",
+        "Total Project Value",
+        "Townsfund Funding",
+        "Private Sector Funding Required",
+        "Private Sector Funding Secured",
+        "gap",
+        "Additional Comments",
+    ]
+    df_psi.columns = headers
     df_psi = drop_empty_rows(df_psi, "Project name")
     df_psi = df_psi.reset_index(drop=True)
+    df_psi.insert(0, "Project ID", df_psi["Project name"].map(project_lookup))
+    df_psi = df_psi.drop(["gap", "Project name"], axis=1)
     return df_psi
 
 


### PR DESCRIPTION
https://trello.com/c/97RfNJ9h


### Change description
Transform PSI ready to load into DB ` PrivateInvestments`
Transform and combine Project and programme risks, into `RiskRegister`
Tweak DB table to allow data for cancelled project, as per example (data rows are empty, but cancellation summary provided in risk name column)


- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


