### PR TITLE
[SMD-156]: backend authorisation

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -51,12 +51,15 @@ def ingest(body, excel_file):
     :raises ValidationError: If the data fails validation against the specified schema.
     """
     source_type = body.get("source_type")  # required
+    place_names = body.get("place names")
     workbook = extract_data(excel_file=excel_file)
     reporting_round = REPORTING_ROUND.get(source_type)
 
     if source_type:
         if reporting_round:
-            pre_transformation_details = extract_submission_details(workbook=workbook, reporting_round=reporting_round)
+            pre_transformation_details = extract_submission_details(
+                workbook=workbook, reporting_round=reporting_round, place_names=place_names
+            )
             file_validation_failures = pre_transformation_check(pre_transformation_details)
             if file_validation_failures:
                 raise ValidationError(validation_failures=file_validation_failures)

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -433,6 +433,30 @@ class InvalidOutcomeProjectFailure(ValidationFailure):
         return sheet, section, message
 
 
+@dataclass
+class UnauthorisedSubmissionFailure(PreTransFormationFailure):
+    """Class representing an unauthorised submission failure."""
+
+    unauthorised_place_name: str
+    authorised_place_names: tuple[str]
+
+    def __str__(self):
+        """Method to get the string representation of the unauthorised submission failure."""
+        return (
+            f"User is not authorised to submit for {self.unauthorised_place_name}"
+            f"User can only submit for {self.authorised_place_names}"
+        )
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        places = ", ".join(self.authorised_place_names)
+        message = (
+            f"You are not authorised to submit for {self.unauthorised_place_name}. "
+            "Please ensure you submit for a place within your local authority. "
+            f"You can submit for the following places: {places}"
+        )
+        return None, None, message
+
+
 def failures_to_messages(
     validation_failures: list[ValidationFailure],
 ) -> dict[str, dict[str, list[str]]] | dict[str, dict]:

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -7,6 +7,7 @@ from core.validation.failures import (
     InvalidOutcomeProjectFailure,
     NonNullableConstraintFailure,
     NonUniqueCompositeKeyFailure,
+    UnauthorisedSubmissionFailure,
     WrongInputFailure,
     WrongTypeFailure,
     failures_to_messages,
@@ -668,4 +669,16 @@ def test_invalid_project_outcome_failure():
         "Footfall Indicator",
         "You must select a project from the drop-down provided for 'Relevant project(s)'. "
         "Do not populate the cell with your own content",
+    )
+
+
+def test_authorised_submission():
+    failure1 = UnauthorisedSubmissionFailure(unauthorised_place_name="Newark", authorised_place_names=("Wigan",))
+
+    assert failure1.to_message() == (
+        None,
+        None,
+        "You are not authorised to submit for Newark. Please ensure you submit for a "
+        "place within your local authority. "
+        "You can submit for the following places: Wigan",
     )

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -235,7 +235,7 @@ def valid_submission_details():
 
 
 def test_extract_round_three_submission_details(valid_workbook):
-    details_dict = extract_submission_details(valid_workbook, 3)
+    details_dict = extract_submission_details(valid_workbook, 3, place_names=("Newark",))
 
     assert "Missing Sheets" not in details_dict
     assert details_dict["Form Version"] == (
@@ -257,7 +257,7 @@ def test_extract_round_three_submission_details(valid_workbook):
 
 
 def test_extract_round_four_submission_details(valid_workbook_round_four):
-    details_dict = extract_submission_details(valid_workbook_round_four, 4)
+    details_dict = extract_submission_details(valid_workbook_round_four, 4, place_names=("Newark",))
 
     assert details_dict["Form Version"] == (
         "Town Deals and Future High Streets Fund Reporting Template (v4.0)",
@@ -275,6 +275,12 @@ def test_extract_round_four_submission_details(valid_workbook_round_four):
         "Newark",
         set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
     )
+
+
+def test_extract_with_unauthorised_place_name(valid_workbook_round_four):
+    unauthorised_place_name_dict = extract_submission_details(valid_workbook_round_four, 4, place_names=("Wigan",))
+
+    assert unauthorised_place_name_dict == {"Unauthorised Place Name": ("Newark", ("Wigan",))}
 
 
 def test_pre_transformation_check_success(valid_submission_details):
@@ -336,3 +342,10 @@ def test_place_name_is_valid(valid_submission_details):
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
     assert isinstance(failures[0], vf.WrongInputFailure)
+
+
+def test_unauthorised_submission():
+    unauthorised_failure_dict = {"Unauthorised Place Name": ("Newark", ("Wigan",))}
+    failures = pre_transformation_check(unauthorised_failure_dict)
+    assert len(failures) == 1
+    assert isinstance(failures[0], vf.UnauthorisedSubmissionFailure)


### PR DESCRIPTION
A user can only submit for the places within their local authority's remit. When a user submits their returns, a tuple of place names is sent to the data store. The pre-transformation checks inspect the place name of the submission form and compare it to the tuple of place names the user is authorised to submit for. If the user is not authorised to submit for the place name, a PreTransFormationFailure is raised. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
