### PR TITLE
FMD-38: add shared VPCss

### DIFF
--- a/copilot/environments/test/manifest.yml
+++ b/copilot/environments/test/manifest.yml
@@ -7,9 +7,16 @@ name: test
 type: Environment
 
 # Import your own VPC and subnets or configure how they should be created.
-# network:
-#   vpc:
-#     id:
+network:
+  vpc:
+    id: 'vpc-0ca7bdd50d5dba428'
+    subnets:
+      public:
+        - id: 'subnet-0f1f40929bdabbcdd'
+        - id: 'subnet-0e686586655747458'
+      private:
+        - id: 'subnet-07f5736fe61f32266'
+        - id: 'subnet-054d3a0257e2c809d'
 
 # Configure the load balancers in your environment, once created.
 # http:


### PR DESCRIPTION
### Change description
In order to create a future network connection between pre-award and post-award apps. We need to add the shared VPCs to allow them to communicate.

Note: this is deliberately draft until we're ready to switch over to the other AWS account 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Can verify using AWS console


### Screenshots of UI changes (if applicable)
