### PR TITLE
PAB-306: set git sha as env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,9 +40,14 @@ jobs:
         run: |
           curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
 
+      - name: Inject Git SHA into manifest
+        run: |
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
+
       - name: Copilot deploy
         run: |
           copilot deploy --env ${{ inputs.environment || 'test' }}
+
 
       # TODO: Replace with Task and perform before deploy step
       - name: Run database migrations


### PR DESCRIPTION
### Change description
Adds git sha env var

This is useful for debugging and propagates to the healthcheck and to sentry e.g.

```
# curl localhost:8080/healthcheck
{"checks":[{"check_flask_running":"OK"}],"version":"b8adfde5ed318928227274a93eef295520755e5d"}
```


### How to test
Tested by deploying branch to Code env with branch deploy
