### PR TITLE
BAU: fixed error with non-unique composite key failure not expecting …

### DIFF
--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -158,7 +158,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
         sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
 
         if sheet == "Funding Profiles":
-            row_str = ", ".join(self.row[1:4])
+            row_str = ", ".join(str(i) for i in self.row[1:4])
             project_number = get_project_number(self.row[0])
             section = f"Funding Profiles - Project {project_number}"
             message = (


### PR DESCRIPTION
QA raised that Non-unique composite key error message was calling a string method on values that could be nullable so it was failing when these were left blank. Added a very simple comprehension to stringify these values and prevent an uncaught exception.


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
