### PR TITLE
[SMD-38] Implement NonUniqueCompositeKeyFailure

### DIFF
--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -143,32 +143,32 @@ class NonUniqueCompositeKeyFailure(ValidationFailure, TFUCFailureMessage):
 
         if sheet == "Funding Profiles":
             row_str = ", ".join(self.row[1:4])
-            project_number = int(self.row[0].split('-')[2])
+            project_number = int(self.row[0].split("-")[2])
             section = f"Project {project_number} Funding Profiles"
             message = (
                 f"You have repeated funding information. You must use a new row for each project, "
                 f"funding source name, funding type and if its been secured. You have"
-                f" repeat entries for {row_str}"
+                f' repeat entries for "{row_str}"'
             )
         elif sheet == "Project Outputs":
-            project_number = int(self.row[0].split('-')[2])
+            project_number = int(self.row[0].split("-")[2])
             section = f"Project {project_number} Outputs"
             message = (
-                f"You have entered the indicator {self.row[1]} repeatedly. Only enter an indicator once per project"
+                f'You have entered the indicator "{self.row[1]}" repeatedly. Only enter an indicator once per project'
             )
         elif sheet == "Outcomes":
             section = "Outcome Indicators (excluding footfall)"
             message = (
-                f"You have entered the indicator {self.row[1]} repeatedly for the same project and geography indicator."
-                f" Only enter an indicator once per project"
+                f'You have entered the indicator "{self.row[1]}" repeatedly for the same project and geography '
+                f"indicator. Only enter an indicator once per project"
             )
         elif sheet == "Risk Register":
             if pd.notna(self.row[1]):
-                project_number = int(self.row[1].split('-')[2])
+                project_number = int(self.row[1].split("-")[2])
                 section = f"Project {project_number} Risks"
             else:
                 section = "Programme Risks"
-            message = f"You have entered the risk {self.row[2]} repeatedly. Only enter a risk once per project"
+            message = f'You have entered the risk "{self.row[2]}" repeatedly. Only enter a risk once per project'
         else:
             raise e.UnimplementedUCException
 
@@ -203,24 +203,24 @@ class WrongTypeFailure(ValidationFailure, TFUCFailureMessage):
 
         if self.expected_type == "datetime64[ns]":
             message = (
-                f"For column {column} you entered {actual_type} when we expected {expected_type}. "
+                f'For column "{column}" you entered {actual_type} when we expected {expected_type}. '
                 f"You must enter dates in the correct format, for example, Dec-22, Jun-23"
             )
         elif sheet == "PSI":
             message = (
-                f"For column {column} you entered {actual_type} when we expected {expected_type}. "
+                f'For column "{column}" you entered {actual_type} when we expected {expected_type}. '
                 f"You must enter the required data in the correct format, for example, £5,588.13 or £238,"
                 f"062.50"
             )
         elif sheet == "Funding Profiles":
             message = (
-                f"Between columns {column} you entered {actual_type} when we expected {expected_type}. "
+                f'Between columns "{column}" you entered {actual_type} when we expected {expected_type}. '
                 f"You must enter the required data in the correct format, for example, £5,588.13 or £238,"
                 f"062.50"
             )
         elif sheet in ["Project Outputs", "Outcomes"]:
             message = (
-                f"Between columns {column} you entered {actual_type} when we expected {expected_type}. "
+                f'Between columns "{column}" you entered {actual_type} when we expected {expected_type}. '
                 f"You must enter data using the correct format, for example, 9 rather than 9m2. Only use numbers"
             )
         else:
@@ -430,6 +430,7 @@ def serialise_user_centered_failures(
         # ignore tab and section for pre-transformation failures
         return {"PreTransformationErrors": [message for _, _, message in uc_failures]}
 
+    # remove duplicate failure messages
     uc_failures = list(set(uc_failures))
     uc_failures.sort()
 


### PR DESCRIPTION
Add user centered error component for Non-unique composite key failure. This error occurs when users specify duplicate funding sources, project outputs, outcomes or risks.

this commit includes a change to the failure message serialisation to ignore duplicate messages and a refactor of all the failure messages to be based solely on the to_user_cetered_components method.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
