### PR TITLE
[BAU] refactor ingest calling components

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,8 @@ from werkzeug.serving import WSGIRequestHandler
 from config import Config
 from core.cli import create_cli
 from core.db import db, migrate
-from core.errors import ValidationError, handle_exception, handle_validation_error
+from core.exceptions import ValidationError
+from core.handlers import handle_exception, handle_validation_error
 from openapi.utils import get_bundled_specs
 
 WORKING_DIR = Path(__file__).parent

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,18 +1,9 @@
 import os
 import tempfile
-from copy import deepcopy
 from os import environ
 from pathlib import Path
 
 from fsd_utils import configclass
-
-from core.validation.schema import parse_schema
-from core.validation_schema import (
-    ROUND_FOUR_TF_SCHEMA,
-    ROUND_ONE_TF_SCHEMA,
-    ROUND_THREE_TF_SCHEMA,
-    ROUND_TWO_TF_SCHEMA,
-)
 
 
 @configclass
@@ -20,10 +11,6 @@ class DefaultConfig(object):
     FLASK_ROOT = Path(__file__).parent.parent.parent
 
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL", f"sqlite:///{tempfile.gettempdir()}/sqlite.db")
-    ROUND_ONE_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_ONE_TF_SCHEMA))
-    ROUND_TWO_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_TWO_TF_SCHEMA))
-    ROUND_THREE_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_THREE_TF_SCHEMA))
-    ROUND_FOUR_TF_VALIDATION_SCHEMA = parse_schema(deepcopy(ROUND_FOUR_TF_SCHEMA))
     EXAMPLE_DATA_MODEL_PATH = (
         FLASK_ROOT / "tests" / "controller_tests" / "resources" / "Post_transform_EXAMPLE_data.xlsx"
     )

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,5 @@
+class ValidationError(RuntimeError):
+    """Validation error."""
+
+    def __init__(self, validation_failures):
+        self.validation_failures = validation_failures

--- a/core/extraction/__init__.py
+++ b/core/extraction/__init__.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+from core.extraction.towns_fund_round_four import ingest_round_four_data_towns_fund
+from core.extraction.towns_fund_round_one import ingest_round_one_data_towns_fund
+from core.extraction.towns_fund_round_three import ingest_round_three_data_towns_fund
+from core.extraction.towns_fund_round_two import ingest_round_two_data_towns_fund
+
+
+def transform_data(workbook: dict[str, pd.DataFrame], reporting_round: int):
+    """Transforms the data from a submission into the data model.
+
+    :param workbook: a DataFrame containing the extracted contents of the submission
+    :param reporting_round: the reporting round
+    :return: the extracted and transformed data from the submission into the data model
+    """
+    match reporting_round:
+        case 1:
+            workbook = ingest_round_one_data_towns_fund(workbook)
+        case 2:
+            workbook = ingest_round_two_data_towns_fund(workbook)
+        case 3:
+            workbook = ingest_round_three_data_towns_fund(workbook)
+        case 4:
+            workbook = ingest_round_four_data_towns_fund(workbook)
+    return workbook

--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -17,7 +17,7 @@ from core.const import (
     TF_PLACE_NAMES_TO_ORGANISATIONS,
     FundTypeIdEnum,
 )
-from core.errors import ValidationError
+from core.exceptions import ValidationError
 from core.extraction.utils import (
     convert_financial_halves,
     drop_empty_rows,

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -1,21 +1,15 @@
-from http.client import HTTPException
-
 from flask import current_app, request
+from werkzeug.exceptions import HTTPException
 
-from core.validation.failures import ValidationFailure, failures_to_messages
-
-
-class ValidationError(RuntimeError):
-    """Validation error."""
-
-    def __init__(self, validation_failures: list[ValidationFailure]):
-        self.failure_messages = failures_to_messages(validation_failures)
+from core.exceptions import ValidationError
+from core.validation.failures import failures_to_messages
 
 
-def handle_validation_error(error: ValidationError):
+def handle_validation_error(validation_error: ValidationError):
+    validation_messages = failures_to_messages(validation_error.validation_failures)
     return {
         "detail": "Workbook validation failed",
-        "validation_errors": error.failure_messages,
+        "validation_errors": validation_messages,
         "status": 400,
         "title": "Bad Request",
     }, 400

--- a/core/validation/__init__.py
+++ b/core/validation/__init__.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+import core.validation.specific_validations.towns_fund_round_four as tf_round_4
+from core.exceptions import ValidationError
+from core.validation.casting import cast_to_schema
+from core.validation.validate import validate_workbook
+from core.validation_schema import get_schema
+
+
+def validate(workbook: dict[str, pd.DataFrame], reporting_round: int):
+    """Validate a workbook against it's round specific schema.
+
+    :param workbook: a set of data in a dataframe that fits the data model
+    :param reporting_round: the reporting round
+    :raises: ValidationError: if the workbook fails validation
+    :return: any captured validation failures
+    """
+    validation_schema = get_schema(reporting_round)
+    cast_to_schema(workbook, validation_schema)
+    validation_failures = validate_workbook(workbook, validation_schema)
+
+    if reporting_round == 4:
+        round_4_failures = tf_round_4.validate(workbook)
+        validation_failures = [*validation_failures, *round_4_failures]
+
+    if validation_failures:
+        raise ValidationError(validation_failures=validation_failures)

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -6,12 +6,30 @@ from core.const import (
     GET_FORM_VERSION_AND_REPORTING_PERIOD,
     TF_PLACE_NAMES_TO_ORGANISATIONS,
 )
+from core.exceptions import ValidationError
+
+
+def validate_before_transformation(workbook: dict[str, pd.DataFrame], reporting_round: int, place_names: list[str]):
+    """High-level validation of the workbook before transformation.
+
+    :param workbook: a DataFrame containing the extracted contents of the submission
+    :param reporting_round: the reporting round
+    :param place_names: a list of valid places for this ingest
+    :raises: ValidationError: if the workbook fails validation
+    :return: the extracted and transformed data from the submission into the data model
+    """
+    pre_transformation_details = extract_submission_details(
+        workbook=workbook, reporting_round=reporting_round, place_names=place_names
+    )
+    file_validation_failures = pre_transformation_check(pre_transformation_details)
+    if file_validation_failures:
+        raise ValidationError(validation_failures=file_validation_failures)
 
 
 def extract_submission_details(
     workbook: dict[str, pd.DataFrame],
     reporting_round: int,
-    place_names: tuple[str] | None,
+    place_names: list[str] | None,
 ) -> dict[str, tuple[str]]:
     """
     Extract submission details from the given workbook.

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 import core.validation.failures as vf
 
 
-def validate(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.ValidationFailure]:
+def validate_workbook(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.ValidationFailure]:
     """Validate a workbook against a schema.
 
     This is the top-level validate function. It:
@@ -27,7 +27,7 @@ def validate(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.Validat
              found.
     """
     extra_sheets = remove_undefined_sheets(workbook, schema)
-    validation_failures = validate_workbook(workbook, schema)
+    validation_failures = validations(workbook, schema)
     return [*extra_sheets, *validation_failures]
 
 
@@ -51,7 +51,7 @@ def remove_undefined_sheets(workbook: dict[str, pd.DataFrame], schema: dict) -> 
     return extra_sheet_failures
 
 
-def validate_workbook(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.ValidationFailure]:
+def validations(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.ValidationFailure]:
     """
     Validate the given workbook against a provided schema by checking each sheet's
     columns, data types, unique values, and foreign keys.

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -1,4 +1,7 @@
+from copy import deepcopy
+
 import core.const as enums
+from core.validation.schema import parse_schema
 
 ROUND_FOUR_TF_SCHEMA = {
     "Submission_Ref": {
@@ -1113,3 +1116,19 @@ ROUND_ONE_TF_SCHEMA = {
         ],
     },
 }
+
+PARSED_SCHEMAS = {
+    1: parse_schema(deepcopy(ROUND_ONE_TF_SCHEMA)),
+    2: parse_schema(deepcopy(ROUND_TWO_TF_SCHEMA)),
+    3: parse_schema(deepcopy(ROUND_THREE_TF_SCHEMA)),
+    4: parse_schema(deepcopy(ROUND_FOUR_TF_SCHEMA)),
+}
+
+
+def get_schema(reporting_round: int) -> dict[str, object]:
+    """Returns validation schema corresponding to reporting round.
+
+    :param reporting_round: the round being ingested
+    :return: the validation schema
+    """
+    return PARSED_SCHEMAS.get(reporting_round, PARSED_SCHEMAS[3])

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -6,9 +6,9 @@ components:
         excel_file:
           type: string
           format: binary
-        source_type:
-          type: string
-          enum: [ tf_round_one, tf_round_two, tf_round_three, tf_round_four ]
+        reporting_period:
+          type: integer
+          enum: [ 1, 2, 3, 4 ]
         place_names:
           description: Restrict ingest to submissions for this list of places.
           example: [ "Sunderland City Centre", "Blackfriars - Northern City Centre", "Worcester" ]

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from core.validation.casting import cast_to_schema
 from core.validation.schema import parse_schema
-from core.validation.validate import validate
+from core.validation.validate import validate_workbook
 
 
 def load_schema(file_path, variable):
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         exit()
 
     cast_to_schema(workbook, schema)
-    errors = validate(workbook=workbook, schema=schema)
+    errors = validate_workbook(workbook=workbook, schema=schema)
 
     if errors:
         for error in errors:

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
 
 from core.const import OUTCOME_CATEGORIES, OUTPUT_CATEGORIES
 from core.controllers.mappings import INGEST_MAPPINGS
-from core.errors import ValidationError
+from core.exceptions import ValidationError
 from core.extraction import towns_fund_round_three as tf
 from core.extraction.towns_fund_round_two import ingest_round_two_data_towns_fund
 

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -18,7 +18,6 @@ from core.validation.failures import (
 )
 from core.validation.validate import (
     remove_undefined_sheets,
-    validate,
     validate_columns,
     validate_enums,
     validate_foreign_keys,
@@ -26,6 +25,7 @@ from core.validation.validate import (
     validate_unique_composite_key,
     validate_uniques,
     validate_workbook,
+    validations,
 )
 
 ####################################
@@ -638,14 +638,14 @@ def test_validate_columns_extra_and_missing_columns(valid_workbook_and_schema):
 def test_table_nullable_allows_empty_table():
     workbook = {"Test Table": pd.DataFrame()}
     schema = {"Test Table": {"table_nullable": True}}
-    failures = validate(workbook, schema)
+    failures = validate_workbook(workbook, schema)
     assert not failures
 
 
 def test_table_nullable_catches_empty_table():
     workbook = {"Test Table": pd.DataFrame()}
     schema = {"Test Table": {"table_nullable": False}}
-    failures = validate(workbook, schema)
+    failures = validate_workbook(workbook, schema)
 
     assert failures == [EmptySheetFailure(empty_sheet="Test Table")]
 
@@ -653,7 +653,7 @@ def test_table_nullable_catches_empty_table():
 def test_table_nullable_catches_empty_table_by_default():
     workbook = {"Test Table": pd.DataFrame()}
     schema = {"Test Table": {}}
-    failures = validate(workbook, schema)
+    failures = validate_workbook(workbook, schema)
 
     assert failures == [EmptySheetFailure(empty_sheet="Test Table")]
 
@@ -666,7 +666,7 @@ def test_table_nullable_catches_empty_table_by_default():
 def test_validate_workbook_valid(valid_workbook_and_schema):
     workbook, schema = valid_workbook_and_schema
 
-    failures = validate_workbook(workbook, schema)
+    failures = validations(workbook, schema)
 
     assert not failures
 
@@ -678,7 +678,7 @@ def test_validate_workbook_invalid(valid_workbook_and_schema, invalid_workbook):
     # (this is enforced in an earlier function)
     schema["Empty Sheet"] = {"columns": {}}
 
-    failures = validate_workbook(invalid_workbook, schema)
+    failures = validations(invalid_workbook, schema)
 
     assert failures
     assert all(isinstance(failure, ValidationFailure) for failure in failures)
@@ -722,7 +722,7 @@ def test_remove_undefined_sheets_unchanged(valid_workbook_and_schema):
 def test_validate_valid(valid_workbook_and_schema):
     workbook, schema = valid_workbook_and_schema
 
-    failures = validate(workbook, schema)
+    failures = validate_workbook(workbook, schema)
 
     assert not failures
 
@@ -733,6 +733,6 @@ def test_validate_invalid(valid_workbook_and_schema, invalid_workbook):
     schema["Empty Sheet"] = {"columns": {}}  # triggers Empty Sheet failure
     invalid_workbook["Extra Sheet"] = pd.DataFrame()  # triggers Extra Sheet failure
 
-    failures = validate(invalid_workbook, schema)
+    failures = validate_workbook(invalid_workbook, schema)
 
     assert len(failures) == 8


### PR DESCRIPTION
### Change description
This refactor expanded to cover more files than I had planned.. I originally wanted to just remove the redundancy that using both source_type and reporting_round created. The additional changes tidy things up though and make our approach to configuring the different components per reporting round more consistent - making ingest easier to follow. Obviously if we move to multiple funds this will have to change to incorporate that, but the last system didn't do that anyway.

- ingest now calls pre_tranformation_checks, extract_data, and validate_workbook functions with the workbook and the reporting round
- each functions are located in their various packages
- "source type" has been removed and replaced solely with "reporting_round" - it had some 1-1 mappings already and having both was redundant

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
