### PR TITLE
Updating the cpu and memory requirements

### DIFF
--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -21,8 +21,8 @@ image:
   # Port exposed through your container to route traffic to it.
   port: 8080
 
-cpu: 256       # Number of CPU units for the task.
-memory: 512    # Amount of memory in MiB used by the task.
+cpu: 1024       # Number of CPU units for the task.
+memory: 2048    # Amount of memory in MiB used by the task.
 platform: linux/x86_64     # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.


### PR DESCRIPTION
* Boosted from .25 of a vCPU to 1 vCPU
* Boosted from 512 MB to a minimum of 2GB

These values are directed from
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html

+ref: 468
+semver: minor

- [ N/A ] Unit tests and other appropriate tests added or updated
- [ N/A ] README and other documentation has been updated / added (if needed)
- [ X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")