### PR TITLE
[SMD-85] Enable Round 4 ingest request and validation

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from fsd_utils import configclass
 
 from core.validation.schema import parse_schema
-
-# isort: off
-from core.validation_schema import ROUND_ONE_TF_SCHEMA, ROUND_TWO_TF_SCHEMA, SCHEMA
+from core.validation_schema import (
+    ROUND_FOUR_TF_SCHEMA,
+    ROUND_ONE_TF_SCHEMA,
+    ROUND_THREE_TF_SCHEMA,
+    ROUND_TWO_TF_SCHEMA,
+)
 
 
 @configclass
@@ -17,9 +20,10 @@ class DefaultConfig(object):
     FLASK_ROOT = Path(__file__).parent.parent.parent
 
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL", f"sqlite:///{tempfile.gettempdir()}/sqlite.db")
-    VALIDATION_SCHEMA = parse_schema(deepcopy(SCHEMA))
     ROUND_ONE_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_ONE_TF_SCHEMA))
     ROUND_TWO_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_TWO_TF_SCHEMA))
+    ROUND_THREE_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_THREE_TF_SCHEMA))
+    ROUND_FOUR_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_FOUR_TF_SCHEMA))
     EXAMPLE_DATA_MODEL_PATH = (
         FLASK_ROOT / "tests" / "controller_tests" / "resources" / "Post_transform_EXAMPLE_data.xlsx"
     )

--- a/core/const.py
+++ b/core/const.py
@@ -410,7 +410,6 @@ TF_PLACE_NAMES_TO_ORGANISATIONS = {
     "Kidderminster": "Wyre Forest District Council",
 }
 
-
 # Hard-coded map of Outputs to categories, as provided by TF 09/06/2023
 OUTPUT_CATEGORIES = {
     "# of additional enterprises with broadband access of at least 30mbps": "Regeneration - Community Infrastructure",
@@ -627,7 +626,7 @@ TABLE_SORT_ORDERS = {
     "RiskRegister": ["SubmissionID", "ProgrammeID", "ProjectID", "RiskName"],
 }
 
-# Internal table names to Round 3 TF tab names mapping
+# Internal table names to Round 3 & 4 TF tab names mapping
 INTERNAL_TABLE_TO_FORM_TAB = {
     "Project Details": "Project Admin",
     "Project Progress": "Programme Progress",
@@ -641,7 +640,7 @@ INTERNAL_TABLE_TO_FORM_TAB = {
     "Private Investments": "PSI",
 }
 
-# Internal column names to Round 3 TF column and section mapping
+# Internal column names to Round 3 & 4 TF column and section mapping
 INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     "Single or Multiple Locations": (
         "Does the project have a single location (e.g. one site) or multiple (e.g. multiple sites or across a number "
@@ -649,14 +648,26 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
         "Project Details",
     ),
     "GIS Provided": ("Are you providing a GIS map (see guidance) with your return?", "Project Details"),
+    "Start Date": ("Start Date - mmm/yy (e.g. Dec-22)", "Projects Progress Summary"),
+    "Completion Date": ("Completion Date - mmm/yy (e.g. Dec-22)", "Projects Progress Summary"),
     "Project Delivery Status": ("Project Delivery Status", "Projects Progress Summary"),
     "Delivery (RAG)": ("Delivery (RAG)", "Projects Progress Summary"),
     "Spend (RAG)": ("Spend (RAG)", "Projects Progress Summary"),
     "Risk (RAG)": ("Risk (RAG)", "Projects Progress Summary"),
+    "Commentary on Status and RAG Ratings": ("Commentary on Status and RAG Ratings", "Projects Progress Summary"),
+    "Most Important Upcoming Comms Milestone": ("Most Important Upcoming Comms Milestone", "Projects Progress Summary"),
+    "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)": (
+        "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
+        "Projects Progress Summary",
+    ),
     "Secured": ("Has this funding source been secured?", "Project Funding Profiles"),
     "GeographyIndicator": ("Geography Indicator", "Outcome Indicators (excluding footfall)"),
+    "Short Description": ("Short description of the Risk", "Programme / Project Risks"),
+    "Full Description": ("Full Description", "Programme / Project Risks"),
+    "Consequences": ("Consequences", "Programme / Project Risks"),
     "Pre-mitigatedImpact": ("Pre-mitigated Impact", "Programme / Project Risks"),
     "Pre-mitigatedLikelihood": ("Pre-mitigated Likelihood", "Programme / Project Risks"),
+    "Mitigatons": ("Mitigations", "Programme / Project Risks"),
     "PostMitigatedImpact": ("Post-Mitigated Impact", "Programme / Project Risks"),
     "PostMitigatedLikelihood": ("Post-mitigated Likelihood", "Programme / Project Risks"),
     "Proximity": ("Proximity", "Programme / Project Risks"),
@@ -673,19 +684,19 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     "Project Name": ("Project Name", "Project Details"),
     "Primary Intervention Theme": ("Primary Intervention Theme", "Project Details"),
     "Locations": ("Project Location(s) - Post Code (e.g. SW1P 4DF)", "Project Details"),
+    "Lat/Long": ("Project Location - Lat/Long Coordinates (3.d.p e.g. 51.496, -0.129)", "Project Details"),
 }
-
 
 # message back of uc pre-transformation failure messages for Round 4
 PRETRANSFORMATION_FAILURE_UC_MESSAGE_BANK = {
-    "Reporting Round": "Start Here: The reporting period is incorrect. Make sure you submit the correct reporting "
-    "period for the round commencing 1 April 2023 to 30 September 2023",
-    "Fund Type": "Project Admin: You must select a fund from the list provided. Do not populate the cell with your "
-    "own content",
-    "Place Name": "Project Admin: You must select a place name from the list provided. Do not populate the cell with "
-    "your own content",
-    "Form Version": "Start Here: The reporting template is incorrect. Make sure you submit "
-    "Town Deals and Future High Streets Fund Reporting Template (v4.0)",
+    "Reporting Period": "The reporting period is incorrect on the Start Here tab in cell B6. Make sure you submit the "
+    "correct reporting period for the round commencing 1 April 2023 to 30 September 2023",
+    "Fund Type": "You must select a fund from the list provided on the Project Admin tab in cell E7."
+    " Do not populate the cell with your own content",
+    "Place Name": "You must select a place name from the list provided on the Project Admin tab in "
+    "cell E8. Do not populate the cell with your own content",
+    "Form Version": "You have submitted the wrong reporting template. Make sure you submit Town Deals and Future High "
+    "Streets Fund Reporting Template (v4.0)",
 }
 
 # form version and reporting period for different rounds

--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -30,6 +30,7 @@ ETL_PIPELINES = {
     "tf_round_one": ingest_round_one_data_towns_fund,
     "tf_round_two": ingest_round_two_data_towns_fund,
     "tf_round_three": ingest_towns_fund_data,
+    "tf_round_four": ingest_towns_fund_data,
 }
 
 
@@ -154,6 +155,10 @@ def populate_db(workbook: dict[str, pd.DataFrame], mappings: tuple[DataMapping])
                      the workbook to the database.
     :return: None
     """
+    # TODO: We do not have an updated "Round 4" spreadsheet yet so all concept of Round 4 is purely for validation only.
+    #  Once we have an updated Round 4 spreadsheet we need to create a new transformation pipeline based off of Round 3.
+    #  "Round 4" will ingest as if it were Round 3 - replacing that programme in the database.
+
     reporting_round = int(workbook["Submission_Ref"]["Reporting Round"].iloc[0])
     programme_id = workbook["Programme_Ref"]["Programme ID"].iloc[0]
 
@@ -355,9 +360,10 @@ def get_schema(reporting_round: str) -> dict[str, object]:
     schema_dict = {
         "tf_round_one": current_app.config["ROUND_ONE_TF_VALIDATION_SCHEMA"],
         "tf_round_two": current_app.config["ROUND_TWO_TF_VALIDATION_SCHEMA"],
+        "tf_round_four": current_app.config["ROUND_FOUR_TF_VALIDATION_SCHEMA"],
     }
 
-    return schema_dict.get(reporting_round, current_app.config["VALIDATION_SCHEMA"])
+    return schema_dict.get(reporting_round, current_app.config["ROUND_THREE_TF_VALIDATION_SCHEMA"])
 
 
 def get_outcomes_outputs_to_insert(mapping: DataMapping, models: list) -> list:

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -1,6 +1,6 @@
 import core.const as enums
 
-SCHEMA = {
+ROUND_THREE_TF_SCHEMA = {
     "Submission_Ref": {
         "columns": {
             "Submission Date": "datetime",
@@ -302,7 +302,6 @@ SCHEMA = {
     },
 }
 
-
 ROUND_TWO_TF_SCHEMA = {
     "Submission_Ref": {
         "columns": {
@@ -550,7 +549,6 @@ ROUND_TWO_TF_SCHEMA = {
     },
 }
 
-
 ROUND_ONE_TF_SCHEMA = {
     "Submission_Ref": {
         "columns": {
@@ -781,6 +779,336 @@ ROUND_ONE_TF_SCHEMA = {
         },
         "non-nullable": [
             "RiskName",
+        ],
+    },
+}
+
+ROUND_FOUR_TF_SCHEMA = {
+    "Submission_Ref": {
+        "columns": {
+            "Submission Date": "datetime",
+            "Reporting Period Start": "datetime",
+            "Reporting Period End": "datetime",
+            "Reporting Round": "int",
+        },
+        "non-nullable": ["Reporting Period Start", "Reporting Period End", "Reporting Round"],
+    },
+    "Organisation_Ref": {
+        "columns": {
+            "Organisation": "str",
+            "Geography": "str",
+        },
+        "uniques": ["Organisation"],
+        "non-nullable": ["Organisation"],
+    },
+    "Programme_Ref": {
+        "columns": {
+            "Programme ID": "str",
+            "Programme Name": "str",
+            "FundType_ID": "str",
+            "Organisation": "str",
+        },
+        "uniques": ["Programme ID"],
+        "foreign_keys": {"Organisation": {"parent_table": "Organisation_Ref", "parent_pk": "Organisation"}},
+        "enums": {"FundType_ID": enums.FundTypeIdEnum},
+        "non-nullable": ["Programme ID", "Programme Name", "FundType_ID", "Organisation"],
+    },
+    "Programme Progress": {
+        "columns": {
+            "Programme ID": "str",
+            "Question": "str",
+            "Answer": "str",
+        },
+        "foreign_keys": {
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
+        },
+        # TODO: Round 4 Answer added because this all programme progress are required
+        "non-nullable": ["Programme ID", "Question", "Answer"],
+    },
+    "Place Details": {
+        "columns": {
+            "Programme ID": "str",
+            "Question": "str",
+            "Answer": "str",
+            "Indicator": "str",
+        },
+        "foreign_keys": {
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
+        },
+        "composite_key": (
+            "Programme ID",
+            "Question",
+            "Indicator",
+        ),
+        # TODO: Round 4 Answer added because place details data is required
+        "non-nullable": ["Programme ID", "Question", "Indicator", "Answer"],
+    },
+    "Funding Questions": {
+        "columns": {
+            "Programme ID": "str",
+            "Question": "str",
+            "Indicator": "str",
+            "Response": "str",
+            "Guidance Notes": "str",
+        },
+        "foreign_keys": {
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
+        },
+        "composite_key": (
+            "Programme ID",
+            "Question",
+            "Indicator",
+        ),
+        "non-nullable": ["Programme ID", "Question"],
+    },
+    "Project Details": {
+        "columns": {
+            "Project ID": "str",
+            "Programme ID": "str",
+            "Project Name": "str",
+            "Primary Intervention Theme": "str",
+            "Single or Multiple Locations": "str",
+            "Locations": "str",
+            "Postcodes": "str",
+            "GIS Provided": "str",
+            "Lat/Long": "str",
+        },
+        "uniques": ["Project ID"],
+        "foreign_keys": {
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
+        },
+        "enums": {"Single or Multiple Locations": enums.MultiplicityEnum, "GIS Provided": enums.YesNoEnum},
+        "non-nullable": [
+            "Project ID",
+            "Programme ID",
+            "Project Name",
+            "Primary Intervention Theme",
+            "Single or Multiple Locations",
+            "Locations",
+            "Lat/Long",
+            # TODO: added Lat/Long for Round 4 - looks like we also need GIS Provided but only in some circumstances
+        ],
+    },
+    "Project Progress": {
+        "columns": {
+            "Project ID": "str",
+            "Start Date": "datetime",
+            "Completion Date": "datetime",
+            "Project Adjustment Request Status": "str",
+            "Project Delivery Status": "str",
+            "Delivery (RAG)": "str",
+            "Spend (RAG)": "str",
+            "Risk (RAG)": "str",
+            "Commentary on Status and RAG Ratings": "str",
+            "Most Important Upcoming Comms Milestone": "str",
+            "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)": "datetime",
+        },
+        "uniques": ["Project ID"],
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
+        },
+        "enums": {
+            "Project Delivery Status": enums.StatusEnum,
+            "Delivery (RAG)": enums.RagEnum,
+            "Spend (RAG)": enums.RagEnum,
+            "Risk (RAG)": enums.RagEnum,
+        },
+        "non-nullable": [
+            "Project ID",
+            "Start Date",
+            "Completion Date",
+            "Project Adjustment Request Status",
+            "Project Delivery Status",
+            "Delivery (RAG)",
+            "Spend (RAG)",
+            "Risk (RAG)",
+            "Commentary on Status and RAG Ratings",
+            "Most Important Upcoming Comms Milestone",
+            "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
+            # TODO: Added all fields for Round 4 (was previously only Project ID)
+        ],
+    },
+    "Funding": {
+        "columns": {
+            "Project ID": "str",
+            "Funding Source Name": "str",
+            "Funding Source Type": "str",
+            "Secured": "str",
+            "Start_Date": "datetime",
+            "End_Date": "datetime",
+            "Spend for Reporting Period": "float",
+            "Actual/Forecast": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
+        },
+        "composite_key": (
+            "Project ID",
+            "Funding Source Name",
+            "Funding Source Type",
+            "Secured",
+            "Start_Date",
+            "End_Date",
+        ),
+        "enums": {
+            "Secured": enums.YesNoEnum,
+            "Actual/Forecast": enums.StateEnum,
+        },
+        "non-nullable": [
+            "Project ID",
+            "Funding Source Name",
+            "Funding Source Type",
+        ],
+    },
+    "Funding Comments": {
+        "columns": {
+            "Project ID": "str",
+            "Comment": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
+        },
+        "non-nullable": ["Project ID"],
+    },
+    "Private Investments": {
+        "columns": {
+            "Project ID": "str",
+            "Total Project Value": "float",
+            "Townsfund Funding": "float",
+            "Private Sector Funding Required": "float",
+            "Private Sector Funding Secured": "float",
+            "Additional Comments": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
+        },
+        "uniques": ["Project ID"],
+        "non-nullable": ["Project ID", "Total Project Value", "Townsfund Funding"],
+    },
+    "Outputs_Ref": {
+        "columns": {"Output Name": "str", "Output Category": "str"},
+        "uniques": ["Output Name"],
+        "non-nullable": ["Output Name", "Output Category"],
+    },
+    "Output_Data": {
+        "columns": {
+            "Project ID": "str",
+            "Start_Date": "datetime",
+            "End_Date": "datetime",
+            "Output": "str",
+            "Unit of Measurement": "str",
+            "Actual/Forecast": "str",
+            "Amount": "float",
+            "Additional Information": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
+            "Output": {"parent_table": "Outputs_Ref", "parent_pk": "Output Name"},
+        },
+        "composite_key": (
+            "Project ID",
+            "Output",
+            "Start_Date",
+            "End_Date",
+            "Unit of Measurement",
+            "Actual/Forecast",
+        ),
+        "enums": {"Actual/Forecast": enums.StateEnum},
+        "non-nullable": ["Project ID", "Start_Date", "Output", "Unit of Measurement"],
+    },
+    "Outcome_Ref": {
+        "table_nullable": True,
+        "columns": {"Outcome_Name": "str", "Outcome_Category": "str"},
+        "uniques": ["Outcome_Name"],
+        "non-nullable": ["Outcome_Name", "Outcome_Category"],
+    },
+    "Outcome_Data": {
+        "table_nullable": True,
+        "columns": {
+            "Project ID": "str",
+            "Programme ID": "str",
+            "Start_Date": "datetime",
+            "End_Date": "datetime",
+            "Outcome": "str",
+            "UnitofMeasurement": "str",
+            "GeographyIndicator": "str",
+            "Amount": "float",
+            "Actual/Forecast": "str",
+            "Higher Frequency": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID", "nullable": True},
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID", "nullable": True},
+            "Outcome": {"parent_table": "Outcome_Ref", "parent_pk": "Outcome_Name"},
+        },
+        "composite_key": (
+            "Project ID",
+            "Outcome",
+            "Start_Date",
+            "End_Date",
+            "GeographyIndicator",
+        ),
+        "enums": {
+            "GeographyIndicator": enums.GeographyIndicatorEnum,
+            "Actual/Forecast": enums.StateEnum,
+        },
+        "non-nullable": [
+            "Start_Date",
+            "End_Date",
+            "Outcome",
+            "UnitofMeasurement",
+            "Actual/Forecast",
+        ],
+    },
+    "RiskRegister": {
+        "table_nullable": True,
+        "columns": {
+            "Programme ID": "str",
+            "Project ID": "str",
+            "RiskName": "str",
+            "RiskCategory": "str",
+            "Short Description": "str",
+            "Full Description": "str",
+            "Consequences": "str",
+            "Pre-mitigatedImpact": "str",
+            "Pre-mitigatedLikelihood": "str",
+            "Mitigatons": "str",
+            "PostMitigatedImpact": "str",
+            "PostMitigatedLikelihood": "str",
+            "Proximity": "str",
+            "RiskOwnerRole": "str",
+        },
+        "foreign_keys": {
+            "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID", "nullable": True},
+            "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID", "nullable": True},
+        },
+        "composite_key": (
+            "Programme ID",
+            "Project ID",
+            "RiskName",
+        ),
+        "enums": {
+            "Pre-mitigatedImpact": enums.ImpactEnum,
+            "Pre-mitigatedLikelihood": enums.LikelihoodEnum,
+            "PostMitigatedImpact": enums.ImpactEnum,
+            "PostMitigatedLikelihood": enums.LikelihoodEnum,
+            "Proximity": enums.ProximityEnum,
+        },
+        "non-nullable": [
+            "RiskName",
+            "RiskName",
+            "RiskCategory",
+            "Short Description",
+            "Full Description",
+            "Consequences",
+            "Pre-mitigatedImpact",
+            "Pre-mitigatedLikelihood",
+            "Mitigatons",
+            "PostMitigatedImpact",
+            "PostMitigatedLikelihood",
+            "Proximity",
+            "RiskOwnerRole",
+            # TODO: Added all fields for Round 4
         ],
     },
 }

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -8,7 +8,7 @@ components:
           format: binary
         source_type:
           type: string
-          enum: [ tf_round_one, tf_round_two, tf_round_three ]
+          enum: [ tf_round_one, tf_round_two, tf_round_three, tf_round_four ]
 
       required:
         - excel_file

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -51,46 +51,143 @@ def test_invalid_enum_user_centered_failures():
     }
 
 
-def test_non_nullable_user_centered_failures():
+def test_non_nullable_user_centered_failures_project_details():
     failure1 = NonNullableConstraintFailure(
         sheet="Project Details",
         column="Locations",
     )
     failure2 = NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="Unit of Measurement",
-    )
-    failure3 = NonNullableConstraintFailure(
-        sheet="Output_Data",
-        column="Unit of Measurement",
+        sheet="Project Details",
+        column="Lat/Long",
     )
 
-    failures = [
-        failure1,
-        failure2,
-        failure3,
-    ]
+    failures = [failure1, failure2]
     output = serialise_user_centered_failures(failures)
     assert output == {
         "TabErrors": {
             "Project Admin": {
                 "Project Details": [
                     'There are blank cells in column: "Project Location(s) - Post Code (e.g. SW1P 4DF)". Use the space '
-                    "provided to tell us the relevant information"
+                    "provided to tell us the relevant information",
+                    'There are blank cells in column: "Project Location - Lat/Long Coordinates (3.d.p e.g. 51.496, '
+                    '-0.129)". Use the space provided to tell us the relevant information',
                 ]
             },
+        }
+    }
+
+
+def test_non_nullable_user_centered_failures_project_progress():
+    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date")
+    failure2 = NonNullableConstraintFailure(sheet="Project Progress", column="Completion Date")
+    failure3 = NonNullableConstraintFailure(sheet="Project Progress", column="Commentary on Status and RAG Ratings")
+    failure4 = NonNullableConstraintFailure(sheet="Project Progress", column="Most Important Upcoming Comms Milestone")
+    failure5 = NonNullableConstraintFailure(
+        sheet="Project Progress", column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)"
+    )
+
+    failures = [failure1, failure2, failure3, failure4, failure5]
+    output = serialise_user_centered_failures(failures)
+
+    assert output == {
+        "TabErrors": {
+            "Programme Progress": {
+                "Projects Progress Summary": [
+                    'There are blank cells in column: "Start Date - mmm/yy (e.g. Dec-22)". Use the space provided to '
+                    "tell us the relevant information",
+                    'There are blank cells in column: "Completion Date - mmm/yy (e.g. Dec-22)". Use the space provided '
+                    "to tell us the relevant information",
+                    'There are blank cells in column: "Commentary on Status and RAG Ratings". Use the space provided '
+                    "to tell us the relevant information",
+                    'There are blank cells in column: "Most Important Upcoming Comms Milestone". Use the space '
+                    "provided to tell us the relevant information",
+                    'There are blank cells in column: "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)". '
+                    "Use the space provided to tell us the relevant information",
+                ]
+            }
+        }
+    }
+
+
+def test_non_nullable_user_centered_failures_outcome_data():
+    failure1 = NonNullableConstraintFailure(
+        sheet="Outcome_Data",
+        column="Unit of Measurement",
+    )
+    failure2 = NonNullableConstraintFailure(
+        sheet="Output_Data",
+        column="Unit of Measurement",
+    )
+
+    failures = [failure1, failure2]
+    output = serialise_user_centered_failures(failures)
+
+    assert output == {
+        "TabErrors": {
             "Outcomes": {
                 "Outcome Indicators (excluding footfall) / Footfall Indicator": [
-                    "There are blank cells in column: Unit of Measurement."
-                    " Please ensure you have selected valid indicators for all Outcomes on the Outcomes tab,"
-                    " and that the Unit of Measurement is correct for this outcome"
+                    "There are blank cells in column: Unit of Measurement. Please ensure you have selected valid "
+                    "indicators for all Outcomes on the Outcomes tab, and that the Unit of Measurement is correct for "
+                    "this outcome"
                 ]
             },
             "Project Outputs": {
                 "Project Outputs": [
-                    "There are blank cells in column: Unit of Measurement."
-                    " Please ensure you have selected valid indicators for all Outputs on the Project Outputs tab,"
-                    " and that the Unit of Measurement is correct for this output"
+                    "There are blank cells in column: Unit of Measurement. Please ensure you have selected valid "
+                    "indicators for all Outputs on the Project Outputs tab, and that the Unit of Measurement is correct"
+                    " for this output"
+                ]
+            },
+        }
+    }
+
+
+def test_non_nullable_user_centered_failures_risk_register():
+    failure1 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description")
+    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Full Description")
+    failure3 = NonNullableConstraintFailure(sheet="RiskRegister", column="Consequences")
+    failure4 = NonNullableConstraintFailure(sheet="RiskRegister", column="Mitigatons")  # typo throughout code
+
+    failures = [failure1, failure2, failure3, failure4]
+    output = serialise_user_centered_failures(failures)
+
+    assert output == {
+        "TabErrors": {
+            "Risk Register": {
+                "Programme / Project Risks": [
+                    'There are blank cells in column: "Short description of the Risk". Use the space provided to tell '
+                    "us the relevant information",
+                    'There are blank cells in column: "Full Description". Use the space provided to tell us the '
+                    "relevant information",
+                    'There are blank cells in column: "Consequences". Use the space provided to tell us the relevant '
+                    "information",
+                    'There are blank cells in column: "Mitigations". Use the space provided to tell us the relevant '
+                    "information",
+                ]
+            }
+        }
+    }
+
+
+def test_non_nullable_user_centered_failures_multiple_tabs():
+    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date")
+    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description")
+
+    failures = [failure1, failure2]
+    output = serialise_user_centered_failures(failures)
+
+    assert output == {
+        "TabErrors": {
+            "Programme Progress": {
+                "Projects Progress Summary": [
+                    'There are blank cells in column: "Start Date - mmm/yy (e.g. Dec-22)". Use the space provided to '
+                    "tell us the relevant information"
+                ]
+            },
+            "Risk Register": {
+                "Programme / Project Risks": [
+                    'There are blank cells in column: "Short description of the Risk". Use the space provided to tell'
+                    " us the relevant information"
                 ]
             },
         }
@@ -99,7 +196,7 @@ def test_non_nullable_user_centered_failures():
 
 def test_pretransformation_user_centered_failures():
     failure1 = WrongInputFailure(
-        value_descriptor="Reporting Round",
+        value_descriptor="Reporting Period",
         entered_value="wrong round",
         expected_values=set("correct round"),
     )
@@ -120,14 +217,14 @@ def test_pretransformation_user_centered_failures():
     output = serialise_user_centered_failures(failures)
 
     assert output == {
-        "PreTransformationError": [
-            "Start Here: The reporting period is incorrect. Make sure you submit the correct reporting "
-            "period for the round commencing 1 April 2023 to 30 September 2023",
-            "Project Admin: You must select a fund from the list provided. Do not populate the cell with your "
-            "own content",
-            "Project Admin: You must select a place name from the list provided. Do not populate the cell with "
-            "your own content",
-            "Start Here: The reporting template is incorrect. Make sure you submit "
-            "Town Deals and Future High Streets Fund Reporting Template (v4.0)",
+        "PreTransformationErrors": [
+            "The reporting period is incorrect on the Start Here tab in cell B6. Make sure you submit the correct "
+            "reporting period for the round commencing 1 April 2023 to 30 September 2023",
+            "You must select a fund from the list provided on the Project Admin tab in cell E7. Do not populate the "
+            "cell with your own content",
+            "You must select a place name from the list provided on the Project Admin tab in cell E8. Do not populate "
+            "the cell with your own content",
+            "You have submitted the wrong reporting template. Make sure you submit Town Deals and Future High Streets "
+            "Fund Reporting Template (v4.0)",
         ]
     }


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140/backlog?view=detail&selectedIssue=SMD-85&issueLimit=100

### Change description
- Adds ability to request ingest for Round 4
- Adds a validation schema for Round 4 that enforces Round 4 validation requirements ([see this](https://communities-govuk.slack.com/files/U04V6KQCNCU/F05P7MMASHK/image.png)).
- Adds more `NonNullableConstraintFailure` support for additional validation scenarios added for Round 4

NOTE: This adds the concept of a Round 4 submission - however, this is purely for validation at the moment. It will still use the Round 3 transformation and ingest logic. Once we have a new Round 4 template, transformation and ingest will also need updating.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
