### PR TITLE
BAU: added JSON sucsessful upload response

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import numpy as np
 import pandas as pd
-from flask import abort, current_app
+from flask import abort, current_app, jsonify
 from sqlalchemy import desc, func
 from werkzeug.datastructures import FileStorage
 
@@ -80,7 +80,13 @@ def ingest(body, excel_file):
 
     save_submission_file(excel_file, submission_id)
 
-    return "Success: Spreadsheet data ingested", 200
+    return jsonify(
+        {
+            "detail": "Spreadsheet successfully uploaded",
+            "status": 200,
+            "title": "success",
+        }
+    )
 
 
 def extract_data(excel_file: FileStorage) -> dict[str, pd.DataFrame]:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -20,11 +20,22 @@ components:
         }
 
     SpreadsheetIngested:
-      type: string
-
-      example:
-        type: string
-        example: "Success: Spreadsheet data ingested"
+      type: object
+      items:
+        type: object
+        properties:
+          detail:
+            type: string
+          title:
+            type: string
+          status:
+            type: integer
+            format: int32
+      example: {
+        "detail": "Spreadsheet successfully uploaded",
+        "status": 200,
+        "title": "success",
+       }
 
     ProjectData:
       type: object

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -58,6 +58,11 @@ def test_ingest_endpoint(test_client, example_data_model_file):
     )
 
     assert response.status_code == 200, f"{response.json}"
+    assert response.json == {
+        "detail": "Spreadsheet successfully uploaded",
+        "status": 200,
+        "title": "success",
+    }
 
 
 def test_r3_prog_updates_r1(test_client, example_data_model_file):


### PR DESCRIPTION
Send response from ingest in JSON format to be in parity with the responses from bad ingests with validation errors.

Sucsessful response is:

```
{
          "detail": "Spreadsheet successfully uploaded",
          "status": 200,
          "title": "success",
}
```


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
