### PR TITLE
[BAU_FIX] r3 ingest support for projects with colons in the name

### DIFF
--- a/core/extraction/towns_fund.py
+++ b/core/extraction/towns_fund.py
@@ -437,7 +437,7 @@ def extract_funding_comments(df_input: pd.DataFrame, project_lookup: dict) -> pd
 
     for idx in range(len(project_lookup)):
         line_idx = 28 * idx
-        current_project = df_input.iloc[line_idx, 0].split(": ")[1]
+        current_project = ": ".join(df_input.iloc[line_idx, 0].split(": ")[1:])  # omit the "Project X: " prefix
         comment = df_input.iloc[line_idx + 26, 0]
         fund_row = pd.DataFrame([[current_project, comment]], columns=header)
         df_fund_comments = df_fund_comments.append(fund_row)
@@ -476,7 +476,7 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.Dat
 
     for idx in range(len(project_lookup)):
         line_idx = 28 * idx
-        current_project = df_input.iloc[line_idx, 0].split(": ")[1]
+        current_project = ": ".join(df_input.iloc[line_idx, 0].split(": ")[1:])  # omit the "Project X: " prefix
 
         # Extract only pertinent parts of each subsection
         current_profile = df_input.iloc[line_idx + 5 : line_idx + 8].append(df_input.iloc[line_idx + 9 : line_idx + 11])
@@ -666,7 +666,8 @@ def extract_outputs(df_input: pd.DataFrame, project_lookup: dict) -> pd.DataFram
         if idx >= 1:  # hacky fix to allow for hidden line part way through section for project 1
             line_idx += 1
 
-        current_project = df_input.iloc[line_idx, 0].split(": ")[1]
+        # TODO: write tests for this logic (or preferably for the whole of extract and transform)
+        current_project = ": ".join(df_input.iloc[line_idx, 0].split(": ")[1:])  # omit the "Project X: " prefix
 
         if idx >= 1:  # hacky fix to allow for hidden line part way through section for project 1
             line_idx -= 1


### PR DESCRIPTION
### Change description
Ingest couldn't match project names to ID's if the project name contained a colon ":", resulting in non-nullable ID failures during validation. This change manages this scenario.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
This can be tested by attempting to ingest the `TF_Reporting_Template_(v3.0)_-_TD_-_CASTLEFORD_-_080623.xlsx` ingest ss. This was previously returning lots of validation errors but now passes and ingests.


### Screenshots of UI changes (if applicable)
