### PR TITLE
FIX: Fix submission query: invalid input types

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -112,6 +112,8 @@ def next_submission_id(reporting_round: int) -> str:
 
     :return: The next submission ID.
     """
+    # Conversion to cast numpy int types from pandas data extract
+    reporting_round = int(reporting_round)
     latest_submission = (
         Submission.query.filter_by(reporting_round=reporting_round)
         # substring submission number digits, cast to int and order to get the latest submission


### PR DESCRIPTION
BAU_


### Change description
Previous submission id generation is not working with Postgres due to casting problems between pipeline and postgres (postgres can't adapt type "numpy.int64" - Pandas is outputting this numpy type)
Casting the param to python int before the query fixed it.


- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Needs testing on Docker - run compose, try and ingest data / run flask seed CLI command on data-store docker container



