### PR TITLE
PAB-306: Add sentry integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import connexion
 from flask import Flask
+from fsd_utils import init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.logging import logging
@@ -17,6 +18,7 @@ WORKING_DIR = Path(__file__).parent
 
 
 def create_app(config_class=Config) -> Flask:
+    init_sentry()
     connexion_options = {"swagger_url": "/"}
     connexion_app = connexion.FlaskApp(
         "Sample API",

--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -36,6 +36,8 @@ network:
 #
 variables:                    # Pass environment variables as key value pairs.
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
+  # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
+  SENTRY_DSN: https://6a2623e302e641ba88eabe6675a70ddf@o1432034.ingest.sentry.io/4505390859747328
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 


### PR DESCRIPTION
### Change description
Add Sentry integration to alert on exceptions, using existing functionality in utils library.


### How to test
Have tested manually locally. Will not cause any changes locally unless you have `SENTRY_DSN` env var set.
