### PR TITLE
FMD-13 update spelling on OutputRef field

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -613,7 +613,7 @@ TABLE_SORT_ORDERS = {
     ],
     "FundingComments": ["SubmissionID", "ProjectID"],
     "PrivateInvestments": ["SubmissionID", "ProjectID"],
-    "OutputsRef": ["OutputName"],
+    "OutputRef": ["OutputName"],
     "OutputData": [
         "SubmissionID",
         "ProjectID",

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -66,7 +66,7 @@ def serialise_download_data(
         "Funding": (funding_query, FundingSchema),
         "FundingComments": (funding_comment_query, FundingCommentSchema),
         "PrivateInvestments": (private_investment_query, PrivateInvestmentSchema),
-        "OutputsRef": (output_dim_query, OutputDimSchema),
+        "OutputRef": (output_dim_query, OutputDimSchema),
         "OutputData": (output_data_query, OutputDataSchema),
         "OutcomeRef": (outcome_dim_query, OutcomeDimSchema),
         "OutcomeData": (outcome_data_query, OutcomeDataSchema),

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -37,16 +37,16 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
     assert test_serialised_data.get("Funding")
     assert test_serialised_data.get("FundingComments")
     assert test_serialised_data.get("PrivateInvestments")
-    assert test_serialised_data.get("OutputsRef")
+    assert test_serialised_data.get("OutputRef")
     assert test_serialised_data.get("OutputData")
     assert test_serialised_data.get("OutcomeRef")
     assert test_serialised_data.get("OutcomeData")
     assert test_serialised_data.get("RiskRegister")
     assert len(test_serialised_data) == 15
 
-    # assert all tables contain place and organisation (apart from OrgRef, OutputsRef and OutcomeRef)
+    # assert all tables contain place and organisation (apart from OrgRef, OutputRef and OutcomeRef)
     for section_name, data in test_serialised_data.items():
-        if section_name in ["ProgrammeRef", "OrganisationRef", "OutputsRef", "OutcomeRef"]:
+        if section_name in ["ProgrammeRef", "OrganisationRef", "OutputRef", "OutcomeRef"]:
             continue
         assert "Place" in data[0].keys()
         assert "OrganisationName" in data[0].keys()
@@ -150,7 +150,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
-    assert list(test_serialised_data["OutputsRef"][0].keys()) == ["OutputName", "OutputCategory"]
+    assert list(test_serialised_data["OutputRef"][0].keys()) == ["OutputName", "OutputCategory"]
     assert list(test_serialised_data["OutputData"][0].keys()) == [
         "SubmissionID",
         "ProjectID",


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FMD-13


### Change description
Corrects the spelling of OutputsRef to OutputRef. The tests have also been updated and running as normal.

### How to test
If you check the data extract after clicking download, the spelling on the tab should be updated.


### Screenshots of UI changes (if applicable)
