### PR TITLE
PAB-306: run migration as task

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,16 +45,7 @@ jobs:
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
 
       - name: Run database migrations
-        run: |
-          copilot task run \
-          --app post-award \
-          --follow \
-          --command "flask db upgrade" \
-          --env ${{ inputs.environment || 'test' }} \
-          --env-vars FLASK_ENV=${{ inputs.environment || 'test' }} \
-          --secrets DATASTORECLUSTER_SECRET=${{ secrets.DATASTORECLUSTER_SECRET_ARN }} \
-          --security-groups ${{ secrets.DATASTORECLUSTER_SECURITY_GROUP }} \
-          --task-group-name "db-migrate"
+        run: scripts/migration-task-script.sh --environment ${{ inputs.environment || 'test' }}
 
       - name: Copilot deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
 
       - name: Run database migrations
-        run: scripts/migration-task-script.sh --environment ${{ inputs.environment || 'test' }}
+        run: scripts/migration-task-script.sh --environment ${{ inputs.environment || 'test' }} --command "flask db upgrade"
 
       - name: Copilot deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
 
       - name: Run database migrations
-        run: scripts/migration-task-script.sh --environment ${{ inputs.environment || 'test' }} --command "flask db upgrade"
+        run: scripts/migration-task-script.sh test "flask db upgrade"
 
       - name: Copilot deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,12 +44,18 @@ jobs:
         run: |
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
 
+      - name: Run database migrations
+        run: |
+          copilot task run \
+          --app post-award \
+          --follow \
+          --command "flask db upgrade" \
+          --env ${{ inputs.environment || 'test' }} \
+          --env-vars FLASK_ENV=${{ inputs.environment || 'test' }} \
+          --secrets DATASTORECLUSTER_SECRET=${{ secrets.DATASTORECLUSTER_SECRET_ARN }} \
+          --security-groups ${{ secrets.DATASTORECLUSTER_SECURITY_GROUP }} \
+          --task-group-name "db-migrate"
+
       - name: Copilot deploy
         run: |
           copilot deploy --env ${{ inputs.environment || 'test' }}
-
-
-      # TODO: Replace with Task and perform before deploy step
-      - name: Run database migrations
-        run: |
-          copilot svc exec -n "data-store" -c "flask db upgrade" --env ${{ inputs.environment || 'test' }}

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,7 +1,7 @@
 filename=generated_command_taskrun.sh
 echo '' >$filename
 
-(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/') >>$filename
+(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | | sed 's/--command.*/d \\/') >>$filename
 
 cat <<EOF >>$filename
 --follow \\

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,13 +1,21 @@
 filename=generated_command_taskrun.sh
 echo '' >$filename
-(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/--command \"/bin/sh -c \'flask db current ; echo EXEC-EXIT-CODE=\\\$?\'\"\\/g') >>$filename
+
+(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/') >>$filename
+
 cat <<EOF >>$filename
 --follow \\
 --task-group-name "db-migrate" \\
 EOF
+
+echo "--command \"/bin/sh -c 'flask db current ; echo EXEC-EXIT-CODE=\\\$?'\"" >>$filename
+
 source $filename | tee /tmp/exec-output
+
 exitcode=$(sed -nr 's/.* EXEC-EXIT-CODE=([0-9]+)/\1/p' /tmp/exec-output | tr -d '\r\n')
+
 echo got exit code "'$exitcode'"
+
 if [ -z "$exitcode" ]; then
   echo could not find exit code in copilot output
   exit 1

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,7 +1,7 @@
 filename=generated_command_taskrun.sh
 echo '' >$filename
 
-(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | | sed 's/--command.*/d \\/') >>$filename
+(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/d \\/') >>$filename
 
 cat <<EOF >>$filename
 --follow \\

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,16 +1,48 @@
 #!/usr/bin/env bash
 
+# Define the options
+options="-l environment:,command:,"
+
+# Initialize the variables
+environment="test"
+command="flask db current"
+
+# Get the options
+while getopts $options OPT; do
+  case $OPT in
+    e|environment)
+      environment="$OPTARG"
+      ;;
+    c|command)
+      command="$OPTARG"
+      ;;
+    l)
+      echo "Environment: $environment (long: --environment)"
+      echo "Command: $command (long: --command)"
+      exit 0
+      ;;
+    ?)
+      echo "Invalid option: $OPT"
+      exit 1
+      ;;
+  esac
+done
+
+# Print the arguments
+echo "Environment: $environment"
+echo "Command: $command"
+
 filename=generated_command_taskrun.sh
 echo '' >$filename
 
-(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/d \\/') >>$filename
+(copilot task run --generate-cmd post-award/$environment/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/d \\/') >>$filename
 
 cat <<EOF >>$filename
 --follow \\
 --task-group-name "db-migrate" \\
 EOF
 
-echo "--command \"/bin/sh -c 'flask db current ; echo EXEC-EXIT-CODE=\\\$?'\"" >>$filename
+echo "--command \"/bin/sh -c '$command ; echo EXEC-EXIT-CODE=\\\$?'\"" >>$filename
 
 source $filename | tee /tmp/exec-output
 

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,0 +1,14 @@
+filename=generated_command_taskrun.sh
+echo '' >$filename
+(copilot task run --generate-cmd post-award/test/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/--command \"/bin/sh -c \'flask db current ; echo EXEC-EXIT-CODE=\\\$?\'\"\\/g') >>$filename
+cat <<EOF >>$filename
+--follow \\
+--task-group-name "db-migrate" \\
+EOF
+source $filename | tee /tmp/exec-output
+exitcode=$(sed -nr 's/.* EXEC-EXIT-CODE=([0-9]+)/\1/p' /tmp/exec-output | tr -d '\r\n')
+echo got exit code "'$exitcode'"
+if [ -z "$exitcode" ]; then
+  echo could not find exit code in copilot output
+  exit 1
+fi

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,48 +1,24 @@
 #!/usr/bin/env bash
 
-# Define the options
-options="-l environment:,command:,"
+ENVIRONMENT=${1:-test}
+COMMAND=${2:-'flask db current'}
 
-# Initialize the variables
-environment="test"
-command="flask db current"
-
-# Get the options
-while getopts $options OPT; do
-  case $OPT in
-    e|environment)
-      environment="$OPTARG"
-      ;;
-    c|command)
-      command="$OPTARG"
-      ;;
-    l)
-      echo "Environment: $environment (long: --environment)"
-      echo "Command: $command (long: --command)"
-      exit 0
-      ;;
-    ?)
-      echo "Invalid option: $OPT"
-      exit 1
-      ;;
-  esac
-done
 
 # Print the arguments
-echo "Environment: $environment"
-echo "Command: $command"
+echo "Environment: $ENVIRONMENT"
+echo "Command: $COMMAND"
 
 filename=generated_command_taskrun.sh
 echo '' >$filename
 
-(copilot task run --generate-cmd post-award/$environment/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/d \\/') >>$filename
+(copilot task run --generate-cmd post-award/$ENVIRONMENT/data-store 2>&1 | sed '$ s/$/ \\/' | sed 's/--command.*/d \\/') >>$filename
 
 cat <<EOF >>$filename
 --follow \\
 --task-group-name "db-migrate" \\
 EOF
 
-echo "--command \"/bin/sh -c '$command ; echo EXEC-EXIT-CODE=\\\$?'\"" >>$filename
+echo "--command \"/bin/sh -c '$COMMAND ; echo EXEC-EXIT-CODE=\\\$?'\"" >>$filename
 
 source $filename | tee /tmp/exec-output
 

--- a/scripts/migration-task-script.sh
+++ b/scripts/migration-task-script.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 filename=generated_command_taskrun.sh
 echo '' >$filename
 


### PR DESCRIPTION
### Change description
Previously we were running the migrations post-deploy. This was suboptimal in a number of ways:
* Logs not visible 
* Failed migration will not fail CI
* App will be running new version of code if migration fails
* Possible race condition between app code being deployed and migration being applied.

This approach fixes the above issues by running the migrations as a standalone task in a step before the deploy.

See related discussion in: https://github.com/aws/copilot-cli/issues/4989

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Tested by deploying branch: https://github.com/communitiesuk/funding-service-design-post-award-data-store/actions/runs/5379096280/jobs/9759839271

