### PR TITLE
add financial period endpoint

### DIFF
--- a/core/controllers/get_filters.py
+++ b/core/controllers/get_filters.py
@@ -1,7 +1,7 @@
 from flask import abort
 
 from core.const import FUND_ID_TO_NAME
-from core.db.entities import Organisation, OutcomeDim, Programme
+from core.db.entities import Organisation, OutcomeDim, Programme, Submission
 
 
 def get_organisation_names():
@@ -47,3 +47,22 @@ def get_outcome_categories():
     outcome_categories = [outcome_dim.outcome_category for outcome_dim in outcome_dims]
 
     return outcome_categories, 200
+
+
+def get_returns():
+    """Returns the start and end of the financial period.
+
+    :return: Minimum reporting start and maximum reporting end period
+    """
+    returns = (
+        Submission.query.with_entities(Submission.reporting_period_start, Submission.reporting_period_end)
+        .distinct()
+        .all()
+    )
+
+    if not returns:
+        return abort(404, "No return periods found.")
+
+    returns_list = [{"start_date": row.reporting_period_start, "end_date": row.reporting_period_end} for row in returns]
+
+    return returns_list, 200

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -182,3 +182,21 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yml#/components/schemas/GeneralError'
+
+  /returns:
+    get:
+      summary: Returns the start and end date reporting period.
+      operationId: core.controllers.get_filters.get_returns
+      responses:
+        '200':
+          description: The min and max reporting period dates
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yml#/components/schemas/ReturnsData'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yml#/components/schemas/GeneralError'

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -85,6 +85,16 @@ components:
         type: string
       example: ["Transport", "Culture", "Economy"]
 
+    ReturnsData:
+      type: array
+      items:
+        type: object
+        properties:
+          start_date:
+            type: string
+          end_date:
+            type: string
+
     GeneralError:
       type: object
       properties:

--- a/tests/controller_tests/test_filters.py
+++ b/tests/controller_tests/test_filters.py
@@ -1,4 +1,9 @@
+from datetime import datetime
+
 from flask.testing import FlaskClient
+
+from core.db import db
+from core.db.entities import Submission
 
 
 def test_get_organisation_names_failure(app: FlaskClient):
@@ -74,3 +79,58 @@ def test_get_outcome_categories(seeded_app_ctx):
 
     assert response_json
     assert all(isinstance(cat, str) for cat in response_json)
+
+
+def test_get_returns_not_found(app: FlaskClient):
+    """Asserts failed retrieval of funds."""
+
+    response = app.get("/returns")
+
+    assert response.status_code == 404
+    assert response.json["detail"] == "No return periods found."
+
+
+def test_get_returns(app_ctx):
+    """Asserts successful retrieval of financial periods."""
+
+    # Create some sample submissions for testing
+    sub1 = Submission(
+        submission_id="1",
+        submission_date=datetime(2023, 5, 1),
+        reporting_period_start=datetime(2023, 4, 1),
+        reporting_period_end=datetime(2023, 4, 30),
+        reporting_round=1,
+    )
+    sub2 = Submission(
+        submission_id="2",
+        submission_date=datetime(2024, 5, 5),
+        reporting_period_start=datetime(2024, 5, 1),
+        reporting_period_end=datetime(2024, 5, 31),
+        reporting_round=2,
+    )
+    sub3 = Submission(
+        submission_id="3",
+        submission_date=datetime(2025, 6, 1),
+        reporting_period_start=datetime(2025, 6, 1),
+        reporting_period_end=datetime(2025, 6, 30),
+        reporting_round=1,
+    )
+    sub4 = Submission(
+        submission_id="4",
+        submission_date=datetime(2021, 6, 5),
+        reporting_period_start=datetime(2021, 6, 1),
+        reporting_period_end=datetime(2021, 6, 30),
+        reporting_round=2,
+    )
+    submissions = [sub1, sub2, sub3, sub4]
+    db.session.add_all(submissions)
+    db.session.flush()
+
+    response = app_ctx.get("/returns")
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+
+    response_json = response.json
+
+    assert response_json == {"start": datetime(2021, 6, 1), "end": datetime(2025, 6, 30)}


### PR DESCRIPTION
https://trello.com/c/qT7fuTec/427-be-endpoint-list-of-financial-periods-covered-by-the-data


### Change description
Returns the start and end reporting dates, as a string representation of the Python datetime object. This format can be changed (eg to a normal string) if required by the front end

- [X ] Unit tests and other appropriate tests added or updated
- [X ] README and other documentation has been updated / added (if needed)
- [X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
