### PR TITLE
[#PAB-427] reporting period range endpoint

### DIFF
--- a/core/controllers/get_filters.py
+++ b/core/controllers/get_filters.py
@@ -1,7 +1,14 @@
 from flask import abort
+from sqlalchemy import func
 
 from core.const import FUND_ID_TO_NAME
-from core.db.entities import Organisation, OutcomeDim, Programme, Project
+from core.db import db
+
+# isort: off
+from core.db.entities import Organisation, OutcomeDim, Programme, Project, Submission
+
+
+# isort: on
 
 
 def get_organisation_names():
@@ -62,3 +69,23 @@ def get_regions():
         return abort(404, "No regions found.")
 
     return list(itl_regions), 200
+
+
+def get_reporting_period_range():
+    """Returns the start and end of the financial period.
+
+    :return: Minimum reporting start and maximum reporting end period
+    """
+    result = db.session.query(
+        func.min(Submission.reporting_period_start), func.max(Submission.reporting_period_end)
+    ).first()
+
+    start = result[0]  # earliest reporting period start date
+    end = result[1]  # latest reporting period end date
+
+    if not start or not end:
+        return abort(404, "No reporting period range found.")
+
+    return_period_range = {"start_date": start, "end_date": end}
+
+    return return_period_range, 200

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -204,3 +204,21 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yml#/components/schemas/GeneralError'
+
+  /reporting-period-range:
+    get:
+      summary: Returns the start and end date reporting period in date-time format e.g. 2025-06-30T00:00:00Z
+      operationId: core.controllers.get_filters.get_reporting_period_range
+      responses:
+        '200':
+          description: Returns the earliest reporting period start date and the latest reporting period end date in the data
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yml#/components/schemas/ReportingPeriodRangeData'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yml#/components/schemas/GeneralError'

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -83,7 +83,19 @@ components:
       type: array
       items:
         type: string
-      example: ["Transport", "Culture", "Economy"]
+      example: [ "Transport", "Culture", "Economy" ]
+
+    ReportingPeriodRangeData:
+      type: object
+      properties:
+        start_date:
+          type: string
+          format: date-time
+          example: 2021-06-01T00:00:00Z
+        end_date:
+          type: string
+          format: date-time
+          example: 2025-06-30T00:00:00Z
 
     RegionData:
       type: array

--- a/tests/controller_tests/test_filters.py
+++ b/tests/controller_tests/test_filters.py
@@ -1,4 +1,10 @@
+from datetime import datetime
+
 from flask.testing import FlaskClient
+
+from core.const import DATETIME_ISO_8610
+from core.db import db
+from core.db.entities import Submission
 
 # TODO: Test these endpoints with specific seeded data that doesn't rely on being seeded via the example data model ss
 
@@ -97,3 +103,59 @@ def test_get_regions(seeded_app_ctx):
 
     assert response_json
     assert all(isinstance(region, str) for region in response_json)
+
+
+def test_get_reporting_period_range_not_found(app: FlaskClient):
+    """Asserts failed retrieval of funds."""
+
+    response = app.get("/reporting-period-range")
+
+    assert response.status_code == 404
+    assert response.json["detail"] == "No reporting period range found."
+
+
+def test_get_reporting_period_range(app_ctx):
+    """Asserts successful retrieval of financial periods."""
+
+    # Create some sample submissions for testing
+    sub1 = Submission(
+        submission_id="1",
+        submission_date=datetime(2023, 5, 1),
+        reporting_period_start=datetime(2023, 4, 1),
+        reporting_period_end=datetime(2023, 4, 30),
+        reporting_round=1,
+    )
+    sub2 = Submission(
+        submission_id="2",
+        submission_date=datetime(2024, 5, 5),
+        reporting_period_start=datetime(2024, 5, 1),
+        reporting_period_end=datetime(2024, 5, 31),
+        reporting_round=2,
+    )
+    sub3 = Submission(
+        submission_id="3",
+        submission_date=datetime(2025, 6, 1),
+        reporting_period_start=datetime(2025, 6, 1),
+        reporting_period_end=datetime(2025, 6, 30),
+        reporting_round=1,
+    )
+    sub4 = Submission(
+        submission_id="4",
+        submission_date=datetime(2021, 6, 5),
+        reporting_period_start=datetime(2021, 6, 1),
+        reporting_period_end=datetime(2021, 6, 30),
+        reporting_round=2,
+    )
+    submissions = [sub1, sub2, sub3, sub4]
+    db.session.add_all(submissions)
+
+    response = app_ctx.get("/reporting-period-range")
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+
+    expected_start = datetime(2021, 6, 1).strftime(DATETIME_ISO_8610) + "Z"
+    expected_end = datetime(2025, 6, 30).strftime(DATETIME_ISO_8610) + "Z"
+
+    response_json = response.json
+    assert response_json == {"start_date": expected_start, "end_date": expected_end}


### PR DESCRIPTION
https://trello.com/c/qT7fuTec/427-be-endpoint-list-of-financial-periods-covered-by-the-data

### Change description
Adds the `/reporting-period-range` endpoint that returns the first reporting period start date and the last reporting period end date in the Submission table.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
