### PR TITLE
BAU_ FIX: Added Mandatory category lookups

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -461,6 +461,9 @@ OUTPUT_CATEGORIES = {
     "Total length of pedestrian paths improved": "Transport",
     "Total length of resurfaced/improved road": "Transport",
     "Total length of roads converted to cycling or pedestrian ways": "Transport",
+    "# of temporary FT jobs supported": "Mandatory",
+    "# of full-time equivalent (FTE) permanent jobs created through the project": "Mandatory",
+    "# of full-time equivalent (FTE) permanent jobs safeguarded through the project": "Mandatory",
 }
 
 # Hard-coded map of Outcomes to categories, as provided by TF 09/06/2023


### PR DESCRIPTION
Added final 3 Output category lookups as "mandatory"


### Change description

3 new rows added to constants dict

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


