### PR TITLE
BAU: fix more descriptive error messages by casting to string

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -566,7 +566,7 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.Dat
     df_funding["Reporting Period"] = [
         x.split(" (£s)__")[1][:3] + x[17:22] if "__" in x else x for x in df_funding["Reporting Period"]
     ]
-    df_funding["Funding Source Name"] = df_funding["Funding Source Name"].str.strip()
+    df_funding["Funding Source Name"] = df_funding["Funding Source Name"].astype(str).str.strip()
 
     df_funding = convert_financial_halves(df_funding, "Reporting Period")
     df_funding.reset_index(drop=True, inplace=True)

--- a/core/extraction/utils.py
+++ b/core/extraction/utils.py
@@ -1,5 +1,6 @@
 """Module for reusable DataFrame transformation functions."""
 import re
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -98,3 +99,12 @@ def extract_postcodes(s: str | float) -> list[str]:
     else:
         postcode_area_matches = re.findall(POSTCODE_REGEX, str(s))
     return postcode_area_matches
+
+
+def join_as_string(values: Sequence) -> str:
+    """Join values in a sequence of strings with commas separating.
+
+    :param values: A sequence of strings
+    :return: A string of all input values with ", " separating.
+    """
+    return ", ".join(str(value) for value in values)

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -16,6 +16,7 @@ from core.const import (
     INTERNAL_TYPE_TO_MESSAGE_FORMAT,
     PRETRANSFORMATION_FAILURE_MESSAGE_BANK,
 )
+from core.extraction.utils import join_as_string
 from core.util import get_project_number, group_by_first_element
 from core.validation.exceptions import UnimplementedErrorMessageException
 
@@ -137,7 +138,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
 
     def __str__(self):
         """Method to get the string representation of the non-unique-composite_key failure."""
-        cols_str = ", ".join(str(i) for i in self.cols)
+        cols_str = join_as_string(self.cols)
         row_str = list(self.row)
         return (
             f'Non Unique Row Failure: Sheet "{self.sheet}"; '
@@ -158,7 +159,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
         sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
 
         if sheet == "Funding Profiles":
-            row_str = ", ".join(str(i) for i in self.row[1:4])
+            row_str = join_as_string(self.row[1:4])
             project_number = get_project_number(self.row[0])
             section = f"Funding Profiles - Project {project_number}"
             message = (
@@ -383,7 +384,7 @@ class WrongInputFailure(PreTransFormationFailure):
         return (
             f"Pre-transformation Failure: The workbook failed a pre-transformation check for {self.value_descriptor} "
             f'where the entered value "{self.entered_value}" '
-            f'was outside of the expected values [{", ".join(self.expected_values)}].'
+            f"was outside of the expected values [{join_as_string(self.expected_values)}]."
         )
 
     def to_message(self) -> tuple[str | None, str | None, str]:
@@ -448,7 +449,7 @@ class UnauthorisedSubmissionFailure(PreTransFormationFailure):
         )
 
     def to_message(self) -> tuple[str | None, str | None, str]:
-        places = ", ".join(self.authorised_place_names)
+        places = join_as_string(self.authorised_place_names)
         message = (
             f"You are not authorised to submit for {self.unauthorised_place_name}. "
             "Please ensure you submit for a place within your local authority. "


### PR DESCRIPTION
Fixed an edge case where if users entered a numeric character as a funding source name it would be cast to NA when string methods were applied to it by first converting the colum with astype(str)

Seperate refactor of a small method to cast to a string and join with ', ' in failures.py as  was recomended a few days ago


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
