### PR TITLE
[FMD-56] Fix programme level joins

### DIFF
--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -65,7 +65,10 @@ def download_data_base_query(
             ents.OutcomeData,
             or_(
                 ents.Project.id == ents.OutcomeData.project_id,
-                ents.Project.programme_id == ents.OutcomeData.programme_id,
+                and_(
+                    ents.Submission.id == ents.OutcomeData.submission_id,
+                    ents.OutcomeData.project_id.is_(None),
+                ),
             ),
         )
         .outerjoin(ents.OutcomeDim)
@@ -145,7 +148,7 @@ def funding_question_query(base_query: Query) -> Query:
     :return: updated query.
     """
     extended_query = (
-        base_query.join(ents.FundingQuestion, ents.FundingQuestion.programme_id == ents.Programme.id)
+        base_query.join(ents.FundingQuestion, ents.FundingQuestion.submission_id == ents.Submission.id)
         .with_entities(
             ents.Submission.submission_id,
             ents.Programme.programme_id,
@@ -313,7 +316,7 @@ def place_detail_query(base_query: Query) -> Query:
     :return: updated query.
     """
     extended_query = (
-        base_query.join(ents.PlaceDetail, ents.PlaceDetail.programme_id == ents.Programme.id).with_entities(
+        base_query.join(ents.PlaceDetail, ents.PlaceDetail.submission_id == ents.Submission.id).with_entities(
             ents.PlaceDetail.question,
             ents.PlaceDetail.answer,
             ents.PlaceDetail.indicator,
@@ -381,7 +384,7 @@ def programme_progress_query(base_query: Query) -> Query:
     :return: updated query.
     """
     extended_query = (
-        base_query.join(ents.ProgrammeProgress, ents.ProgrammeProgress.programme_id == ents.Programme.id)
+        base_query.join(ents.ProgrammeProgress, ents.ProgrammeProgress.submission_id == ents.Submission.id)
         .with_entities(
             ents.Submission.submission_id,
             ents.Programme.programme_id,
@@ -486,7 +489,10 @@ def risk_register_query(base_query: Query) -> Query:
             ents.RiskRegister,
             or_(
                 ents.Project.id == ents.RiskRegister.project_id,
-                ents.Project.programme_id == ents.RiskRegister.programme_id,
+                and_(
+                    ents.RiskRegister.submission_id == ents.Submission.id,
+                    ents.RiskRegister.project_id.is_(None),
+                ),
             ),
         )
         .with_entities(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,15 @@ from app import create_app
 from core.const import GeographyIndicatorEnum
 from core.db import db
 from core.db.entities import (
+    FundingQuestion,
     Organisation,
     OutcomeData,
     OutcomeDim,
+    PlaceDetail,
     Programme,
+    ProgrammeProgress,
     Project,
+    RiskRegister,
     Submission,
 )
 
@@ -65,6 +69,7 @@ def additional_test_data():
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
+
     organisation = Organisation(organisation_name="TEST-ORGANISATION")
     organisation2 = Organisation(organisation_name="TEST-ORGANISATION2")
     db.session.add_all((submission, organisation, organisation2))
@@ -189,10 +194,62 @@ def additional_test_data():
         state="Actual",
         higher_frequency=None,
     )
+    # the following entities are all for a previous funding round (testing joins)
+    prog_id = Programme.query.filter(Programme.programme_id == "FHSF001").first().id
+    funding_question = FundingQuestion(
+        submission_id=submission.id,
+        programme_id=prog_id,  # linked to programme
+        question="Some Question",
+        indicator="You shouldn't see this",
+        response="test response",
+        guidance_notes="test notes",
+    )
+    prog_risk = RiskRegister(
+        submission_id=submission.id,
+        programme_id=prog_id,  # linked to programme
+        project_id=None,
+        risk_name="Test NAME",
+        risk_category="Test CAT",
+    )
+    programme_progress = ProgrammeProgress(
+        submission_id=submission.id,
+        programme_id=prog_id,  # linked to programme
+        question="test QUESTION",
+        answer="test ANSWER",
+    )
+    place_detail = PlaceDetail(
+        submission_id=submission.id,
+        programme_id=prog_id,  # linked to programme
+        question="test QUESTION",
+        answer="test ANSWER",
+        indicator="test INDICATOR",
+    )
+    outcome_programme = OutcomeData(
+        submission_id=submission.id,
+        programme_id=prog_id,  # linked to programme
+        project_id=None,
+        outcome_id=test_outcome_dim.id,  # linked to TEST-OUTCOME-CATEGORY OutcomeDim
+        start_date=datetime(2024, 1, 1),
+        end_date=datetime(2023, 12, 31),
+        unit_of_measurement="TEST Units",
+    )
 
-    db.session.add_all((project_outcome1, project_outcome2, programme_outcome, programme_outcome2))
+    db.session.add_all(
+        (
+            project_outcome1,
+            project_outcome2,
+            programme_outcome,
+            programme_outcome2,
+            funding_question,
+            prog_risk,
+            programme_progress,
+            place_detail,
+            outcome_programme,
+        )
+    )
     db.session.flush()
 
+    # TODO: switch this to a dict
     return (
         organisation,
         submission,
@@ -204,4 +261,9 @@ def additional_test_data():
         project4,
         test_outcome_dim,
         transport_outcome_dim,
+        funding_question,
+        prog_risk,
+        programme_progress,
+        place_detail,
+        outcome_programme,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,21 +249,21 @@ def additional_test_data():
     )
     db.session.flush()
 
-    # TODO: switch this to a dict
-    return (
-        organisation,
-        submission,
-        programme,
-        programme_with_no_projects,
-        project1,
-        project2,
-        project3,
-        project4,
-        test_outcome_dim,
-        transport_outcome_dim,
-        funding_question,
-        prog_risk,
-        programme_progress,
-        place_detail,
-        outcome_programme,
-    )
+    return {
+        "organisation": organisation,
+        "submission": submission,
+        "programme": programme,
+        "programme_with_no_projects": programme_with_no_projects,
+        "project1": project1,
+        "project2": project2,
+        "project3": project3,
+        "project4": project4,
+        "test_outcome_dim": test_outcome_dim,
+        "transport_outcome_dim": transport_outcome_dim,
+        "funding_question": funding_question,
+        "prog_risk": prog_risk,
+        "programme_progress": programme_progress,
+        "place_detail": place_detail,
+        "outcome_programme": outcome_programme,
+        "outcome_no_projects": programme_outcome2,
+    }

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -294,19 +294,8 @@ def test_get_download_data_region_filter(seeded_test_client, additional_test_dat
 def test_get_download_data_region_and_fund(seeded_test_client, additional_test_data):
     # when both ITL region and fund_type filter params are passed, return relevant results
 
-    (
-        _,
-        _,
-        programme,
-        _,
-        _,
-        _,
-        _,
-        project4,
-        _,
-        _,
-    ) = additional_test_data
-
+    programme = additional_test_data[2]
+    project4 = additional_test_data[7]
     itl_regions = {ITLRegion.SouthWest}
     fund_type_ids = [programme.fund_type_id]
 
@@ -333,19 +322,9 @@ def test_get_download_data_region_and_fund(seeded_test_client, additional_test_d
 
 def test_outcomes_with_non_outcome_filters(seeded_test_client, additional_test_data):
     """Specifically testing the OutcomeData joins when filters applied to OTHER tables."""
-    (
-        organisation,
-        _,
-        programme,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-    ) = additional_test_data
 
+    organisation = additional_test_data[0]
+    programme = additional_test_data[2]
     organisation_uuids = [organisation.id]
     itl_regions = {ITLRegion.SouthWest}
     fund_type_ids = [programme.fund_type_id]

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -210,7 +210,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
 
 def test_serialise_download_data_organisation_filter(seeded_test_client, additional_test_data):
     """Assert filter applied reduces results returned."""
-    organisation = additional_test_data[0]
+    organisation = additional_test_data["organisation"]
     organisation_uuids = [organisation.id]
     test_query_org = download_data_base_query(organisation_uuids=organisation_uuids)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(test_query_org)}
@@ -234,7 +234,7 @@ def test_serialise_data_region_filter(seeded_test_client, additional_test_data):
     #  read into pandas for ease of inspection
     test_fund_filtered_df = pd.DataFrame.from_records(test_serialised_data["ProjectDetails"])
 
-    project4 = additional_test_data[7]
+    project4 = additional_test_data["project4"]
     assert project4.project_id not in test_fund_filtered_df["ProjectID"]  # not in SW region
     assert all(
         ITLRegion.SouthWest in project.itl_regions
@@ -291,8 +291,8 @@ def test_funding_question_programme_joins(seeded_test_client, additional_test_da
     """
 
     # this is a funding question with the same parent programme, that shouldn't be returned in this query.
-    funding_question = additional_test_data[10]
-    unwanted_submission = additional_test_data[1]
+    funding_question = additional_test_data["funding_question"]
+    unwanted_submission = additional_test_data["submission"]
     rp_start_wanted = unwanted_submission.reporting_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
@@ -323,8 +323,8 @@ def test_programme_progress_joins(seeded_test_client, additional_test_data):
     """
 
     # this is a programme progress record with the same parent programme, that shouldn't be returned in this query.
-    programme_progress = additional_test_data[12]
-    unwanted_submission = additional_test_data[1]
+    programme_progress = additional_test_data["programme_progress"]
+    unwanted_submission = additional_test_data["submission"]
     rp_start_wanted = unwanted_submission.reporting_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
@@ -357,8 +357,8 @@ def test_place_detail_joins(seeded_test_client, additional_test_data):
     """
 
     # this is a place details record with the same parent programme, that shouldn't be returned in this query.
-    place_detail = additional_test_data[13]
-    unwanted_submission = additional_test_data[1]
+    place_detail = additional_test_data["place_detail"]
+    unwanted_submission = additional_test_data["submission"]
     rp_start_wanted = unwanted_submission.reporting_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
@@ -388,8 +388,8 @@ def test_risk_table_for_programme_join(seeded_test_client, additional_test_data)
     share a parent programme with historical round data risks.
     """
 
-    programme_risk = additional_test_data[11]
-    unwanted_submission = additional_test_data[1]
+    programme_risk = additional_test_data["prog_risk"]
+    unwanted_submission = additional_test_data["submission"]
     rp_start_wanted = unwanted_submission.reporting_period_end
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
@@ -418,8 +418,8 @@ def test_outcome_table_for_programme_join(seeded_test_client, additional_test_da
     share a parent programme with historical round data risks.
     """
 
-    programme_outcome = additional_test_data[14]
-    unwanted_submission = additional_test_data[1]
+    programme_outcome = additional_test_data["outcome_programme"]
+    unwanted_submission = additional_test_data["submission"]
     rp_start_wanted = unwanted_submission.reporting_period_end
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FMD-56


### Change description
Programme level tables were getting duplicated data in the data extract due to incorrect joins. Namely, data from other rounds was showing up against every row of programme related data, but with the incorrect submission etc.

- Add tests to isolate the failures
- Changed programme level joins to join on Submission
- For specific cases of tables that join on project OR programme (RiskRegister and OutcomeData), the programme part of the conditional join changed to be a further nested conditional join on submission only when there is no project_id.
- Refactored some query tests that were becoming obsolete / hard to maintain

- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Test downloading extract data from UI. For projects with data from multiple rounds, check the project data tabs don't have duplicated / unexpected rows.


