### PR TITLE
FMD-46: Increase cloudfront timeout to 120 seconds

### DIFF
--- a/copilot/environments/overrides/cfn.patches.yml
+++ b/copilot/environments/overrides/cfn.patches.yml
@@ -20,4 +20,4 @@
 
 - op: replace
   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/Origins/0/CustomOriginConfig
-  value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 60 }
+  value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 120 }


### PR DESCRIPTION
### Change description
Increase cloudfront timeout

### How to test
Will deploy manually and confirm in AWS console

### Screenshots of UI changes (if applicable)
