### PR TITLE
[FIX] remove trailing space from outcome category mapping for culture

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -532,7 +532,7 @@ OUTCOME_CATEGORIES = {
     "Public transport reliability": "Transport",
     "Public transport trips as a proportion of total trips per year": "Transport",
     "Road traffic flows in corridors of interest (for road schemes)": "Transport",
-    "Total visitor spend at cultural venues": "Culture ",
+    "Total visitor spend at cultural venues": "Culture",
     "Towns Self-Assessment Questions": "Place",
     "Travel times in the corridors of interest": "Transport",
     "User satisfaction (transport)": "Transport",


### PR DESCRIPTION
https://trello.com/c/WmTxlOpQ/14-bug-production-outcome-filter-issue

### Change description
Fixes hard coded mapping used at ingest to remove a trailing space adding a seemingly duplicate outcome category to the database. This will fix future ingests but we'll need to update the live dim data.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
