### PR TITLE
Transform Round 2 Footfall

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -404,7 +404,6 @@ SUPPLEMENTARY_ABBREVIATION_MAPPINGS = {
     "Sutton Town Centre High Street": "SUT",
 }
 
-# TODO: Currently missing "mandatory" 3 outputs.
 # Hard-coded map of Outputs to categories, as provided by TF 09/06/2023
 OUTPUT_CATEGORIES = {
     "# of additional enterprises with broadband access of at least 30mbps": "Regeneration - Community Infrastructure",


### PR DESCRIPTION
Transformation for footfall outcomes. This concatenates the dataframes for outcomes and footfall outcomes.

Also small modifications to the function for attaching a project id to outcomes.


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

Please note that the subset used for testing Round 2 will produce an empty dataframe for footfall outcomes. This is because all of the rows for footfall in the subset are effectively null. For this reason, it is advisable to test with the full dataset. 