### PR TITLE
BAU: bug fix for null projects in outcomes

### DIFF
--- a/core/extraction/towns_fund.py
+++ b/core/extraction/towns_fund.py
@@ -812,8 +812,6 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
     outcomes_df = pd.concat([outcomes_df, pd.DataFrame(df_input.values[27:37], columns=header_row_combined)])
     # If indicator name or project ref is empty - drop row (cannot map to DB table)
     outcomes_df = drop_empty_rows(outcomes_df, "Indicator Name")
-    # TODO: could put this back in and catch at validation?
-    outcomes_df = drop_empty_rows(outcomes_df, "Relevant project(s)")
     relevant_projects = set(outcomes_df["Relevant project(s)"])
     relevant_projects.discard("Multiple")
     if invalid_projects := relevant_projects - set(project_lookup.keys()):
@@ -912,8 +910,6 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
         footfall_instance.columns = header
         footfall_df = pd.concat([footfall_df, footfall_instance])
 
-    # TODO: is this correct? what if row has other data entered? Save at programme level? MAybe catch at validation
-    # assuming that no project id (or "multiple") is not to be ingested
     footfall_df = drop_empty_rows(footfall_df, "Relevant Project(s)")
     relevant_projects = set(footfall_df["Relevant Project(s)"])
     relevant_projects.discard("Multiple")

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -411,6 +411,17 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
     )
 
 
+def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup):
+    """Test that appropriate validation error is raised when a project null."""
+    # replace a valid project with a null
+    mock_outcomes_sheet = mock_outcomes_sheet.replace("Test Project 1", np.nan)
+    with pytest.raises(ValidationError) as ve:
+        tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
+    assert str(ve.value) == (
+        "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome Indicators (excluding " "footfall)')]"
+    )
+
+
 def test_extract_risk(mock_risk_sheet, mock_project_lookup, mock_programme_lookup):
     """Test risk data extracted as expected."""
     extracted_risk_data = tf.extract_risks(mock_risk_sheet, mock_project_lookup, mock_programme_lookup)


### PR DESCRIPTION
PR to fix bug raised in: https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?assignee=712020%3A604bc6cd-3120-45eb-939d-28f261742d7b&selectedIssue=SMD-103

Users could enter null values for a project in outcomes because we dropped all nulls in the Relevant Project(s) column before checking to see if the project was valid or not. 

For footfall outcomes, as all of the Indicator Names are pre-populated, it is not possible to check for nulls, but we can continue to check for invalid projects. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
