### PR TITLE
BAU: add run name to differentiate task runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: push to AWS
+run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
 on:
   push:
     branches:


### PR DESCRIPTION
### Change description
Previously it was difficult to see what version was being deployed to environments
This adds a `run-name` attribute including the branch, environment and SHA which is visible in github actions 

### How to test
Have tested by running workflow against branch with these changes

### Screenshots of UI changes (if applicable)
<img width="862" alt="Screenshot 2023-07-24 at 12 01 21" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/1764158/a9e16635-595a-4f4d-8a2b-97cf6d2279aa">
