### PR TITLE
[#PAB-457]: add initial pre transformation validation

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -554,3 +554,29 @@ OUTCOME_CATEGORIES = {
     "Year on Year monthly % change in footfall": "Place",
     "Year-on-year % change in monthly footfall": "Place",
 }
+
+# A dictionary mapping ingest form periods to ingestion rounds
+REPORTING_PERIOD_DICT = {
+    "2019/20 to 31 March 2022": 1,
+    "1 April 2022 to 30 September 2022": 2,
+    "1 October 2022 to 31 March 2023": 3,
+    "1 April 2023 to 30 September 2023": 4,
+    "1 October 2023 to 31 March 2024": 5,
+    "1 April 2024 to 30 September 2024": 6,
+    "1 October 2024 to 31 March 2025": 7,
+    "1 April 2025 to 30 September 2025": 8,
+    "1 October 2025 to 31 March 2026": 9,
+}
+
+# Sheets we expect to be in the Round 3 ingestion form
+EXPECTED_ROUND_THREE_SHEETS = [
+    "1 - Start Here",
+    "2 - Project Admin",
+    "3 - Programme Progress",
+    "4a - Funding Profiles",
+    "4b - PSI",
+    "5 - Project Outputs",
+    "6 - Outcomes",
+    "7 - Risk Register",
+    "8 - Review & Sign-Off",
+]

--- a/core/extraction/towns_fund.py
+++ b/core/extraction/towns_fund.py
@@ -8,7 +8,10 @@ import numpy as np
 import pandas as pd
 from pandas.tseries.offsets import MonthEnd
 
-from core.const import OUTCOME_CATEGORIES, OUTPUT_CATEGORIES, FundTypeIdEnum
+# isort: off
+from core.const import OUTCOME_CATEGORIES, OUTPUT_CATEGORIES, REPORTING_PERIOD_DICT, FundTypeIdEnum
+
+# isort: on
 from core.extraction.utils import convert_financial_halves, drop_empty_rows
 from core.util import extract_postcodes
 
@@ -87,17 +90,7 @@ def extract_submission_details(submission_period: str) -> pd.DataFrame:
     first_period = "1 April 2019"
     # TODO: Review this - next round is actually Round 4. If the wrong round selected on form, it could wipe data
     #  for the same programme in a different round - we should probably hard-code for now.
-    for period, reporting_round in {
-        "2019/20 to 31 March 2022": 1,
-        "1 April 2022 to 30 September 2022": 2,
-        "1 October 2022 to 31 March 2023": 3,
-        "1 April 2023 to 30 September 2023": 4,
-        "1 October 2023 to 31 March 2024": 5,
-        "1 April 2024 to 30 September 2024": 6,
-        "1 October 2024 to 31 March 2025": 7,
-        "1 April 2025 to 30 September 2025": 8,
-        "1 October 2025 to 31 March 2026": 9,
-    }.items():
+    for period, reporting_round in REPORTING_PERIOD_DICT.items():
         start_str, end_str = period.split(" to ")
 
         # assuming start date of 1st round is 1st April 2019, otherwise extract from string

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -41,7 +41,7 @@ class EmptySheetFailure(ValidationFailure):
 
     def __str__(self):
         """Method to get the string representation of the empty sheet failure."""
-        return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contain no ' "data."
+        return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contains no ' "data."
 
 
 @dataclass
@@ -153,4 +153,50 @@ class NonNullableConstraintFailure(ValidationFailure):
         return (
             f'Non-nullable Constraint Failure: Sheet "{self.sheet}" Column "{self.column}" '
             f"is non-nullable but contains a null value(s)."
+        )
+
+
+@dataclass
+class PreTransformationFailure(ValidationFailure):
+    """Class representing a pre-transformation failure."""
+
+    value_descriptor: str
+    entered_value: str
+    expected_values: set
+
+    def __str__(self):
+        """
+        Method to get the string representation of the pre-transformation failure.
+        """
+        return (
+            f"Pre-transformation Failure: The workbook failed a pre-transformation check for {self.value_descriptor} "
+            f'where the entered value "{self.entered_value}" '
+            f'was outside of the expected values [{", ".join(self.expected_values)}].'
+        )
+
+
+@dataclass
+class NoInputFailure(ValidationFailure):
+    """Class representing a no input failure."""
+
+    value_descriptor: str
+
+    def __str__(self):
+        """
+        Method to get the string representation of the no input failure.
+        """
+        return f"No Input Failure: Expected an input value for {self.value_descriptor}"
+
+
+@dataclass
+class InvalidSheetFailure(ValidationFailure):
+    """Class representing an invalid sheet failure."""
+
+    invalid_sheet: str
+
+    def __str__(self):
+        """Method to get the string representation of the empty sheet failure."""
+        return (
+            f"Invalid Sheets Failure: The sheet named {self.invalid_sheet} is invalid "
+            f"as it is missing expected values"
         )

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -1,0 +1,120 @@
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+import core.validation.failures as vf
+from core.const import EXPECTED_ROUND_THREE_SHEETS
+
+
+def extract_round_three_submission_details(
+    workbook: dict[str, pd.DataFrame]
+) -> dict[str, list[str]] | dict[str, dict[Any, Any]]:
+    """
+    Extract submission details for round three from the given workbook.
+
+    :param workbook: A dictionary where keys are sheet names and values are pandas DataFrames.
+    :return: A dictionary containing the extracted submission details.
+    """
+    details_dict = {"ValueChecks": {}, "NullChecks": {}}
+
+    missing_sheets = check_missing_sheets(EXPECTED_ROUND_THREE_SHEETS, workbook)
+
+    if missing_sheets:
+        return {"Missing Sheets": missing_sheets}
+
+    invalid_sheets = []
+
+    sheet_a1 = workbook.get("1 - Start Here")
+    sheet_a2 = workbook.get("2 - Project Admin")
+    try:
+        details_dict["ValueChecks"]["Form Version"] = (
+            sheet_a1.iloc[6][1],
+            {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
+        )
+        details_dict["ValueChecks"]["Reporting Period"] = (sheet_a1.iloc[4][1], {"1 October 2022 to 31 March 2023"})
+    except IndexError:
+        invalid_sheets.append("1 - Start Here")
+
+    try:
+        details_dict["ValueChecks"]["Fund Type"] = (sheet_a2.iloc[5][4], {"Town_Deal", "Future_High_Street_Fund"})
+        details_dict["NullChecks"]["Place Name"] = sheet_a2.iloc[6][4]
+    except IndexError:
+        invalid_sheets.append("2 - Project Admin")
+
+    if invalid_sheets:
+        return {"Invalid Sheets": missing_sheets}
+
+    return details_dict
+
+
+def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[vf.ValidationFailure]:
+    """
+    Perform pre-transformation checks on the given workbook.
+
+    :param submission_details: A dictionary containing submission details.
+    :return: A list of validation failures encountered during pre-transformation checks.
+    """
+
+    if missing_sheets := submission_details.get("Missing Sheets"):
+        return [vf.EmptySheetFailure(empty_sheet) for empty_sheet in missing_sheets]
+
+    if invalid_sheets := submission_details.get("Invalid Sheets"):
+        return [vf.InvalidSheetFailure(invalid_sheet) for invalid_sheet in invalid_sheets]
+
+    failures = []
+
+    for value_descriptor, (entered_value, expected_values) in submission_details["ValueChecks"].items():
+        if failure := check_values(value_descriptor, entered_value, expected_values):
+            failures.append(failure)
+
+    for value_descriptor, value in submission_details["NullChecks"].items():
+        if failure := check_nulls(value_descriptor, value):
+            failures.append(failure)
+
+    return failures
+
+
+def check_values(value_descriptor: str, entered_value: str, expected_values: set) -> vf.PreTransformationFailure | None:
+    """
+    Check the form input for pre-transformation failures.
+
+    :param value_descriptor: A string describing the form input value.
+    :param entered_value: A string containing the entered value
+    :param expected_values: A set containing the set of expected values.
+    :return: A ValidationFailure object representing the failure, if any.
+    """
+
+    if entered_value not in expected_values:
+        return vf.PreTransformationFailure(
+            value_descriptor=value_descriptor, entered_value=entered_value, expected_values=expected_values
+        )
+
+
+def check_nulls(value_descriptor: str, value: str) -> vf.NoInputFailure | None:
+    """
+    Check the form input for pre-transformation failures.
+
+    :param value_descriptor: A string describing the form input value.
+    :param value: A string containing the form input value.
+    :return: A ValidationFailure object representing the failure, if any.
+    """
+
+    if value in ["", np.nan]:
+        return vf.NoInputFailure(value_descriptor=value_descriptor)
+
+
+def check_missing_sheets(expected_sheets: list[str], workbook: dict[str, pd.DataFrame]) -> list[str]:
+    """
+    Check for missing sheets in the workbook.
+
+    :param expected_sheets: A list of expected sheet names.
+    :param workbook: A dictionary where keys are sheet names and values are pandas DataFrames.
+    :return: A list of missing sheets.
+    """
+    missing_sheets = []
+    for sheet in expected_sheets:
+        if workbook.get(sheet) is None or workbook.get(sheet).empty:
+            missing_sheets.append(sheet)
+
+    return missing_sheets

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -1,0 +1,199 @@
+import pandas as pd
+import pytest
+
+import core.validation.failures as vf
+
+# isort: off
+from core.validation.initial_check import (
+    extract_round_three_submission_details,
+    pre_transformation_check,
+)
+
+
+@pytest.fixture
+def valid_workbook():
+    valid_workbook = {
+        "1 - Start Here": pd.DataFrame(
+            {
+                0: ["", "", "", "", "", "", "", "", ""],
+                1: [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "1 October 2022 to 31 March 2023",
+                    "",
+                    "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
+                    "",
+                    "",
+                ],
+            }
+        ),
+        "2 - Project Admin": pd.DataFrame(
+            {
+                0: ["", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: [
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Are you filling this in for a Town Deal or Future High Street Fund?",
+                    "Please select your place name",
+                    "",
+                    "",
+                ],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "Town_Deal", "Newark", "", ""],
+            }
+        ),
+        "3 - Programme Progress": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "4a - Funding Profiles": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "4b - PSI": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "5 - Project Outputs": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "6 - Outcomes": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "7 - Risk Register": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+        "8 - Review & Sign-Off": pd.DataFrame(
+            {
+                0: ["test", "", "", "", "", "", "", "", ""],
+                1: ["", "", "", "", "", "", "", "", ""],
+                2: ["", "", "", "", "", "", "", "", ""],
+                3: ["", "", "", "", "", "", "", "", ""],
+                4: ["", "", "", "", "", "", "", "", ""],
+            }
+        ),
+    }
+    return valid_workbook
+
+
+@pytest.fixture
+def valid_submission_details():
+    return {
+        "NullChecks": {
+            "Place Name": "Newark",
+        },
+        "ValueChecks": {
+            "Fund Type": ("Town_Deal", {"Town_Deal", "Future_High_Street_Fund"}),
+            "Form Version": (
+                "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
+                {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
+            ),
+            "Reporting Period": ("1 October 2022 to 31 March 2023", {"1 October 2022 to 31 March 2023"}),
+        },
+    }
+
+
+def test_extract_round_three_submission_details(valid_workbook):
+    details_dict = extract_round_three_submission_details(valid_workbook)
+
+    assert "Missing Sheets" not in details_dict
+    assert details_dict["ValueChecks"]["Form Version"] == (
+        "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
+        {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
+    )
+    assert details_dict["ValueChecks"]["Reporting Period"] == (
+        "1 October 2022 to 31 March 2023",
+        {"1 October 2022 to 31 March 2023"},
+    )
+    assert details_dict["ValueChecks"]["Fund Type"] == (
+        "Town_Deal",
+        {"Town_Deal", "Future_High_Street_Fund"},
+    )
+    assert details_dict["NullChecks"]["Place Name"] == "Newark"
+
+
+def test_pre_transformation_check_success(valid_submission_details):
+    failures = pre_transformation_check(valid_submission_details)
+
+    assert len(failures) == 0
+
+
+def test_pre_transformation_check_failures(valid_submission_details):
+    valid_submission_details["ValueChecks"]["Form Version"] = (
+        "Invalid Form Version",
+        {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
+    )
+    failures = pre_transformation_check(valid_submission_details)
+
+    assert len(failures) == 1
+    assert isinstance(failures[0], vf.PreTransformationFailure)
+
+    valid_submission_details["ValueChecks"]["Reporting Period"] = (
+        "Invalid Reporting Period",
+        {"1 October 2022 to 31 March 2023"},
+    )
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 2
+    assert isinstance(failures[1], vf.PreTransformationFailure)
+
+    valid_submission_details["ValueChecks"]["Fund Type"] = (
+        "Invalid Fund Type",
+        {"Town_Deal", "Future_High_Street_Fund"},
+    )
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 3
+    assert isinstance(failures[2], vf.PreTransformationFailure)
+
+    valid_submission_details["NullChecks"]["Place Name"] = ""
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 4
+    assert isinstance(failures[3], vf.NoInputFailure)
+
+    valid_submission_details["Invalid Sheets"] = ["1 - Start Here"]
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 1
+    assert isinstance(failures[0], vf.InvalidSheetFailure)
+
+    valid_submission_details["Missing Sheets"] = ["1 - Start Here"]
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 1
+    assert isinstance(failures[0], vf.EmptySheetFailure)


### PR DESCRIPTION
Added feature to validate file before transformations occur. 

These checks are intended to ensure the following:

- Form version must be: “Town Deals and Future High Streets Fund Reporting Template (v3.0)” → Sheet 1A, column B8
 - Reporting period MUST be round 3. Date input string can be mapped to rounds using the dict in core.extraction.towns_fund.extract_submission_details. It would be worth refactoring the code to have this lookup dict in constants folder since it’s being re-used.
- There must be a valid answer provided for sheet 2, Section A, Question A1 (fund type) → if left blank or “< Select >” then ingest will break.
- As previous point but with A2 (place name)


- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_

For manual testing, the user must attempt to ingest both a valid and invalid file in order to catch the errors above. These checks are only for Round 3 data, and will not apply to other rounds. Therefore, test using Round 3 data. 



