### PR TITLE
Revert "Merge pull request #193 from communitiesuk/feature/575-filena…

### DIFF
--- a/core/controllers/download.py
+++ b/core/controllers/download.py
@@ -42,8 +42,6 @@ def download():
     rp_start_datetime = datetime.strptime(rp_start, DATETIME_ISO_8610) if rp_start else None
     rp_end_datetime = datetime.strptime(rp_end, DATETIME_ISO_8610) if rp_end else None
 
-    current_datetime = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-
     programmes, programme_outcomes, projects, project_outcomes = get_download_data(
         fund_ids, organisation_ids, outcome_categories, itl_regions, rp_start_datetime, rp_end_datetime
     )
@@ -64,8 +62,7 @@ def download():
 
     response = make_response(file_content)
     response.headers.set("Content-Type", content_type)
-    # Suffix the downloaded filename with current datetime in format yyyy-mm-dd-hhmmss
-    response.headers.set("Content-Disposition", "attachment", filename=f"download-{current_datetime}.{file_extension}")
+    response.headers.set("Content-Disposition", "attachment", filename=f"download.{file_extension}")
 
     return response
 

--- a/tests/controller_tests/test_download.py
+++ b/tests/controller_tests/test_download.py
@@ -1,6 +1,4 @@
-import re
 from copy import deepcopy
-from datetime import datetime
 
 import pandas as pd
 
@@ -81,14 +79,3 @@ def test_sort_columns_function(test_client):
         "Grant Recipient's Single Point of Contact",
     ]
     assert list(sorted_place_df.OrganisationName) == ["Org 3", "Org 2", "Org X", "Org 1"]
-
-
-def test_download_filename(test_client):
-    response = test_client.get("/download?file_format=xlsx")
-
-    # Regex pattern for datetime format %Y-%m-%d-%H%M%S
-    datetime_pattern = r"^\d{4}-\d{2}-\d{2}-\d{6}$"
-    extracted_datetime = re.search(r"\d{4}-\d{2}-\d{2}-\d{6}", response.headers[2][1]).group()
-
-    assert re.match(datetime_pattern, extracted_datetime)
-    assert datetime.strptime(extracted_datetime, "%Y-%m-%d-%H%M%S")


### PR DESCRIPTION
…me-timestamp"

This reverts commit 105e078530bc24454048fa4a82458cf4125ac32d, reversing changes made to b22ba9615da589e57a97ecd6f6ff04d633c7b8ce.

I moved these changes to the front-end repo, reverting this commit will prevent writing the timestamp to the request headers twice, and gives us a single point of test/failure for this feature on the front end only.

The code was commited to the front end here:
https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/commit/ad142f0a2fd24fc072418181517fa205c4d528ac

Ticket ref:
https://trello.com/c/dq3Y7Cgn/575-add-timestamp-to-data-extract-filename
