### PR TITLE
[#PAB-566]: remove excluded projects from R2

### DIFF
--- a/core/extraction/round_two.py
+++ b/core/extraction/round_two.py
@@ -25,6 +25,8 @@ def ingest_round_two_data(df_dict: Dict[str, pd.DataFrame]) -> Dict[str, pd.Data
     :return: Dictionary of extracted "tables" as DataFrames
     """
 
+    df_dict = remove_excluded_projects(df_dict)
+
     df_ingest = df_dict["December 2022"]
     df_lookup = df_dict["Reported_Finance"]
 
@@ -1267,3 +1269,22 @@ def join_to_project_outcomes(df_input: pd.DataFrame, df_lookup: pd.DataFrame) ->
     )
 
     return with_project_id
+
+
+def remove_excluded_projects(df_dict: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
+    """Removed excluded projects from the ingest before data extraction occurs.
+
+    :param df_dict: dictionary of DataFrames ingested from Round 2 xlsx file
+    :return df_dict: dictionary of DataFrame modified to remove excluded projects
+    """
+
+    excluded_projects = df_dict["Excluded_Projects"]["Project ID"]
+    # this will remove excluded projects from outcomes as well as other dataframes
+    # this is because we use "Reported_Finance" to lookup projects for outcomes
+    to_exclude_from = [df_dict["December 2022"], df_dict["Reported_Finance"]]
+    project_id_column = "Tab 2 - Project Admin - Index Codes"
+
+    for df in to_exclude_from:
+        df.drop(df[df[project_id_column].isin(excluded_projects)].index, inplace=True)
+
+    return df_dict

--- a/tests/extraction_tests/test_historical_extraction.py
+++ b/tests/extraction_tests/test_historical_extraction.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import pytest
+
+from core.extraction.round_two import remove_excluded_projects
+
+
+@pytest.fixture
+def r2_extract_mockup():
+    r2_extract_mockup = {
+        "December 2022": pd.DataFrame(
+            {
+                "Submission ID": [
+                    "S-R02-1",
+                    "S-R02-2",
+                    "S-R02-3",
+                    "S-R02-4",
+                    "S-R02-5",
+                    "S-R02-6",
+                    "S-R02-7",
+                    "S-R02-8",
+                    "S-R02-9",
+                ],
+                "Tab 2 - Project Admin - Index Codes": [
+                    "HS-BIS-01",
+                    "HS-BIS-02",
+                    "HS-BIS-03",
+                    "TD-NOR-01",
+                    "TD-NOR-02",
+                    "TD-NOR-03",
+                    "TD-NOR-04",
+                    "TD-NOR-05",
+                    "TD-NOR-06",
+                ],
+            }
+        ),
+        "Reported_Finance": pd.DataFrame(
+            {
+                "Project Number": ["proj1", "proj2", "proj3", "proj4", "proj5", "proj6", "proj7", "proj8", "proj9"],
+                "Tab 2 - Project Admin - Index Codes": [
+                    "HS-BIS-03",
+                    "HS-BIS-04",
+                    "HS-BIS-05",
+                    "TD-NOR-01",
+                    "TD-NOR-02",
+                    "TD-MID-03",
+                    "TD-MID-04",
+                    "TD-MID-05",
+                    "TD-MID-06",
+                ],
+            }
+        ),
+        "Excluded_Projects": pd.DataFrame(
+            {
+                "Project ID": ["HS-BIS-01", "TD-MID-06", "TD-BOU-03"],
+            }
+        ),
+    }
+    return r2_extract_mockup
+
+
+def test_remove_excluded_projects(r2_extract_mockup):
+    df_dict = remove_excluded_projects(r2_extract_mockup)
+    assert "HS-BIS-01" not in df_dict["December 2022"]["Tab 2 - Project Admin - Index Codes"].tolist()
+    assert "S-R02-1" not in df_dict["December 2022"]["Submission ID"].tolist()
+    assert "TD-MID-06" not in df_dict["Reported_Finance"]["Tab 2 - Project Admin - Index Codes"].tolist()
+    assert "proj9" not in df_dict["Reported_Finance"]["Project Number"].tolist()
+
+    assert "HS-BIS-02" in df_dict["December 2022"]["Tab 2 - Project Admin - Index Codes"].tolist()
+    assert "S-R02-2" in df_dict["December 2022"]["Submission ID"].tolist()
+    assert "TD-MID-05" in df_dict["Reported_Finance"]["Tab 2 - Project Admin - Index Codes"].tolist()
+    assert "proj6" in df_dict["Reported_Finance"]["Project Number"].tolist()


### PR DESCRIPTION
Removes excluded projects from R2. 

Also created a unittest in a new file, test_historical_extraction.py, which can be used to test future modifications to R1/R2 extraction.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
