### PR TITLE
[SMD-39] Implement WrongTypeFailure UC messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,12 @@ from werkzeug.serving import WSGIRequestHandler
 from config import Config
 from core.cli import create_cli
 from core.db import db, migrate
-from core.errors import ValidationError, validation_error_handler
+from core.errors import (
+    UnimplementedUCException,
+    ValidationError,
+    unimplemented_uc_error_handler,
+    validation_error_handler,
+)
 from openapi.utils import get_bundled_specs
 
 WORKING_DIR = Path(__file__).parent
@@ -54,6 +59,7 @@ def create_app(config_class=Config) -> Flask:
             db.create_all()
 
     connexion_app.add_error_handler(ValidationError, validation_error_handler)
+    connexion_app.add_error_handler(UnimplementedUCException, unimplemented_uc_error_handler)
 
     create_cli(flask_app)
 

--- a/core/const.py
+++ b/core/const.py
@@ -685,6 +685,10 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     "Primary Intervention Theme": ("Primary Intervention Theme", "Project Details"),
     "Locations": ("Project Location(s) - Post Code (e.g. SW1P 4DF)", "Project Details"),
     "Lat/Long": ("Project Location - Lat/Long Coordinates (3.d.p e.g. 51.496, -0.129)", "Project Details"),
+    "Private Sector Funding Required": ("Private Sector Funding Required", "Private Sector Investment"),
+    "Private Sector Funding Secured": ("Private Sector Funding Secured", "Private Sector Investment"),
+    "Spend for Reporting Period": ("Financial Year 2022/21 - Financial Year 2025/26", "Project Funding Profiles"),
+    "Amount": ("Financial Year 2022/21 - Financial Year 2025/26", "Project Outputs"),
 }
 
 # message back of uc pre-transformation failure messages for Round 4
@@ -704,3 +708,5 @@ GET_FORM_VERSION_AND_REPORTING_PERIOD = {
     3: ("Town Deals and Future High Streets Fund Reporting Template (v3.0)", "1 October 2022 to 31 March 2023"),
     4: ("Town Deals and Future High Streets Fund Reporting Template (v4.0)", "1 April 2023 to 30 September 2023"),
 }
+
+INTERNAL_TYPE_TO_USER_CENTERED_TYPE = {"datetime64[ns]": "a date", "float64": "a number", "object": "text"}

--- a/core/errors.py
+++ b/core/errors.py
@@ -18,3 +18,15 @@ def validation_error_handler(error: ValidationError):
         "status": 400,
         "title": "Bad Request",
     }, 400
+
+
+class UnimplementedUCException(Exception):
+    """Raised when a validation error occurs that is not supported as a user-centred error message."""
+
+
+def unimplemented_uc_error_handler():
+    return {
+        "detail": "Uncaught workbook validation failure",
+        "status": 500,
+        "title": "Bad Request",
+    }, 500

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -1,8 +1,12 @@
+import pytest
+
+from core.errors import UnimplementedUCException
 from core.validation.failures import (
     InvalidEnumValueFailure,
     NoInputFailure,
     NonNullableConstraintFailure,
     WrongInputFailure,
+    WrongTypeFailure,
     serialise_user_centered_failures,
 )
 
@@ -228,3 +232,94 @@ def test_pretransformation_user_centered_failures():
             "Fund Reporting Template (v4.0)",
         ]
     }
+
+
+def test_wrong_type_user_centered_failures():
+    failure1 = WrongTypeFailure(
+        sheet="Project Progress", column="Start Date", expected_type="datetime64[ns]", actual_type="object"
+    )
+    failure2 = WrongTypeFailure(
+        sheet="Project Progress", column="Completion Date", expected_type="datetime64[ns]", actual_type="object"
+    )
+    failure3 = WrongTypeFailure(
+        sheet="Project Progress",
+        column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
+        expected_type="datetime64[ns]",
+        actual_type="object",
+    )
+    failure4 = WrongTypeFailure(
+        sheet="Private Investments",
+        column="Private Sector Funding Required",
+        expected_type="float64",
+        actual_type="object",
+    )
+    failure5 = WrongTypeFailure(
+        sheet="Private Investments",
+        column="Private Sector Funding Secured",
+        expected_type="float64",
+        actual_type="object",
+    )
+    failure6 = WrongTypeFailure(
+        sheet="Funding", column="Spend for Reporting Period", expected_type="float64", actual_type="object"
+    )
+    failure7 = WrongTypeFailure(sheet="Output_Data", column="Amount", expected_type="float64", actual_type="object")
+    failure8 = WrongTypeFailure(sheet="Outcome_Data", column="Amount", expected_type="float64", actual_type="object")
+    failure9 = WrongTypeFailure(
+        sheet="Project Details", column="Spend for Reporting Period", expected_type="float64", actual_type="object"
+    )
+    failures = [
+        failure1,
+        failure2,
+        failure3,
+        failure4,
+        failure5,
+        failure6,
+        failure7,
+        failure8,
+    ]
+    output = serialise_user_centered_failures(failures)
+    assert output == {
+        "TabErrors": {
+            "Programme Progress": {
+                "Projects Progress Summary": [
+                    "For column Start Date - mmm/yy (e.g. Dec-22) you entered text when we expected a date. "
+                    "You must enter dates in the correct format, for example, Dec-22, Jun-23",
+                    "For column Completion Date - mmm/yy (e.g. Dec-22) you entered text when we expected a date. "
+                    "You must enter dates in the correct format, for example, Dec-22, Jun-23",
+                    "For column Date of Most Important Upcoming Comms Milestone (e.g. Dec-22) you entered text when "
+                    "we expected a date. You must enter dates in the correct format, for example, Dec-22, Jun-23",
+                ]
+            },
+            "PSI": {
+                "Private Sector Investment": [
+                    "For column Private Sector Funding Required you entered text when we expected a number. "
+                    "You must enter the required data in the correct format, for example, £5,588.13 or £238,062.50",
+                    "For column Private Sector Funding Secured you entered text when we expected a number. "
+                    "You must enter the required data in the correct format, for example, £5,588.13 or £238,062.50",
+                ]
+            },
+            "Funding Profiles": {
+                "Project Funding Profiles": [
+                    "Between columns Financial Year 2022/21 - Financial Year 2025/26 you entered text when we "
+                    "expected a number. You must enter the required data in the correct format, for example, £5,"
+                    "588.13 or £238,062.50"
+                ]
+            },
+            "Project Outputs": {
+                "Project Outputs": [
+                    "Between columns Financial Year 2022/21 - Financial Year 2025/26 you entered text when we "
+                    "expected a number. You must enter data using the correct format, for example, 9 rather than 9m2. "
+                    "Only use numbers"
+                ]
+            },
+            "Outcomes": {
+                "Outcome Indicators (excluding footfall) and Footfall Indicator": [
+                    "Between columns Financial Year 2022/21 - Financial Year 2029/30 you entered text when we "
+                    "expected a number. You must enter data using the correct format, for example, 9 rather than 9m2. "
+                    "Only use numbers"
+                ]
+            },
+        }
+    }
+    with pytest.raises(UnimplementedUCException):
+        serialise_user_centered_failures([failure9])


### PR DESCRIPTION
## Wrong Type Error

Added error for wrong types including dates, and numbers usually input incoractly as text. Often simply the unit e.g m^2 is appended to the number.

These errors occur on sheets: Program Progress, Funding Profiles, PSI, Project outputs, Outcomes

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
