### PR TITLE
FMD-46: Increase cloudfront timeout to 180 seconds

### DIFF
--- a/copilot/environments/overrides/cfn.patches.yml
+++ b/copilot/environments/overrides/cfn.patches.yml
@@ -20,4 +20,4 @@
 
 - op: replace
   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/Origins/0/CustomOriginConfig
-  value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 120 }
+  value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 180 }


### PR DESCRIPTION
### Change description
Sister PR to: https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/pull/60
Increase Cloudfront timeout to match gunicorn timeout on frontend

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Will deploy change on merge


### Screenshots of UI changes (if applicable)
