### PR TITLE
BAU: set protocol version to HTTP/1.1

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.logging import logging
 from sqlalchemy import event
+from werkzeug.serving import WSGIRequestHandler
 
 from config import Config
 from core.cli import create_cli
@@ -57,6 +58,7 @@ def create_app(config_class=Config) -> Flask:
 
     health = Healthcheck(flask_app)
     health.add_check(FlaskRunningChecker())
+    WSGIRequestHandler.protocol_version = "HTTP/1.1"
     return flask_app
 
 


### PR DESCRIPTION
### Change description
 keep connection alive as should enable keep-alive on long running request

Theory is connections were timing out as we weren't sending a Keep-Alive on the long running requests, changing this setting updates this by proxy as described in: https://stackoverflow.com/a/10528211

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have tested on test environment and appears to have fixed downloads
