### PR TITLE
PAB-484: Set 60 second origin timeout

### DIFF
--- a/copilot/environments/overrides/cfn.patches.yml
+++ b/copilot/environments/overrides/cfn.patches.yml
@@ -17,3 +17,7 @@
 - op: replace
   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/ViewerCertificate/1/MinimumProtocolVersion
   value: TLSv1.2_2021
+
+- op: replace
+  path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/Origins/0/CustomOriginConfig
+  value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 60 }


### PR DESCRIPTION
In order to handle slow responses from the API to large download queries we need to increase this timeout

This codifies a change that was previously made manually

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Has been deployed locally to test, will deploy to production post-merge.


### Screenshots of UI changes (if applicable)
