### PR TITLE
BAU_ FIX: Strip rows with invalid entry from Outcomes

### DIFF
--- a/core/extraction/towns_fund.py
+++ b/core/extraction/towns_fund.py
@@ -775,6 +775,8 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
     outcomes_df = drop_empty_rows(outcomes_df, "Indicator Name")
     # TODO: could put this back in and catch at validation?
     outcomes_df = drop_empty_rows(outcomes_df, "Relevant project(s)")
+    # Drop rows with Section header selected as the outcome from dropdown on form - This is not a valid outcome option.
+    outcomes_df.drop(outcomes_df[outcomes_df["Relevant project(s)"] == "*** ORIGINAL: ***"].index, inplace=True)
 
     outcomes_df.insert(0, "Project ID", outcomes_df["Relevant project(s)"].map(project_lookup))
     # if ingest form has "multiple" selected for project, then set at programme level instead.


### PR DESCRIPTION
Rows with outcome "*** ORIGINAL***" were being misused in the form to mean no entries. 

Potentially this one could be selected by accident also.

This is not intended as a selectable outcome, removed these rows on ingest


### Change description

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


