### PR TITLE
BAU_ FIX: expand unique index on Funding

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -462,6 +462,7 @@ class Funding(BaseModel):
             "project_id",
             "funding_source_name",
             "funding_source_type",
+            "secured",
             "start_date",
             "end_date",
             unique=True,


### PR DESCRIPTION
DB table Funding's unique constraint was too tight to allow all valid combinations in. Added "secured" to the index, to allow multiple rows with the same project, funding source and funding name, differentiated only by "secured".

### Change description
Added "secured" to unique index on Funding

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


