### PR TITLE
[SMD-144] TF Round 4 validation - Funding Source dropdown validation

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -36,6 +36,7 @@ class FundingSourceCategoryEnum(StrEnum):
     THIRD_SECTOR_FUNDING = "Third Sector Funding"
     OTHER_PUBLIC_FUNDING = "Other Public Funding"
     PRIVATE_FUNDING = "Private Funding"
+    OTHER_PUBLIC_FUNDING_INC_KIND = "Other Funding inc. In Kind"
 
 
 class GeographyIndicatorEnum(StrEnum):
@@ -713,3 +714,13 @@ GET_FORM_VERSION_AND_REPORTING_PERIOD = {
 }
 
 INTERNAL_TYPE_TO_MESSAGE_FORMAT = {"datetime64[ns]": "a date", "float64": "a number", "object": "text"}
+
+PRE_DEFINED_FUNDING_SOURCES = [
+    "Commercial Income",
+    "How much of your CDEL forecast is contractually committed?",
+    "How much of your RDEL forecast is contractually committed?",
+    "Town Deals 5% CDEL Pre-Payment",
+    "Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL "
+    "Pre-Payment)",
+    "Towns Fund RDEL Payment which is being utilised on TF project related activity",
+]

--- a/core/util.py
+++ b/core/util.py
@@ -56,3 +56,12 @@ def group_by_first_element(tuples: list[tuple]) -> dict[str, list[tuple | Any]]:
         key: [t[1:] if len(t[1:]) > 1 else t[1] for t in group] for key, group in groups
     }  # Map groups into a dictionary, removing the first index from the group as that's the key
     return nested
+
+
+def get_project_number(project_id):
+    """Extracts the project number from a project ID.
+
+    :param project_id: A project ID code
+    :return: project number
+    """
+    return int(project_id.split("-")[2])

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -16,7 +16,7 @@ from core.const import (
     INTERNAL_TYPE_TO_MESSAGE_FORMAT,
     PRETRANSFORMATION_FAILURE_MESSAGE_BANK,
 )
-from core.util import group_by_first_element
+from core.util import get_project_number, group_by_first_element
 from core.validation.exceptions import UnimplementedErrorMessageException
 
 
@@ -159,7 +159,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
 
         if sheet == "Funding Profiles":
             row_str = ", ".join(self.row[1:4])
-            project_number = int(self.row[0].split("-")[2])
+            project_number = get_project_number(self.row[0])
             section = f"Funding Profiles - Project {project_number}"
             message = (
                 f"You have repeated funding information. You must use a new row for each project, "
@@ -167,7 +167,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
                 f' repeat entries for "{row_str}"'
             )
         elif sheet == "Project Outputs":
-            project_number = int(self.row[0].split("-")[2])
+            project_number = get_project_number(self.row[0])
             section = f"Project Outputs - Project {project_number}"
             message = (
                 f'You have entered the indicator "{self.row[1]}" repeatedly. Only enter an indicator once per project'
@@ -180,7 +180,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
             )
         elif sheet == "Risk Register":
             if pd.notna(self.row[1]):
-                project_number = int(self.row[1].split("-")[2])
+                project_number = get_project_number(self.row[1])
                 section = f"Project Risks - Project {project_number}"
             else:
                 section = "Programme Risks"
@@ -304,11 +304,15 @@ class InvalidEnumValueFailure(ValidationFailure):
             project_id = self.row_values[1]
             if pd.notna(project_id):
                 # project risk
-                project_number = int(self.row_values[1].split("-")[2])
+                project_number = get_project_number(self.row_values[1])
                 section = f"Project Risks - Project {project_number}"
             else:
                 # programme risk
                 section = "Programme Risks"
+
+        if section == "Project Funding Profiles":
+            project_number = get_project_number(self.row_values[0])
+            section = f"Project Funding Profiles - Project {project_number}"
 
         return sheet, section, message
 

--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
+from core.util import get_project_number
 from core.validation.failures import ValidationFailure
 
 
@@ -39,7 +40,7 @@ def validate_project_risks(workbook: dict[str, pd.DataFrame]) -> list["TownsFund
 
     if projects_missing_risks:
         projects_missing_risks.sort()
-        project_numbers = [int(project_id.split("-")[2]) for project_id in projects_missing_risks]
+        project_numbers = [get_project_number(project_id) for project_id in projects_missing_risks]
         return [
             TownsFundRoundFourValidationFailure(
                 tab="Risk Register",

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -154,7 +154,7 @@ def test_invalid_enum_messages():
         sheet="Funding",
         column="Secured",
         row=2,
-        row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
+        row_values=("TD-ABC-1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure8 = InvalidEnumValueFailure(
@@ -234,7 +234,7 @@ def test_invalid_enum_messages():
     )
     assert failure7.to_message() == (
         "Funding Profiles",
-        "Project Funding Profiles",
+        "Project Funding Profiles - Project 1",
         'For column "Has this funding source been secured?", you have entered "Value" '
         "which isn't correct. You must select an option from the list provided",
     )


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?selectedIssue=SMD-144
as part of story:
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?selectedIssue=SMD-69

### Change description
 - Funding Source wasn't being validated against previously. 
 - These changes enable enum validation on the Funding Source column found on the Funding tab for Round 3 and 4.
 - This has been implemented as a context specific validation rather than using the schema driven validation code because there are hardcoded sections of the spreadsheet that use "Towns Fund" as a "Funding Source Type" that is forbidden in the "Funding Source" column in the "Other Funding Sources" section. This means that if it was implemented using the schema then users could incorrectly enter "Towns Fund" as a Funding Source for the "Other Funding Sources" because all the data is combined into a single "Funding" table during transformation.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
