### PR TITLE
BAU: override default minimum protocol version

### DIFF
--- a/copilot/environments/overrides/README.md
+++ b/copilot/environments/overrides/README.md
@@ -1,0 +1,17 @@
+# Overriding Copilot generated CloudFormation templates with YAML Patches
+
+The file `cfn.patches.yml` contains a list of YAML/JSON patches to apply to
+your template before AWS Copilot deploys it.
+
+To view examples and an explanation of how YAML patches work, check out the [documentation](https://aws.github.io/copilot-cli/docs/developing/overrides/yamlpatch).
+
+Note only [`add`](https://www.rfc-editor.org/rfc/rfc6902#section-4.1),
+[`remove`](https://www.rfc-editor.org/rfc/rfc6902#section-4.2), and
+[`replace`](https://www.rfc-editor.org/rfc/rfc6902#section-4.3)
+operations are supported by Copilot.
+Patches are applied in the order specified in the file.
+
+## Troubleshooting
+
+* `copilot [noun] package` preview the transformed template by writing to stdout.
+* `copilot [noun] package --diff` show the difference against the template deployed in your environment.

--- a/copilot/environments/overrides/cfn.patches.yml
+++ b/copilot/environments/overrides/cfn.patches.yml
@@ -1,0 +1,19 @@
+# Delete the task role resource
+# - op: remove
+#   path: /Resources/TaskRole
+
+# Add a service connect alias
+# - op: add
+#   path: /Resources/Service/Properties/ServiceConnectConfiguration/Services/0/ClientAliases/-
+#   value:
+#     Port: !Ref TargetPort
+#     DnsName: yamlpatchiscool
+
+# Replace the task role in the task definition
+# - op: replace
+#   path: /Resources/TaskDefinition/Properties/TaskRoleArn
+#   value: arn:aws:iam::123456789012:role/MyTaskRole
+
+- op: replace
+  path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/ViewerCertificate/1/MinimumProtocolVersion
+  value: TLSv1.2_2021


### PR DESCRIPTION
### Change description
Patch Copilot environment to fix issue raised in pen test

### How to test
Host should not be accessible using older SSL protocols

see diff:
```
~ Description: CloudFormation environment template for infrastructure shared among Copilot workloads. -> CloudFormation environment template for infrastructure shared among Copilot workloads using AWS Copilot with YAML patches.
~ Resources:
    ~ CloudFrontDistribution:
        ~ Properties:
            ~ DistributionConfig:
                ~ ViewerCertificate:
                    (1 unchanged item)
                    ~ - (changed item)
                      ~ MinimumProtocolVersion: TLSv1 -> TLSv1.2_2021
                    (1 unchanged item)
```

### Screenshots of UI changes (if applicable)
