### PR TITLE
[FMD-55] Remove bad FHSF data from historical ingest

### DIFF
--- a/core/extraction/towns_fund_round_two.py
+++ b/core/extraction/towns_fund_round_two.py
@@ -22,6 +22,7 @@ from core.extraction.towns_fund_round_three import (
 from core.extraction.utils import (
     convert_financial_halves,
     datetime_excel_to_pandas,
+    drop_unnecessary_fhsf_data,
     extract_postcodes,
 )
 
@@ -495,6 +496,11 @@ def extract_funding_questions(df_input: pd.DataFrame) -> pd.DataFrame:
 
     df_funding_questions.sort_values(["Submission ID", "Question", "Indicator"], inplace=True)
     df_funding_questions.reset_index(drop=True, inplace=True)
+
+    # drop funding question data associated with Future High Street Fund submissions
+    unused_mask = df_funding_questions.loc[df_funding_questions["Programme ID"].str.startswith("HS")]
+    df_funding_questions.drop(unused_mask.index, inplace=True)
+
     return df_funding_questions
 
 
@@ -646,6 +652,10 @@ def extract_funding_data(df_input: pd.DataFrame) -> pd.DataFrame:
         "End_Date",
     ]
     df_funding_data.drop_duplicates(subset=no_duplicates, keep="first", inplace=True)
+
+    # remove unnecessary data due to conditional formatting on Future High Street fund sheets
+    df_funding_data = drop_unnecessary_fhsf_data(df_funding_data)
+
     return df_funding_data
 
 


### PR DESCRIPTION
Add the same logic to drop the problematic cells as described in the readme here:
https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/233

Caveat:
Due to all the data being ingested from a single sheet, I think it is impractical to check if Programme only has been selected so that scenario has not bee include


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
