### PR TITLE
BAU FIX: filter out non excel files

### DIFF
--- a/scripts/batch_ingest.py
+++ b/scripts/batch_ingest.py
@@ -79,7 +79,7 @@ def output_to_excel():
     """
     output_df = pd.DataFrame(columns=["File Name", "Success", "Errors"])
 
-    dir_items = os.listdir(args.directory_path)
+    dir_items = [item for item in os.listdir(args.directory_path) if item.endswith(".xlsx")]
     for idx, file_name in enumerate(dir_items):
         if file_name == "output":
             continue


### PR DESCRIPTION
### Change description
filter out non excel files
This will filter out non-excel files from the folder e.g. metadata files added by the OS.

### How to test
Add a non-excel file in target folder. Should be filtered out when running script


### Screenshots of UI changes (if applicable)
N/A