### PR TITLE
Feauture/bau fix place name bug

### DIFF
--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -387,22 +387,6 @@ class WrongInputFailure(PreTransFormationFailure):
 
 
 @dataclass
-class NoInputFailure(PreTransFormationFailure):
-    """Class representing a no input failure."""
-
-    value_descriptor: str
-
-    def __str__(self):
-        """
-        Method to get the string representation of the no input failure.
-        """
-        return f"No Input Failure: Expected an input value for {self.value_descriptor}"
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        return None, None, PRETRANSFORMATION_FAILURE_MESSAGE_BANK[self.value_descriptor]
-
-
-@dataclass
 class InvalidSheetFailure(ValidationFailure):
     """Class representing an invalid sheet failure."""
 

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -7,6 +7,7 @@ import core.validation.failures as vf
 from core.const import (
     EXPECTED_ROUND_THREE_SHEETS,
     GET_FORM_VERSION_AND_REPORTING_PERIOD,
+    TF_PLACE_NAMES_TO_ORGANISATIONS,
 )
 
 
@@ -45,6 +46,10 @@ def extract_submission_details(
 
     try:
         details_dict["ValueChecks"]["Fund Type"] = (sheet_a2.iloc[5][4], {"Town_Deal", "Future_High_Street_Fund"})
+        details_dict["ValueChecks"]["Place Name"] = (
+            sheet_a2.iloc[6][4],
+            {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
+        )
         details_dict["NullChecks"]["Place Name"] = sheet_a2.iloc[6][4]
     except IndexError:
         invalid_sheets.append("2 - Project Admin")

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import numpy as np
 import pandas as pd
 
 import core.validation.failures as vf
@@ -18,11 +17,19 @@ def extract_submission_details(
     """
     Extract submission details from the given workbook.
 
+    This function takes a dictionary of sheets from an Excel workbook and a reporting round identifier as input.
+    If the sheets are correct, it extracts values from specified cells, and adds these to a tuple alongside
+    a set representing the range of values a given cell's value is expected to belong to.
+
+    Keys for each of the value's names are added to a dictionary with the tuples representing actual values and
+    expected values as the values in the dictionary.
+
     :param workbook: A dictionary where keys are sheet names and values are pandas DataFrames.
     :param reporting_round: Integer representing the round being ingested.
-    :return: A dictionary containing the extracted submission details.
+    :return: A dictionary containing inputs outside expected values for the cell, or
+    a list of missing or invalid sheets.
     """
-    details_dict = {"ValueChecks": {}, "NullChecks": {}}
+    wrong_input_checks = {}
 
     missing_sheets = check_missing_sheets(EXPECTED_ROUND_THREE_SHEETS, workbook)
 
@@ -36,28 +43,27 @@ def extract_submission_details(
     sheet_a1 = workbook.get("1 - Start Here")
     sheet_a2 = workbook.get("2 - Project Admin")
     try:
-        details_dict["ValueChecks"]["Form Version"] = (
+        wrong_input_checks["Form Version"] = (
             sheet_a1.iloc[6][1],
             {form_version},
         )
-        details_dict["ValueChecks"]["Reporting Period"] = (sheet_a1.iloc[4][1], {reporting_period})
+        wrong_input_checks["Reporting Period"] = (sheet_a1.iloc[4][1], {reporting_period})
     except IndexError:
         invalid_sheets.append("1 - Start Here")
 
     try:
-        details_dict["ValueChecks"]["Fund Type"] = (sheet_a2.iloc[5][4], {"Town_Deal", "Future_High_Street_Fund"})
-        details_dict["ValueChecks"]["Place Name"] = (
+        wrong_input_checks["Fund Type"] = (sheet_a2.iloc[5][4], {"Town_Deal", "Future_High_Street_Fund"})
+        wrong_input_checks["Place Name"] = (
             sheet_a2.iloc[6][4],
-            {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
+            set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
         )
-        details_dict["NullChecks"]["Place Name"] = sheet_a2.iloc[6][4]
     except IndexError:
         invalid_sheets.append("2 - Project Admin")
 
     if invalid_sheets:
         return {"Invalid Sheets": missing_sheets}
 
-    return details_dict
+    return wrong_input_checks
 
 
 def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[vf.ValidationFailure]:
@@ -76,12 +82,8 @@ def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> 
 
     failures = []
 
-    for value_descriptor, (entered_value, expected_values) in submission_details["ValueChecks"].items():
+    for value_descriptor, (entered_value, expected_values) in submission_details.items():
         if failure := check_values(value_descriptor, entered_value, expected_values):
-            failures.append(failure)
-
-    for value_descriptor, value in submission_details["NullChecks"].items():
-        if failure := check_nulls(value_descriptor, value):
             failures.append(failure)
 
     return failures
@@ -101,19 +103,6 @@ def check_values(value_descriptor: str, entered_value: str, expected_values: set
         return vf.WrongInputFailure(
             value_descriptor=value_descriptor, entered_value=entered_value, expected_values=expected_values
         )
-
-
-def check_nulls(value_descriptor: str, value: str) -> vf.NoInputFailure | None:
-    """
-    Check the form input for pre-transformation failures.
-
-    :param value_descriptor: A string describing the form input value.
-    :param value: A string containing the form input value.
-    :return: A ValidationFailure object representing the failure, if any.
-    """
-
-    if value in ["", np.nan]:
-        return vf.NoInputFailure(value_descriptor=value_descriptor)
 
 
 def check_missing_sheets(expected_sheets: list[str], workbook: dict[str, pd.DataFrame]) -> list[str]:

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -26,7 +26,7 @@ from core.db.entities import (
     Project,
     Submission,
 )
-from core.validation.failures import NoInputFailure, NonNullableConstraintFailure
+from core.validation.failures import NonNullableConstraintFailure, WrongInputFailure
 
 resources = Path(__file__).parent / "resources"
 
@@ -399,7 +399,14 @@ def test_ingest_endpoint_returns_pre_transformation_errors(test_client, example_
     """
 
     # mock validate response to return an error
-    mocker.patch("core.controllers.ingest.validate", return_value=[NoInputFailure(value_descriptor="Place Name")])
+    mocker.patch(
+        "core.controllers.ingest.validate",
+        return_value=[
+            WrongInputFailure(
+                value_descriptor="Place Name", entered_value="wrong place", expected_values=set("correct place")
+            )
+        ],
+    )
 
     endpoint = "/ingest"
     response = test_client.post(

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -5,7 +5,6 @@ from core.validation.exceptions import UnimplementedErrorMessageException
 from core.validation.failures import (
     InvalidEnumValueFailure,
     InvalidOutcomeProjectFailure,
-    NoInputFailure,
     NonNullableConstraintFailure,
     NonUniqueCompositeKeyFailure,
     WrongInputFailure,
@@ -83,8 +82,8 @@ def test_failures_to_messages_pre_transformation_failures():
         entered_value="wrong type",
         expected_values=set("wrong type"),
     )
-    failure3 = NoInputFailure(
-        value_descriptor="Place Name",
+    failure3 = WrongInputFailure(
+        value_descriptor="Place Name", entered_value="wrong place", expected_values=set("correct place")
     )
     failure4 = WrongInputFailure(
         value_descriptor="Form Version",
@@ -439,8 +438,10 @@ def test_pretransformation_messages():
         entered_value="wrong type",
         expected_values=set("wrong type"),
     )
-    failure3 = NoInputFailure(
+    failure3 = WrongInputFailure(
         value_descriptor="Place Name",
+        entered_value="wrong place",
+        expected_values=set("correct place"),
     )
     failure4 = WrongInputFailure(
         value_descriptor="Form Version",

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -224,18 +224,13 @@ def valid_workbook_round_four():
 @pytest.fixture
 def valid_submission_details():
     return {
-        "NullChecks": {
-            "Place Name": "Newark",
-        },
-        "ValueChecks": {
-            "Fund Type": ("Town_Deal", {"Town_Deal", "Future_High_Street_Fund"}),
-            "Form Version": (
-                "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
-                {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
-            ),
-            "Reporting Period": ("1 October 2022 to 31 March 2023", {"1 October 2022 to 31 March 2023"}),
-            "Place Name": ("Newark", {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()}),
-        },
+        "Fund Type": ("Town_Deal", {"Town_Deal", "Future_High_Street_Fund"}),
+        "Form Version": (
+            "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
+            {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
+        ),
+        "Reporting Period": ("1 October 2022 to 31 March 2023", {"1 October 2022 to 31 March 2023"}),
+        "Place Name": ("Newark", set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys())),
     }
 
 
@@ -243,45 +238,43 @@ def test_extract_round_three_submission_details(valid_workbook):
     details_dict = extract_submission_details(valid_workbook, 3)
 
     assert "Missing Sheets" not in details_dict
-    assert details_dict["ValueChecks"]["Form Version"] == (
+    assert details_dict["Form Version"] == (
         "Town Deals and Future High Streets Fund Reporting Template (v3.0)",
         {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
     )
-    assert details_dict["ValueChecks"]["Reporting Period"] == (
+    assert details_dict["Reporting Period"] == (
         "1 October 2022 to 31 March 2023",
         {"1 October 2022 to 31 March 2023"},
     )
-    assert details_dict["ValueChecks"]["Fund Type"] == (
+    assert details_dict["Fund Type"] == (
         "Town_Deal",
         {"Town_Deal", "Future_High_Street_Fund"},
     )
-    assert details_dict["ValueChecks"]["Place Name"] == (
+    assert details_dict["Place Name"] == (
         "Newark",
-        {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
+        set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
     )
-    assert details_dict["NullChecks"]["Place Name"] == "Newark"
 
 
 def test_extract_round_four_submission_details(valid_workbook_round_four):
     details_dict = extract_submission_details(valid_workbook_round_four, 4)
 
-    assert details_dict["ValueChecks"]["Form Version"] == (
+    assert details_dict["Form Version"] == (
         "Town Deals and Future High Streets Fund Reporting Template (v4.0)",
         {"Town Deals and Future High Streets Fund Reporting Template (v4.0)"},
     )
-    assert details_dict["ValueChecks"]["Reporting Period"] == (
+    assert details_dict["Reporting Period"] == (
         "1 April 2023 to 30 September 2023",
         {"1 April 2023 to 30 September 2023"},
     )
-    assert details_dict["ValueChecks"]["Fund Type"] == (
+    assert details_dict["Fund Type"] == (
         "Town_Deal",
         {"Town_Deal", "Future_High_Street_Fund"},
     )
-    assert details_dict["ValueChecks"]["Place Name"] == (
+    assert details_dict["Place Name"] == (
         "Newark",
-        {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
+        set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
     )
-    assert details_dict["NullChecks"]["Place Name"] == "Newark"
 
 
 def test_pre_transformation_check_success(valid_submission_details):
@@ -291,7 +284,7 @@ def test_pre_transformation_check_success(valid_submission_details):
 
 
 def test_pre_transformation_check_failures(valid_submission_details):
-    valid_submission_details["ValueChecks"]["Form Version"] = (
+    valid_submission_details["Form Version"] = (
         "Invalid Form Version",
         {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
     )
@@ -300,7 +293,7 @@ def test_pre_transformation_check_failures(valid_submission_details):
     assert len(failures) == 1
     assert isinstance(failures[0], vf.WrongInputFailure)
 
-    valid_submission_details["ValueChecks"]["Reporting Period"] = (
+    valid_submission_details["Reporting Period"] = (
         "Invalid Reporting Period",
         {"1 October 2022 to 31 March 2023"},
     )
@@ -308,7 +301,7 @@ def test_pre_transformation_check_failures(valid_submission_details):
     assert len(failures) == 2
     assert isinstance(failures[1], vf.WrongInputFailure)
 
-    valid_submission_details["ValueChecks"]["Fund Type"] = (
+    valid_submission_details["Fund Type"] = (
         "Invalid Fund Type",
         {"Town_Deal", "Future_High_Street_Fund"},
     )
@@ -316,10 +309,13 @@ def test_pre_transformation_check_failures(valid_submission_details):
     assert len(failures) == 3
     assert isinstance(failures[2], vf.WrongInputFailure)
 
-    valid_submission_details["NullChecks"]["Place Name"] = ""
+    valid_submission_details["Place Name"] = (
+        "",
+        set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
+    )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 4
-    assert isinstance(failures[3], vf.NoInputFailure)
+    assert isinstance(failures[3], vf.WrongInputFailure)
 
     valid_submission_details["Invalid Sheets"] = ["1 - Start Here"]
     failures = pre_transformation_check(valid_submission_details)
@@ -333,9 +329,9 @@ def test_pre_transformation_check_failures(valid_submission_details):
 
 
 def test_place_name_is_valid(valid_submission_details):
-    valid_submission_details["ValueChecks"]["Place Name"] = (
+    valid_submission_details["Place Name"] = (
         "Not in the dropdown",
-        ("Place Name", {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()}),
+        ("Place Name", set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys())),
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import core.validation.failures as vf
+from core.const import TF_PLACE_NAMES_TO_ORGANISATIONS
 
 # isort: off
 from core.validation.initial_check import (
@@ -233,6 +234,7 @@ def valid_submission_details():
                 {"Town Deals and Future High Streets Fund Reporting Template (v3.0)"},
             ),
             "Reporting Period": ("1 October 2022 to 31 March 2023", {"1 October 2022 to 31 March 2023"}),
+            "Place Name": ("Newark", {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()}),
         },
     }
 
@@ -253,6 +255,10 @@ def test_extract_round_three_submission_details(valid_workbook):
         "Town_Deal",
         {"Town_Deal", "Future_High_Street_Fund"},
     )
+    assert details_dict["ValueChecks"]["Place Name"] == (
+        "Newark",
+        {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
+    )
     assert details_dict["NullChecks"]["Place Name"] == "Newark"
 
 
@@ -270,6 +276,10 @@ def test_extract_round_four_submission_details(valid_workbook_round_four):
     assert details_dict["ValueChecks"]["Fund Type"] == (
         "Town_Deal",
         {"Town_Deal", "Future_High_Street_Fund"},
+    )
+    assert details_dict["ValueChecks"]["Place Name"] == (
+        "Newark",
+        {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()},
     )
     assert details_dict["NullChecks"]["Place Name"] == "Newark"
 
@@ -320,3 +330,13 @@ def test_pre_transformation_check_failures(valid_submission_details):
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
     assert isinstance(failures[0], vf.EmptySheetFailure)
+
+
+def test_place_name_is_valid(valid_submission_details):
+    valid_submission_details["ValueChecks"]["Place Name"] = (
+        "Not in the dropdown",
+        ("Place Name", {key for key, value in TF_PLACE_NAMES_TO_ORGANISATIONS.items()}),
+    )
+    failures = pre_transformation_check(valid_submission_details)
+    assert len(failures) == 1
+    assert isinstance(failures[0], vf.WrongInputFailure)


### PR DESCRIPTION
QA testing revealed that users can copy and paste over the cell for Place Name in the Project Admin tab. Previously, we just checked for nulls; this PR broadens the scope, and removes the defunct functionality that checks for a null value in Place Name as that will now be caught as a  WrongInputFailure.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
