### PR TITLE
BAU_ Fix: Migration Name too long

### DIFF
--- a/db/migrations/versions/004_alter_field_nullabilities.py
+++ b/db/migrations/versions/004_alter_field_nullabilities.py
@@ -1,6 +1,6 @@
 """empty message
 
-Revision ID: 004_alter_field_nullabilities_for_round_1_data
+Revision ID: 004_alter_field_nullabilities
 Revises: dee94a0080e2
 Create Date: 2023-06-16 10:12:27.000185
 
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "004_alter_field_nullabilities_for_round_1_data"
+revision = "004_alter_field_nullabilities"
 down_revision = "dee94a0080e2"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION

### Change description
Migration name was over 32 char limit set by alembic, so crashed out when building


- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

