### PR TITLE
Round 2: Outputs & Outcome refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,8 +133,7 @@ dmypy.json
 .pyre/
 
 # Specific Excel files
-Round 2 Reporting - Consolidation.xlsx
-Round 2 Reporting - Consolidation - subset.xlsx
+Round 2 Reporting - Consolidation*
 EXAMPLE_TF_Reporting_Template_-_TD_-_Newhaven_-_DDMMYY.xlsx
 
 # Flask Profiler output

--- a/core/extraction/round_two.py
+++ b/core/extraction/round_two.py
@@ -12,6 +12,7 @@ from core.const import FundTypeIdEnum
 
 # isort: off
 from core.extraction.utils import convert_financial_halves, datetime_excel_to_pandas
+from core.extraction.towns_fund import extract_output_categories, extract_outcome_categories
 
 # isort: on
 from core.util import extract_postcodes
@@ -47,11 +48,13 @@ def ingest_round_two_data(df_dict: Dict[str, pd.DataFrame]) -> Dict[str, pd.Data
     # Note: No data fields for funding comments in Round 2 data-set
     # Note: No data for PSI in Round 2 data-set
     extracted_data["Outputs"] = extract_outputs(df_ingest)
+    extracted_data["Outputs_Ref"] = extract_output_categories(extracted_data["Outputs"])
     extracted_data["Outcomes"] = pd.concat(
         [extract_outcomes(df_ingest, df_lookup), extract_footfall_outcomes(df_ingest, df_lookup)],
         ignore_index=True,
         axis=0,
     )
+    extracted_data["Outcome_Ref"] = extract_outcome_categories(extracted_data["Outcomes"])
     extracted_data["RiskRegister"] = pd.concat(
         [extract_programme_risks(df_ingest), extract_project_risks(df_ingest)],
         ignore_index=True,

--- a/tests/controller_tests/test_integration.py
+++ b/tests/controller_tests/test_integration.py
@@ -34,7 +34,7 @@ def test_ingest_towns_fund_template():
 def test_ingest_round_two_historical():
     # TODO: currently testing with small subset of data (to allow reasonable debugging speed)
     round_two_data = pd.read_excel(
-        "Round 2 Reporting - Consolidation - subset.xlsx",
+        "Round 2 Reporting - Consolidation - subset (MASTER).xlsx",
         # "Round 2 Reporting - Consolidation.xlsx",
         sheet_name=None,  # extract from all sheets
     )


### PR DESCRIPTION
Reference tables for Outputs & Outcome added.

Gitignore + testing has been updated to reflect the master sheets now used for Round 2 ingestion.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Set breakpoint at appropriate point and inspect the "Outputs_Ref" and "Outcomes_Ref" dataframes.