### PR TITLE
BAU_ FIX: blank postcode type errors

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 from flask_sqlalchemy.model import Model
 
 from core.const import POSTCODE_AREA_TO_ITL1
@@ -9,13 +10,16 @@ POSTCODE_AREA_REGEX = r"(^[A-z]{1,2})[0-9R][0-9A-z]?"
 POSTCODE_REGEX = r"[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}"
 
 
-def extract_postcodes(s: str) -> list[str]:
+def extract_postcodes(s: str | float) -> list[str]:
     """Extract postcodes from a string.
 
     :param s: A string from which postcode areas will be extracted.
     :return: A list of postcode areas extracted from the string.
     """
-    postcode_area_matches = re.findall(POSTCODE_REGEX, s)
+    if s is np.nan or s == "":
+        postcode_area_matches = []
+    else:
+        postcode_area_matches = re.findall(POSTCODE_REGEX, s)
     return postcode_area_matches
 
 

--- a/tests/test_postcodes.py
+++ b/tests/test_postcodes.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from core.util import extract_postcodes, postcode_to_itl1
@@ -79,6 +80,14 @@ def test_extract_postcodes_no_matches_returns_single_item_list():
 
 def test_extract_postcodes_no_matches_returns_empty_list():
     postcode_string = ""
+
+    postcodes = extract_postcodes(postcode_string)
+
+    assert postcodes == []
+
+
+def test_extract_postcodes_no_matches_nan_returns_empty_list():
+    postcode_string = np.nan
 
     postcodes = extract_postcodes(postcode_string)
 


### PR DESCRIPTION
### Change description

If user leaves postcode field blank transform gives a weird error when regex tries to run on np.nan (as it's from pandas). 

Handle this case and return empty list.

(NOTE: postcode aka locations field should not actually be nullable on DB, but that's a separate validation issue)

- [x] Unit tests and other appropriate tests added or updated

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


