### PR TITLE
[SMD-188] Fix failing round 3 file ingests

### DIFF
--- a/core/extraction/towns_fund_round_four.py
+++ b/core/extraction/towns_fund_round_four.py
@@ -60,9 +60,7 @@ def ingest_round_four_data_towns_fund(df_ingest: pd.DataFrame) -> dict[str, pd.D
     towns_fund_extracted["Output_Data"] = r3.extract_outputs(df_ingest["5 - Project Outputs"], project_lookup)
     towns_fund_extracted["Outputs_Ref"] = r3.extract_output_categories(towns_fund_extracted["Output_Data"])
     towns_fund_extracted["Outcome_Data"] = r3.combine_outcomes(
-        df_ingest["6 - Outcomes"],
-        project_lookup,
-        programme_id,
+        df_ingest["6 - Outcomes"], project_lookup, programme_id, 4
     )
     towns_fund_extracted["Outcome_Ref"] = r3.extract_outcome_categories(towns_fund_extracted["Outcome_Data"])
     towns_fund_extracted["RiskRegister"] = r3.extract_risks(

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -72,7 +72,7 @@ def extract_submission_details(
     try:
         wrong_input_checks["Fund Type"] = (sheet_a2.iloc[5][4], {"Town_Deal", "Future_High_Street_Fund"})
         wrong_input_checks["Place Name"] = (
-            sheet_a2.iloc[6][4],
+            sheet_a2.iloc[6][4].strip(),
             set(TF_PLACE_NAMES_TO_ORGANISATIONS.keys()),
         )
     except IndexError:

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -384,11 +384,6 @@ ROUND_THREE_TF_SCHEMA = {
         "foreign_keys": {
             "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
         },
-        "composite_key": (
-            "Programme ID",
-            "Question",
-            "Indicator",
-        ),
         "non-nullable": ["Programme ID", "Question", "Indicator"],
     },
     "Funding Questions": {
@@ -402,11 +397,6 @@ ROUND_THREE_TF_SCHEMA = {
         "foreign_keys": {
             "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
         },
-        "composite_key": (
-            "Programme ID",
-            "Question",
-            "Indicator",
-        ),
         "non-nullable": ["Programme ID", "Question"],
         "table_nullable": True,
     },
@@ -478,14 +468,6 @@ ROUND_THREE_TF_SCHEMA = {
         "foreign_keys": {
             "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
         },
-        "composite_key": (
-            "Project ID",
-            "Funding Source Name",
-            "Funding Source Type",
-            "Secured",
-            "Start_Date",
-            "End_Date",
-        ),
         "enums": {
             "Secured": enums.YesNoEnum,
             "Actual/Forecast": enums.StateEnum,
@@ -541,14 +523,6 @@ ROUND_THREE_TF_SCHEMA = {
             "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID"},
             "Output": {"parent_table": "Outputs_Ref", "parent_pk": "Output Name"},
         },
-        "composite_key": (
-            "Project ID",
-            "Output",
-            "Start_Date",
-            "End_Date",
-            "Unit of Measurement",
-            "Actual/Forecast",
-        ),
         "enums": {"Actual/Forecast": enums.StateEnum},
         "non-nullable": ["Project ID", "Start_Date", "Output", "Unit of Measurement"],
     },
@@ -577,13 +551,6 @@ ROUND_THREE_TF_SCHEMA = {
             "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID", "nullable": True},
             "Outcome": {"parent_table": "Outcome_Ref", "parent_pk": "Outcome_Name"},
         },
-        "composite_key": (
-            "Project ID",
-            "Outcome",
-            "Start_Date",
-            "End_Date",
-            "GeographyIndicator",
-        ),
         "enums": {
             "GeographyIndicator": enums.GeographyIndicatorEnum,
             "Actual/Forecast": enums.StateEnum,
@@ -618,11 +585,6 @@ ROUND_THREE_TF_SCHEMA = {
             "Project ID": {"parent_table": "Project Details", "parent_pk": "Project ID", "nullable": True},
             "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID", "nullable": True},
         },
-        "composite_key": (
-            "Programme ID",
-            "Project ID",
-            "RiskName",
-        ),
         "enums": {
             "Pre-mitigatedImpact": enums.ImpactEnum,
             "Pre-mitigatedLikelihood": enums.LikelihoodEnum,

--- a/scripts/batch_ingest.py
+++ b/scripts/batch_ingest.py
@@ -27,6 +27,7 @@ Note:
     - The output will be saved in a subdirectory named 'output' within the specified directory.
 """
 import argparse
+import json
 import os
 from datetime import datetime
 
@@ -98,9 +99,9 @@ def output_to_excel():
             if success:
                 errors = ""
             elif status_code == 400:  # validation error
-                errors = "\n".join(response.json()["validation_errors"])
+                errors = json.dumps(response.json()["validation_errors"])
             else:  # internal error e.g. DB error
-                errors = response.text
+                errors = json.dumps(response.json())
 
             output_df.loc[len(output_df)] = {"File Name": file_name, "Success": success, "Errors": errors}
             print("Success." if success else "Failed.")

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -370,7 +370,7 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
     # delete project lookup to render project in outcomes to be invalid
     del mock_project_lookup["Test Project 1"]
     with pytest.raises(ValidationError) as ve:
-        tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
+        tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 3)
     assert str(ve.value) == (
         "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Outcome Indicators (excluding "
         "footfall)')]"
@@ -380,17 +380,6 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
         tf.extract_footfall_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
     assert str(ve.value) == (
         "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Footfall Indicator')]"
-    )
-
-
-def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup):
-    """Test that appropriate validation error is raised when a project null."""
-    # replace a valid project with a null
-    mock_outcomes_sheet = mock_outcomes_sheet.replace("Test Project 1", np.nan)
-    with pytest.raises(ValidationError) as ve:
-        tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
-    assert str(ve.value) == (
-        "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome Indicators (excluding " "footfall)')]"
     )
 
 


### PR DESCRIPTION
Allow full re-ingest of Round 3 data

Draft PR because we are down to just 4 validation errors

This PR is more like several small bug fixes in one.
Changes:
- towns_fund_round_3.py 292: Some LA's added comments outside the area for inputing data, this created an extra column error so I tightened up the extraction for this sheet.
- towns_fund_round_3.py 883: Some round 3 data is missing projects assigned to outcomes. These rows are dropped (We should not carry this behaviour over to round 4) one test is ignored because and will be deleted.
- round 3 data has a large number of composite key validation errors where data has been previously ingested therefore this constraint is completely relaxed for round 3


Issues remaining:
- One LA has a Dropdown error: "Events programme" is in the cell when the expected is "Events Programme (LA_name)"
- Two LA's have left blank cells instead of inputing postcodes

These issues cannot be solved by relaxing validation rules in the service, therfore we need another way to reingest. The missing data is in the production database so could be downloaded and reingested from there 





### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
