### PR TITLE
[FIX] org endpoint only returns orgs referenced by at least one prog

### DIFF
--- a/core/controllers/get_filters.py
+++ b/core/controllers/get_filters.py
@@ -12,11 +12,11 @@ from core.db.entities import Organisation, OutcomeDim, Programme, Project, Submi
 
 
 def get_organisation_names():
-    """Returns a list of all distinct organisation names.
+    """Returns a list of all distinct organisation names that are referenced by at least one programme.
 
     :return: List of organisation names
     """
-    organisations = Organisation.query.with_entities(Organisation.id, Organisation.organisation_name).distinct().all()
+    organisations = db.session.query(Organisation).join(Programme).distinct().all()
 
     if not organisations:
         return abort(404, "No organisation names found.")


### PR DESCRIPTION
https://trello.com/c/wr8jrP7N/17-organisation-filter-on-hambleton-district-council-returns-no-data

### Change description
Modifies the organisation endpoint to only return organisations referenced by at least one programme. The organisation table itself can not be trusted as the source because we currently ingest unreferenced organisations & organisations can be left unreferenced if re-ingestion with different source data occurs.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
