### PR TITLE
PAB-304: make concurrency per-environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: push to AWS
-concurrency: deploy
+concurrency: deploy-${{ inputs.environment || 'test' }}
 on:
   push:
     branches:


### PR DESCRIPTION
### Change description
Previously concurrency restriction was global, it should be environment specific, now we're deploying to test and prod.


### How to test
Can test post-merge