### PR TITLE
[SMD-67] risk ingest without risk name

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -674,6 +674,7 @@ INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION = {
     ),
     "Secured": ("Has this funding source been secured?", "Project Funding Profiles"),
     "GeographyIndicator": ("Geography Indicator", "Outcome Indicators (excluding footfall)"),
+    "RiskName": ("Risk Name", "Programme / Project Risks"),
     "Short Description": ("Short description of the Risk", "Programme / Project Risks"),
     "Full Description": ("Full Description", "Programme / Project Risks"),
     "Consequences": ("Consequences", "Programme / Project Risks"),

--- a/core/extraction/towns_fund_round_four.py
+++ b/core/extraction/towns_fund_round_four.py
@@ -66,9 +66,7 @@ def ingest_round_four_data_towns_fund(df_ingest: pd.DataFrame) -> dict[str, pd.D
     )
     towns_fund_extracted["Outcome_Ref"] = r3.extract_outcome_categories(towns_fund_extracted["Outcome_Data"])
     towns_fund_extracted["RiskRegister"] = r3.extract_risks(
-        df_ingest["7 - Risk Register"],
-        project_lookup,
-        programme_id,
+        df_ingest["7 - Risk Register"], project_lookup, programme_id, round_four=True
     )
 
     # TODO: Remove this when the validation schema has been updated to include these two columns

--- a/core/extraction/utils.py
+++ b/core/extraction/utils.py
@@ -9,20 +9,21 @@ from pandas.tseries.offsets import MonthEnd
 POSTCODE_REGEX = r"[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}"
 
 
-def drop_empty_rows(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
+def drop_empty_rows(df: pd.DataFrame, column_names: list[str]) -> pd.DataFrame:
     """
-    Drop any rows of a dataframe that have empty or unwanted cell values in the given column.
+    Drop any rows of a dataframe that have entirely empty or unwanted cell values in the given columns.
 
     Unwanted cell values are:
     - Pandas None types. Usually where empty Excel cells are ingested.
     - Strings with value "< Select >", these are unwanted Excel left-overs
 
     :param df: The DataFrame to clean.
-    :param column_name: The name of the column to check for unwanted values in.
+    :param column_names: The name of the columns to check for unwanted values in.
     :return: Dataframe with removed rows.
     """
-    df = df.dropna(subset=[column_name])
-    df.drop(df[df[column_name] == "< Select >"].index, inplace=True)
+    empty_values = ("< Select >", np.nan, None)
+    condition = df[column_names].isin(empty_values).all(axis=1)
+    df = df[~condition]
     return df
 
 

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -180,11 +180,8 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
                 f"indicator. Only enter an indicator once per project"
             )
         elif sheet == "Risk Register":
-            if pd.notna(self.row[1]):
-                project_number = get_project_number(self.row[1])
-                section = f"Project Risks - Project {project_number}"
-            else:
-                section = "Programme Risks"
+            project_id = self.row[1]
+            section = risk_register_section(project_id)
             message = f'You have entered the risk "{self.row[2]}" repeatedly. Only enter a risk once per project'
         else:
             raise UnimplementedErrorMessageException
@@ -303,13 +300,7 @@ class InvalidEnumValueFailure(ValidationFailure):
         # additional logic for risk location
         if sheet == "Risk Register":
             project_id = self.row_values[1]
-            if pd.notna(project_id):
-                # project risk
-                project_number = get_project_number(self.row_values[1])
-                section = f"Project Risks - Project {project_number}"
-            else:
-                # programme risk
-                section = "Programme Risks"
+            section = risk_register_section(project_id)
 
         if section == "Project Funding Profiles":
             project_number = get_project_number(self.row_values[0])
@@ -456,6 +447,17 @@ class UnauthorisedSubmissionFailure(PreTransFormationFailure):
             f"You can submit for the following places: {places}"
         )
         return None, None, message
+
+
+def risk_register_section(project_id):
+    if pd.notna(project_id):
+        # project risk
+        project_number = get_project_number(project_id)
+        section = f"Project Risks - Project {project_number}"
+    else:
+        # programme risk
+        section = "Programme Risks"
+    return section
 
 
 def failures_to_messages(

--- a/tests/extraction_tests/resources/assertion_data/round_four/risks_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_four/risks_expected.csv
@@ -1,0 +1,9 @@
+Programme ID,Project ID,RiskName,RiskCategory,Short Description,Full Description,Consequences,Pre-mitigatedImpact,Pre-mitigatedLikelihood,Mitigatons,PostMitigatedImpact,PostMitigatedLikelihood,Proximity,RiskOwnerRole
+TD-FAK,,test programme risk 1,Client Mistreatment,test comment 1,full desc test text 1,consequence test 1,3 - Medium impact,2 - Medium,test mitigation comment 1,1- Marginal impact,3 - High,2 - Distant: next 12 months,test 1
+TD-FAK,,test programme risk 2,Business Continuity & Disaster Recovery,test comment 2,full desc test text 2,consequence test 2,4 - Significant impact ,1 - Low,test mitigation comment 2,2 - Low impact,1 - Low,1 - Remote,
+TD-FAK,,test programme risk 3,Environment,test comment 3,full desc test text 3,consequence test 3,1- Marginal impact,4 - Almost Certain,test mitigation comment 3,3 - Medium impact,1 - Low,2 - Distant: next 12 months,test 3
+,TD-FAK-01,project risk test 1,Credit Losses,test desc,,,3 - Medium impact,4 - Almost Certain,test mit,1- Marginal impact,2 - Medium,3 - Approaching: next 6 months,test own
+,TD-FAK-01,project risk test 2,Business Continuity & Disaster Recovery,,dest desc,test cons,4 - Significant impact ,2 - Medium,,1- Marginal impact,1 - Low,1 - Remote,test own
+,TD-FAK-01,project risk test 3,Covid Disruption,,,test cons,6 - Critical impact,1 - Low,,2 - Low impact,2 - Medium,2 - Distant: next 12 months,
+,TD-FAK-02,project risk tess a,Client Mistreatment,test desc,test desc,test desc,2 - Low impact,,test desc,1- Marginal impact,,3 - Approaching: next 6 months,test desc
+nan,TD-FAK-02,nan,Change in Policy Focus,"Test - no name, should not be extracted",nan,nan,nan,nan,nan,nan,nan,nan,nan

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -100,6 +100,21 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
     assert_frame_equal(extracted_project_progress, expected_project_progress)
 
 
+def test_extract_risk(mock_risk_sheet, mock_project_lookup, mock_programme_lookup):
+    """Test risk data extracted as expected."""
+    extracted_risk_data = tf.extract_risks(mock_risk_sheet, mock_project_lookup, mock_programme_lookup, round_four=True)
+    expected_risk_data = pd.read_csv(resources_assertions / "risks_expected.csv")
+    assert_frame_equal(extracted_risk_data, expected_risk_data)
+
+    # check rows that rows with no risk name entered are retained (in contrast to R3 behaviour)
+    risk_value_to_keep = mock_risk_sheet.iloc[30, 4]
+    assert risk_value_to_keep in set(extracted_risk_data["Short Description"])
+
+    # Check either project id or programme id populated for each row (but not both). Using XOR(^) operator
+    project_xor_programme = extracted_risk_data["Project ID"].notnull() ^ extracted_risk_data["Programme ID"].notnull()
+    assert project_xor_programme.all()
+
+
 def test_full_ingest(mock_ingest_full_extract):
     """
     Tests on top-level ingest function for Towns Fund Round 4.

--- a/tests/extraction_tests/test_utils.py
+++ b/tests/extraction_tests/test_utils.py
@@ -13,14 +13,23 @@ def test_drop_unwanted_rows():
     """Check util function removes rows based on unwanted values in the specified column."""
     test_df = pd.DataFrame(
         {
-            "val_column": ["test1", "test2", 4, np.nan, None, "< Select >"],
-            "test_data": [3, 4, 5, 4, 3, 4],
+            "val_column": ["test1", "test2", 4, np.nan, np.nan, None, None, "< Select >", "< Select >"],
+            "test_data": [3, 4, 5, 4, None, 4, "< Select >", 7, np.nan],
         }
     )
-    test_df = drop_empty_rows(test_df, "val_column")
-    assert test_df.to_dict(orient="list") == {
+
+    # remove any rows where val_column is an empty value
+    output_df = drop_empty_rows(test_df, ["val_column"])
+    assert output_df.to_dict(orient="list") == {
         "val_column": ["test1", "test2", 4],
         "test_data": [3, 4, 5],
+    }
+
+    # remove any rows where val_column and test_data are both an empty value
+    output_df = drop_empty_rows(test_df, ["val_column", "test_data"])
+    assert output_df.to_dict(orient="list") == {
+        "val_column": ["test1", "test2", 4, np.nan, None, "< Select >"],
+        "test_data": [3, 4, 5, 4, 4, 7],
     }
 
 

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -364,6 +364,7 @@ def test_non_nullable_messages_risk_register():
     failure3 = NonNullableConstraintFailure(sheet="RiskRegister", column="Consequences")
     failure4 = NonNullableConstraintFailure(sheet="RiskRegister", column="Mitigatons")  # typo throughout code
     failure5 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskOwnerRole")
+    failure6 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName")
 
     assert failure1.to_message() == (
         "Risk Register",
@@ -393,6 +394,11 @@ def test_non_nullable_messages_risk_register():
         "Programme / Project Risks",
         'There are blank cells in column: "Risk Owner/Role". Use the space provided to tell us the relevant '
         "information",
+    )
+    assert failure6.to_message() == (
+        "Risk Register",
+        "Programme / Project Risks",
+        'There are blank cells in column: "Risk Name". Use the space provided to tell us the relevant ' "information",
     )
 
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-67

### Change description
- modifies Round 4 ingestion to extract risk data regardless of if it has a null Risk Name
- adds validation support to catch this scenario

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
