### PR TITLE
BAU FIX: bump timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bullseye
 ENV FLASK_ENV=dev
-ENV GUNICORN_CMD_ARGS="--timeout 60 --workers 3"
+ENV GUNICORN_CMD_ARGS="--timeout 120 --workers 3"
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip && pip install -r requirements.txt


### PR DESCRIPTION
### Change description
Requests were timing out on the gunicorn side, curtailing long running ingest tasks. Bumping this timeout solves the immediate issue, although we should also look at query optimisations
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Round 1 ingest should work after deployment.


### Screenshots of UI changes (if applicable)
