### PR TITLE
[SMD-193] Pull through excell cell indexes into validation messages

### DIFF
--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -289,8 +289,8 @@ class InvalidEnumValueFailure(ValidationFailure):
         sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
         column, section = INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION[self.column]
         message = (
-            f'For column "{column}", you have entered "{self.value}" which isn\'t correct. You must select an '
-            f"option from the list provided"
+            f'For column "{column}" row {self.row+2}, you have entered "{self.value}"which isn\'t correct. You must '
+            f"select an option from the list provided"
         )
 
         # additional logic for outcomes to differentiate between footfall and non-footfall

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -279,14 +279,17 @@ def validate_enums(
         row_is_valid = sheet[column].isin(valid_enum_values)
         invalid_rows = row_is_valid[row_is_valid == False]  # noqa: E712 pandas notation
         for row_idx in invalid_rows.keys():
-            invalid_value = sheet[column][row_idx]
+            if sheet_name == "Funding":
+                invalid_value = sheet[column][row_idx].iloc[0]
+            else:
+                invalid_value = sheet[column][row_idx]
             if not pd.isna(invalid_value):  # allow na values here
                 invalid_enum_values.append(
                     vf.InvalidEnumValueFailure(
                         sheet=sheet_name,
                         column=column,
                         row=row_idx,
-                        row_values=tuple(sheet.iloc[row_idx]),
+                        row_values=tuple(sheet.loc[[row_idx]].iloc[0]),
                         value=invalid_value,
                     )
                 )


### PR DESCRIPTION
This is the result of a spike to see if we could pull through excel cell indexes into the validation messages. The strategey is to add a column to the pretransformed data representing the excel row index. Post transformation I set the table index to this column. Now all rows are indexed by there original excel row number. This can be picked up in validation to display the row number. Column Letters are not considered yet in this PR.

This is a proof of concept:
It only works for Tab: funding profiles, Enum failure: column secured.

Behaviour in other areas of the sheet may be buggy/unpredictable so only test manually for this case

expected output:

![Screenshot 2023-09-29 at 15-40-24 Swagger UI](https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/63752812/cb70f987-3c37-4c62-b0da-bb0a52ac77a6)

### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
