### PR TITLE
[SMD-71] bring single/multiple location validation outside of schema …

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -76,6 +76,15 @@ class ProximityEnum(StrEnum):
     IMMINENT = "5 - Imminent: next month"
 
 
+class PrimaryInterventionThemeEnum(StrEnum):
+    TRANSPORT = "Transport"
+    DIGITAL_CONNECTIVITY = "Digital Connectivity"
+    REGENERATION = "Regeneration "
+    SKILLS_ENTERPRISE_INFRASTRUCTURE = "Skills and Enterprise Infrastructure"
+    OTHER = "Other"
+    MULTIPLE = "There are multiple primary intervention themes"
+
+
 class MultiplicityEnum(StrEnum):
     SINGLE = "Single"
     MULTIPLE = "Multiple"

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -102,9 +102,7 @@ ROUND_FOUR_TF_SCHEMA = {
             "Project Name",
             "Primary Intervention Theme",
             "Single or Multiple Locations",
-            "Locations",
-            "Lat/Long",
-            # TODO: added Lat/Long for Round 4 - looks like we also need GIS Provided but only in some circumstances
+            # Locations, Lat/Long and GIS Provided all validated after schema validation due to specific rules
         ],
     },
     "Project Progress": {

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -95,7 +95,10 @@ ROUND_FOUR_TF_SCHEMA = {
         "foreign_keys": {
             "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
         },
-        "enums": {"Single or Multiple Locations": enums.MultiplicityEnum, "GIS Provided": enums.YesNoEnum},
+        "enums": {
+            "Single or Multiple Locations": enums.MultiplicityEnum,
+            "Primary Intervention Theme": enums.PrimaryInterventionThemeEnum,
+        },
         "non-nullable": [
             "Project ID",
             "Programme ID",

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -116,13 +116,6 @@ def test_invalid_enum_messages():
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
-    failure2 = InvalidEnumValueFailure(
-        sheet="Project Details",
-        column="GIS Provided",
-        row=2,
-        row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
-    )
     failure3 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Project Delivery Status",
@@ -201,13 +194,6 @@ def test_invalid_enum_messages():
         'multiple (e.g. multiple sites or across a number of post codes)?", you have '
         'entered "Value" which isn\'t correct. You must select an option from the '
         "list provided",
-    )
-    assert failure2.to_message() == (
-        "Project Admin",
-        "Project Details",
-        'For column "Are you providing a GIS map (see guidance) with your return?", '
-        'you have entered "Value" which isn\'t correct. You must select an option '
-        "from the list provided",
     )
     assert failure3.to_message() == (
         "Programme Progress",


### PR DESCRIPTION
…validation

https://dluhcdigital.atlassian.net/browse/SMD-71

### Change description
Fixes validation for the location columns on the Project Admin tab so that if a user has not correctly selected Single or Multiple location, then the location columns for those rows are not validated against. This is because the messages could be misleading if we made an assumption as to which sets of rows to validate.

This is done separately from the schema validation so that we can skip validation on these columns for rows where
the user has not selected a Single or Multiple location correctly.

- [x] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
