### PR TITLE
[SMD-65]: outputs and outcomes edgecase validation

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -837,6 +837,7 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     "Total Project Value": ("Total Project Value (£)", "Private Sector Investment"),
     "Townsfund Funding": ("Award From Townsfund (£)", "Private Sector Investment"),
     "Output": ("Indicator Name", "Project Outputs"),
+    # TODO: currently 'Unit of Measurement' can be left null because of an enum failure, but still picked up
     "Unit of Measurement": ("Unit of Measurement", "Outcome Indicators (excluding footfall) / Footfall Indicator"),
     "Outcome": ("Indicator Name", "Outcome Indicators (excluding footfall) / Footfall Indicator"),
     "Project Name": ("Project Name", "Project Details"),

--- a/core/const.py
+++ b/core/const.py
@@ -837,7 +837,6 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     "Total Project Value": ("Total Project Value (£)", "Private Sector Investment"),
     "Townsfund Funding": ("Award From Townsfund (£)", "Private Sector Investment"),
     "Output": ("Indicator Name", "Project Outputs"),
-    # TODO: currently 'Unit of Measurement' can be left null because of an enum failure, but still picked up
     "Unit of Measurement": ("Unit of Measurement", "Outcome Indicators (excluding footfall) / Footfall Indicator"),
     "Outcome": ("Indicator Name", "Outcome Indicators (excluding footfall) / Footfall Indicator"),
     "Project Name": ("Project Name", "Project Details"),

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -246,9 +246,22 @@ class NonNullableConstraintFailure(ValidationFailure, TFUCFailureMessage):
 
         # additional logic if Project Outputs as always has same section
         # and can conflict with Outcomes for Unit of Measurement
+        # also additional logic for Unit of Measurement, the nullity of which
+        # requires a different message
         if sheet == "Project Outputs":
             section = "Project Outputs"
-
+            if column == "Unit of Measurement":
+                message = (
+                    "There are blank cells in column: Unit of Measurement."
+                    " Please ensure you have selected a valid indicator as an Output on the Project Outputs tab,"
+                    " and that the Unit of Measurement is correct for this output"
+                )
+        elif sheet == "Outcomes" and column == "Unit of Measurement":
+            message = (
+                "There are blank cells in column: Unit of Measurement."
+                " Please ensure you have selected a valid indicator as an Outcome on the Outcomes tab,"
+                " and that the Unit of Measurement is correct for this outcome"
+            )
         return sheet, section, message
 
 

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -236,6 +236,14 @@ class NonNullableConstraintFailure(ValidationFailure, TFUCFailureMessage):
         )
 
     def to_user_centered_components(self) -> tuple[str, str, str]:
+        """Generate user-centered components for NonNullableConstraintFailure.
+
+        This function returns user-centered components in the case of a NonNullableConstraintFailure.
+        In instances where the Unit of Measurement is null, a distinct error message is necessary.
+        The function distinguishes between Outputs and Outcomes and adjusts the error message accordingly.
+
+        return: tuple[str, str, str]: A tuple containing the sheet name, section, and error message.
+        """
         sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
         column, section = INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION[self.column]
 
@@ -244,22 +252,18 @@ class NonNullableConstraintFailure(ValidationFailure, TFUCFailureMessage):
             f"Use the space provided to tell us the relevant information"
         )
 
-        # additional logic if Project Outputs as always has same section
-        # and can conflict with Outcomes for Unit of Measurement
-        # also additional logic for Unit of Measurement, the nullity of which
-        # requires a different message
         if sheet == "Project Outputs":
             section = "Project Outputs"
             if column == "Unit of Measurement":
                 message = (
                     "There are blank cells in column: Unit of Measurement."
-                    " Please ensure you have selected a valid indicator as an Output on the Project Outputs tab,"
+                    " Please ensure you have selected valid indicators for all Outputs on the Project Outputs tab,"
                     " and that the Unit of Measurement is correct for this output"
                 )
         elif sheet == "Outcomes" and column == "Unit of Measurement":
             message = (
                 "There are blank cells in column: Unit of Measurement."
-                " Please ensure you have selected a valid indicator as an Outcome on the Outcomes tab,"
+                " Please ensure you have selected valid indicators for all Outcomes on the Outcomes tab,"
                 " and that the Unit of Measurement is correct for this outcome"
             )
         return sheet, section, message

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -82,14 +82,14 @@ def test_non_nullable_user_centered_failures():
             "Outcomes": {
                 "Outcome Indicators (excluding footfall) / Footfall Indicator": [
                     "There are blank cells in column: Unit of Measurement."
-                    " Please ensure you have selected a valid indicator as an Outcome on the Outcomes tab,"
+                    " Please ensure you have selected valid indicators for all Outcomes on the Outcomes tab,"
                     " and that the Unit of Measurement is correct for this outcome"
                 ]
             },
             "Project Outputs": {
                 "Project Outputs": [
                     "There are blank cells in column: Unit of Measurement."
-                    " Please ensure you have selected a valid indicator as an Output on the Project Outputs tab,"
+                    " Please ensure you have selected valid indicators for all Outputs on the Project Outputs tab,"
                     " and that the Unit of Measurement is correct for this output"
                 ]
             },

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -81,14 +81,16 @@ def test_non_nullable_user_centered_failures():
             },
             "Outcomes": {
                 "Outcome Indicators (excluding footfall) / Footfall Indicator": [
-                    'There are blank cells in column: "Unit of Measurement". Use the space provided to '
-                    "tell us the relevant information"
+                    "There are blank cells in column: Unit of Measurement."
+                    " Please ensure you have selected a valid indicator as an Outcome on the Outcomes tab,"
+                    " and that the Unit of Measurement is correct for this outcome"
                 ]
             },
             "Project Outputs": {
                 "Project Outputs": [
-                    'There are blank cells in column: "Unit of Measurement". Use the space provided to '
-                    "tell us the relevant information"
+                    "There are blank cells in column: Unit of Measurement."
+                    " Please ensure you have selected a valid indicator as an Output on the Project Outputs tab,"
+                    " and that the Unit of Measurement is correct for this output"
                 ]
             },
         }


### PR DESCRIPTION
Failure to select an output or outcome left the unit of measurement field blank. This resulted in it being picked up as a null failure, when in actuality the issue is an enum failure with the output or outcome. Changed output and outcomes validation so that the fields are treated as enums, and removed null checks for unit of measurement.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

