### PR TITLE
FIX run migrations after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
 
-      - name: Run database migrations
-        run: scripts/migration-task-script.sh test "flask db upgrade"
-
       - name: Copilot deploy
         run: |
           copilot deploy --env ${{ inputs.environment || 'test' }}
+
+      - name: Run database migrations
+        run: scripts/migration-task-script.sh ${{ inputs.environment || 'test' }} "flask db upgrade"


### PR DESCRIPTION
### Change description
It appears that task does not rebuild the image, as such migrations need to run after the deploy and be backwards compatible


### How to test
Can test post merge


### Screenshots of UI changes (if applicable)
