### PR TITLE
[SMD-220]: retain original row indexes

### DIFF
--- a/core/extraction/towns_fund_round_four.py
+++ b/core/extraction/towns_fund_round_four.py
@@ -15,7 +15,7 @@ import core.extraction.towns_fund_round_three as r3
 from core.extraction import common
 
 
-def ingest_round_four_data_towns_fund(df_ingest: pd.DataFrame) -> dict[str, pd.DataFrame]:
+def ingest_round_four_data_towns_fund(df_ingest: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
     """
     Extract data from Towns Fund Round 4 Reporting Template into column headed Pandas DataFrames.
 
@@ -84,6 +84,5 @@ def extract_programme_progress(df_data: pd.DataFrame, programme_id: str) -> pd.D
     :return: A new DataFrame containing the extracted programme progress rows.
     """
     df_data = r3.extract_programme_progress(df_data, programme_id)
-    df_data = df_data.drop(5)  # Question 6 isn't required for Round 4
-    df_data = df_data.reset_index(drop=True)
+    df_data = df_data.drop(df_data.iloc[5].name)  # Question 6 isn't required for Round 4
     return df_data

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -271,7 +271,7 @@ def validate_enums(
     :return: A list of InvalidEnumValueFailure objects for any rows with values outside
              the set of valid enum values.
     """
-    sheet = workbook[sheet_name]
+    sheet = workbook[sheet_name].reset_index(drop=True)
     invalid_enum_values = []
 
     for column, valid_enum_values in enums.items():

--- a/tests/extraction_tests/resources/assertion_data/round_four/programme_progress_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_four/programme_progress_expected.csv
@@ -1,7 +1,7 @@
-Question,Answer,Programme ID
-How is your programme progressing,some comment on profile / forecast,TD-FAK
-Please provide a progress update,Test comment progress update,TD-FAK
-What are the key challenges you,"Test comment, challenges",TD-FAK
-What challenges do you expect to,"Test comment, expected challenges",TD-FAK
-Please provide an update on your,"Test comment, evaluation activities",TD-FAK
-If any support is required from the,"Test comment, support",TD-FAK
+,Question,Answer,Programme ID
+5,How is your programme progressing,some comment on profile / forecast,TD-FAK
+6,Please provide a progress update,Test comment progress update,TD-FAK
+7,What are the key challenges you,"Test comment, challenges",TD-FAK
+8,What challenges do you expect to,"Test comment, expected challenges",TD-FAK
+9,Please provide an update on your,"Test comment, evaluation activities",TD-FAK
+11,If any support is required from the,"Test comment, support",TD-FAK

--- a/tests/extraction_tests/resources/assertion_data/round_four/project_progress_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_four/project_progress_expected.csv
@@ -1,4 +1,4 @@
-Start Date,Completion Date,Current Project Delivery Stage,Project Delivery Status,Leading Factor of Delay,Project Adjustment Request Status,Delivery (RAG),Spend (RAG),Risk (RAG),Commentary on Status and RAG Ratings,Most Important Upcoming Comms Milestone,Date of Most Important Upcoming Comms Milestone (e.g. Dec-22),Project ID
-44562,46082,Feasibility,2. Ongoing - on track,"",PAR not required,3,2,,test comment 1,milestone 1,45078,TD-FAK-01
-44562,46082,Planning & Design,3. Ongoing - delayed,External Stakeholder Management,PAR submitted - approved,2,2,3,test comment 2,milestone 2,45139,TD-FAK-02
-44593,46082,Initiation,1. Not yet started,"",PAR submitted - awaiting approval,2,2,3,test comment 3,milestone 3,45261,TD-FAK-03
+,Start Date,Completion Date,Current Project Delivery Stage,Project Delivery Status,Leading Factor of Delay,Project Adjustment Request Status,Delivery (RAG),Spend (RAG),Risk (RAG),Commentary on Status and RAG Ratings,Most Important Upcoming Comms Milestone,Date of Most Important Upcoming Comms Milestone (e.g. Dec-22),Project ID
+18,44562,46082,Feasibility,2. Ongoing - on track,,PAR not required,3,2,,test comment 1,milestone 1,45078,TD-FAK-01
+19,44562,46082,Planning & Design,3. Ongoing - delayed,External Stakeholder Management,PAR submitted - approved,2,2,3,test comment 2,milestone 2,45139,TD-FAK-02
+20,44593,46082,Initiation,1. Not yet started,,PAR submitted - awaiting approval,2,2,3,test comment 3,milestone 3,45261,TD-FAK-03

--- a/tests/extraction_tests/resources/assertion_data/round_four/risks_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_four/risks_expected.csv
@@ -1,9 +1,9 @@
-Programme ID,Project ID,RiskName,RiskCategory,Short Description,Full Description,Consequences,Pre-mitigatedImpact,Pre-mitigatedLikelihood,Mitigatons,PostMitigatedImpact,PostMitigatedLikelihood,Proximity,RiskOwnerRole
-TD-FAK,,test programme risk 1,Client Mistreatment,test comment 1,full desc test text 1,consequence test 1,3 - Medium impact,2 - Medium,test mitigation comment 1,1- Marginal impact,3 - High,2 - Distant: next 12 months,test 1
-TD-FAK,,test programme risk 2,Business Continuity & Disaster Recovery,test comment 2,full desc test text 2,consequence test 2,4 - Significant impact ,1 - Low,test mitigation comment 2,2 - Low impact,1 - Low,1 - Remote,
-TD-FAK,,test programme risk 3,Environment,test comment 3,full desc test text 3,consequence test 3,1- Marginal impact,4 - Almost Certain,test mitigation comment 3,3 - Medium impact,1 - Low,2 - Distant: next 12 months,test 3
-,TD-FAK-01,project risk test 1,Credit Losses,test desc,,,3 - Medium impact,4 - Almost Certain,test mit,1- Marginal impact,2 - Medium,3 - Approaching: next 6 months,test own
-,TD-FAK-01,project risk test 2,Business Continuity & Disaster Recovery,,dest desc,test cons,4 - Significant impact ,2 - Medium,,1- Marginal impact,1 - Low,1 - Remote,test own
-,TD-FAK-01,project risk test 3,Covid Disruption,,,test cons,6 - Critical impact,1 - Low,,2 - Low impact,2 - Medium,2 - Distant: next 12 months,
-,TD-FAK-02,project risk tess a,Client Mistreatment,test desc,test desc,test desc,2 - Low impact,,test desc,1- Marginal impact,,3 - Approaching: next 6 months,test desc
-nan,TD-FAK-02,nan,Change in Policy Focus,"Test - no name, should not be extracted",nan,nan,nan,nan,nan,nan,nan,nan,nan
+,Programme ID,Project ID,RiskName,RiskCategory,Short Description,Full Description,Consequences,Pre-mitigatedImpact,Pre-mitigatedLikelihood,Mitigatons,PostMitigatedImpact,PostMitigatedLikelihood,Proximity,RiskOwnerRole
+10,TD-FAK,,test programme risk 1,Client Mistreatment,test comment 1,full desc test text 1,consequence test 1,3 - Medium impact,2 - Medium,test mitigation comment 1,1- Marginal impact,3 - High,2 - Distant: next 12 months,test 1
+11,TD-FAK,,test programme risk 2,Business Continuity & Disaster Recovery,test comment 2,full desc test text 2,consequence test 2,4 - Significant impact ,1 - Low,test mitigation comment 2,2 - Low impact,1 - Low,1 - Remote,
+12,TD-FAK,,test programme risk 3,Environment,test comment 3,full desc test text 3,consequence test 3,1- Marginal impact,4 - Almost Certain,test mitigation comment 3,3 - Medium impact,1 - Low,2 - Distant: next 12 months,test 3
+21,,TD-FAK-01,project risk test 1,Credit Losses,test desc,,,3 - Medium impact,4 - Almost Certain,test mit,1- Marginal impact,2 - Medium,3 - Approaching: next 6 months,test own
+22,,TD-FAK-01,project risk test 2,Business Continuity & Disaster Recovery,,dest desc,test cons,4 - Significant impact ,2 - Medium,,1- Marginal impact,1 - Low,1 - Remote,test own
+23,,TD-FAK-01,project risk test 3,Covid Disruption,,,test cons,6 - Critical impact,1 - Low,,2 - Low impact,2 - Medium,2 - Distant: next 12 months,
+29,,TD-FAK-02,project risk tess a,Client Mistreatment,test desc,test desc,test desc,2 - Low impact,,test desc,1- Marginal impact,,3 - Approaching: next 6 months,test desc
+30,nan,TD-FAK-02,nan,Change in Policy Focus,"Test - no name, should not be extracted",nan,nan,nan,nan,nan,nan,nan,nan,nan

--- a/tests/extraction_tests/resources/assertion_data/round_three/funding_comments_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/funding_comments_expected.csv
@@ -1,4 +1,4 @@
-Comment,Project ID
-Test comment 1,TD-FAK-01
-Test comment 2,TD-FAK-02
-,TD-FAK-03
+original_index,Comment,Project ID
+57,Test comment 1,TD-FAK-01
+85,Test comment 2,TD-FAK-02
+113,,TD-FAK-03

--- a/tests/extraction_tests/resources/assertion_data/round_three/funding_data_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/funding_data_expected.csv
@@ -1,237 +1,237 @@
-Project ID,Funding Source Name,Funding Source Type,Secured,Spend for Reporting Period,Actual/Forecast,Start_Date,End_Date
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,354345,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,345,Actual,01/04/2021,30/09/2021
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,Source 2,Third Sector Funding,Yes,2345,,,31/03/2020
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,Source 2,Third Sector Funding,Yes,1414,Actual,01/10/2020,31/03/2021
-TD-FAK-01,Source 2,Third Sector Funding,Yes,14314,Actual,01/04/2021,30/09/2021
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/10/2021,31/03/2022
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,Source 2,Third Sector Funding,Yes,,,01/04/2026,
-TD-FAK-01,Test source,Private Funding,Yes,,,,31/03/2020
-TD-FAK-01,Test source,Private Funding,No,,,,31/03/2020
-TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,Test source,Private Funding,Yes,235253,Actual,01/04/2021,30/09/2021
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2021,30/09/2021
-TD-FAK-01,Test source,Private Funding,Yes,235235,Actual,01/10/2021,31/03/2022
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2021,31/03/2022
-TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,Test source,Private Funding,No,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,Test source,Private Funding,Yes,25323,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,Test source,Private Funding,No,235235,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,Test source,Private Funding,No,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,Test source,Private Funding,Yes,,,01/04/2026,
-TD-FAK-01,Test source,Private Funding,No,,,01/04/2026,
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,345435,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,3455,Actual,01/10/2020,31/03/2021
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,4534,Actual,01/04/2021,30/09/2021
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,3453,Actual,01/10/2021,31/03/2022
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,354,Actual,01/04/2022,30/09/2022
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,345,Actual,01/10/2021,31/03/2022
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,234234,Actual,01/10/2021,31/03/2022
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,134153,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,Test source project 2,Private Funding,Yes,,,,31/03/2020
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2020,30/09/2020
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2021,31/03/2022
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,Test source project 2,Private Funding,Yes,5245245,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,Test source project 2,Private Funding,Yes,234234,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,Test source project 2,Private Funding,Yes,234234,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,Test source project 2,Private Funding,Yes,234234,,01/04/2026,
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,0,Actual,01/04/2020,30/09/2020
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2021,31/03/2022
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
-TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+original_index,Project ID,Funding Source Name,Funding Source Type,Secured,Spend for Reporting Period,Actual/Forecast,Start_Date,End_Date
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,354345,Forecast,01/04/2023,30/09/2023
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+38,TD-FAK-01,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,345,Actual,01/04/2021,30/09/2021
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+41,TD-FAK-01,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,2345,,,31/03/2020
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/04/2020,30/09/2020
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,1414,Actual,01/10/2020,31/03/2021
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,14314,Actual,01/04/2021,30/09/2021
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/10/2021,31/03/2022
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/04/2022,30/09/2022
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Actual,01/10/2022,31/03/2023
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2023,30/09/2023
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2023,31/03/2024
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2024,30/09/2024
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2024,31/03/2025
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/04/2025,30/09/2025
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,Forecast,01/10/2025,31/03/2026
+50,TD-FAK-01,Source 2,Third Sector Funding,Yes,,,01/04/2026,
+48,TD-FAK-01,Test source,Private Funding,Yes,,,,31/03/2020
+49,TD-FAK-01,Test source,Private Funding,No,,,,31/03/2020
+48,TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/04/2020,30/09/2020
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2020,30/09/2020
+48,TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/10/2020,31/03/2021
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2020,31/03/2021
+48,TD-FAK-01,Test source,Private Funding,Yes,235253,Actual,01/04/2021,30/09/2021
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2021,30/09/2021
+48,TD-FAK-01,Test source,Private Funding,Yes,235235,Actual,01/10/2021,31/03/2022
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2021,31/03/2022
+48,TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/04/2022,30/09/2022
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/04/2022,30/09/2022
+48,TD-FAK-01,Test source,Private Funding,Yes,,Actual,01/10/2022,31/03/2023
+49,TD-FAK-01,Test source,Private Funding,No,,Actual,01/10/2022,31/03/2023
+48,TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2023,30/09/2023
+49,TD-FAK-01,Test source,Private Funding,No,,Forecast,01/04/2023,30/09/2023
+48,TD-FAK-01,Test source,Private Funding,Yes,25323,Forecast,01/10/2023,31/03/2024
+49,TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2023,31/03/2024
+48,TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2024,30/09/2024
+49,TD-FAK-01,Test source,Private Funding,No,235235,Forecast,01/04/2024,30/09/2024
+48,TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/10/2024,31/03/2025
+49,TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2024,31/03/2025
+48,TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/04/2025,30/09/2025
+49,TD-FAK-01,Test source,Private Funding,No,,Forecast,01/04/2025,30/09/2025
+48,TD-FAK-01,Test source,Private Funding,Yes,,Forecast,01/10/2025,31/03/2026
+49,TD-FAK-01,Test source,Private Funding,No,,Forecast,01/10/2025,31/03/2026
+48,TD-FAK-01,Test source,Private Funding,Yes,,,01/04/2026,
+49,TD-FAK-01,Test source,Private Funding,No,,,01/04/2026,
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,345435,Forecast,01/10/2023,31/03/2024
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+37,TD-FAK-01,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2020,30/09/2020
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,3455,Actual,01/10/2020,31/03/2021
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,4534,Actual,01/04/2021,30/09/2021
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,3453,Actual,01/10/2021,31/03/2022
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,354,Actual,01/04/2022,30/09/2022
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
+36,TD-FAK-01,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,345,Actual,01/10/2021,31/03/2022
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+40,TD-FAK-01,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,234234,Actual,01/10/2021,31/03/2022
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,134153,Forecast,01/04/2024,30/09/2024
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+66,TD-FAK-02,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+69,TD-FAK-02,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,,,31/03/2020
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2020,30/09/2020
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2020,31/03/2021
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2021,30/09/2021
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2021,31/03/2022
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/04/2022,30/09/2022
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Actual,01/10/2022,31/03/2023
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/04/2023,30/09/2023
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/10/2023,31/03/2024
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,,Forecast,01/04/2024,30/09/2024
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,5245245,Forecast,01/10/2024,31/03/2025
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,234234,Forecast,01/04/2025,30/09/2025
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,234234,Forecast,01/10/2025,31/03/2026
+76,TD-FAK-02,Test source project 2,Private Funding,Yes,234234,,01/04/2026,
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+65,TD-FAK-02,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,0,Actual,01/04/2020,30/09/2020
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2020,31/03/2021
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2021,30/09/2021
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2021,31/03/2022
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2022,30/09/2022
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
+64,TD-FAK-02,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2021,31/03/2022
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+68,TD-FAK-02,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+94,TD-FAK-03,How much of your CDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2020,30/09/2020
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2020,31/03/2021
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2021,30/09/2021
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2021,31/03/2022
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/04/2022,30/09/2022
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Actual,01/10/2022,31/03/2023
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+97,TD-FAK-03,How much of your RDEL forecast is contractually committed?,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2020,30/09/2020
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2020,31/03/2021
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2021,30/09/2021
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2021,31/03/2022
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/04/2022,30/09/2022
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Actual,01/10/2022,31/03/2023
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+93,TD-FAK-03,Town Deals 5% CDEL Pre-Payment,Towns Fund,,,Forecast,01/10/2025,31/03/2026
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2020,30/09/2020
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2020,31/03/2021
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2021,30/09/2021
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2021,31/03/2022
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/04/2022,30/09/2022
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Actual,01/10/2022,31/03/2023
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2023,30/09/2023
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2023,31/03/2024
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2024,30/09/2024
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2024,31/03/2025
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/04/2025,30/09/2025
+92,TD-FAK-03,"Towns Fund CDEL which is being utilised on TF project related activity (For Town Deals, this excludes the 5% CDEL Pre-Payment)",Towns Fund,,,Forecast,01/10/2025,31/03/2026
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2020,30/09/2020
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2020,31/03/2021
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2021,30/09/2021
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2021,31/03/2022
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/04/2022,30/09/2022
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Actual,01/10/2022,31/03/2023
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2023,30/09/2023
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2023,31/03/2024
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2024,30/09/2024
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2024,31/03/2025
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/04/2025,30/09/2025
+96,TD-FAK-03,Towns Fund RDEL Payment which is being utilised on TF project related activity,Towns Fund,,,Forecast,01/10/2025,31/03/2026

--- a/tests/extraction_tests/resources/assertion_data/round_three/funding_questions_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/funding_questions_expected.csv
@@ -1,22 +1,22 @@
-Question,Guidance Notes,Indicator,Response,Programme ID
-"Beyond these three funding types, have you received any payments for specific projects?",,,Yes,TD-FAK
-Please confirm whether the amount utilised represents your entire allocation,,"TD 5% CDEL Pre-Payment
+original_index,Question,Guidance Notes,Indicator,Response,Programme ID
+13,"Beyond these three funding types, have you received any payments for specific projects?",,,Yes,TD-FAK
+15,Please confirm whether the amount utilised represents your entire allocation,,"TD 5% CDEL Pre-Payment
 (Towns Fund FAQs p.46 - 49)",Yes,TD-FAK
-Please confirm whether the amount utilised represents your entire allocation,,TD Accelerated Funding,No,TD-FAK
-Please confirm whether the amount utilised represents your entire allocation,,TD RDEL Capacity Funding,No,TD-FAK
-"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,"TD 5% CDEL Pre-Payment
+15,Please confirm whether the amount utilised represents your entire allocation,,TD Accelerated Funding,No,TD-FAK
+15,Please confirm whether the amount utilised represents your entire allocation,,TD RDEL Capacity Funding,No,TD-FAK
+16,"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,"TD 5% CDEL Pre-Payment
 (Towns Fund FAQs p.46 - 49)",some meaningless time description,TD-FAK
-"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,TD Accelerated Funding,test desc,TD-FAK
-"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,TD RDEL Capacity Funding,another on,TD-FAK
-"Please explain in detail how the funding has, or will be, utilised",,"TD 5% CDEL Pre-Payment
+16,"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,TD Accelerated Funding,test desc,TD-FAK
+16,"Please describe when funding was utilised and, if applicable, when any remaining funding will be utilised",,TD RDEL Capacity Funding,another on,TD-FAK
+18,"Please explain in detail how the funding has, or will be, utilised",,"TD 5% CDEL Pre-Payment
 (Towns Fund FAQs p.46 - 49)",test comments,TD-FAK
-"Please explain in detail how the funding has, or will be, utilised",,TD Accelerated Funding,test comments 3,TD-FAK
-"Please explain in detail how the funding has, or will be, utilised",,TD RDEL Capacity Funding,test comments 2,TD-FAK
-Please indicate how much of your allocation has been utilised (in £s),,"TD 5% CDEL Pre-Payment
+18,"Please explain in detail how the funding has, or will be, utilised",,TD Accelerated Funding,test comments 3,TD-FAK
+18,"Please explain in detail how the funding has, or will be, utilised",,TD RDEL Capacity Funding,test comments 2,TD-FAK
+14,Please indicate how much of your allocation has been utilised (in £s),,"TD 5% CDEL Pre-Payment
 (Towns Fund FAQs p.46 - 49)",55,TD-FAK
-Please indicate how much of your allocation has been utilised (in £s),,TD Accelerated Funding,77,TD-FAK
-Please indicate how much of your allocation has been utilised (in £s),,TD RDEL Capacity Funding,66,TD-FAK
-"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below","TD 5% CDEL Pre-Payment
+14,Please indicate how much of your allocation has been utilised (in £s),,TD Accelerated Funding,77,TD-FAK
+14,Please indicate how much of your allocation has been utilised (in £s),,TD RDEL Capacity Funding,66,TD-FAK
+17,"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below","TD 5% CDEL Pre-Payment
 (Towns Fund FAQs p.46 - 49)",Mix of programme and projects,TD-FAK
-"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below",TD Accelerated Funding,Programme only,TD-FAK
-"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below",TD RDEL Capacity Funding,Specific project(s) only,TD-FAK
+17,"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below",TD Accelerated Funding,Programme only,TD-FAK
+17,"Please select the option that best describes how the funding was, or will be, utilised","Given your answer on the 5% CDEL Pre-Payment, please ensure you detail this spend in the project tables below",TD RDEL Capacity Funding,Specific project(s) only,TD-FAK

--- a/tests/extraction_tests/resources/assertion_data/round_three/outcomes_data_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/outcomes_data_expected.csv
@@ -1,195 +1,195 @@
-Higher Frequency,Project ID,Programme ID,Outcome,UnitofMeasurement,GeographyIndicator,Amount,Actual/Forecast,Start_Date,End_Date
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Actual,2020-04-01,2021-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,2020-04-01,2021-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Actual,2020-04-01,2021-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,55,Actual,2021-04-01,2022-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,2021-04-01,2022-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Actual,2021-04-01,2022-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Actual,2022-04-01,2023-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,2022-04-01,2023-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Actual,2022-04-01,2023-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2023-04-01,2024-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2023-04-01,2024-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Forecast,2023-04-01,2024-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2024-04-01,2025-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,66,Forecast,2024-04-01,2025-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,2024-04-01,2025-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2025-04-01,2026-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2025-04-01,2026-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,2025-04-01,2026-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2026-04-01,2027-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2026-04-01,2027-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,2026-04-01,2027-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,44,Forecast,2027-04-01,2028-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2027-04-01,2028-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,2027-04-01,2028-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2028-04-01,2029-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2028-04-01,2029-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,2028-04-01,2029-03-31
-Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,2029-04-01,2030-03-31
-,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,2029-04-01,2030-03-31
-Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Forecast,2029-04-01,2030-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,2020-04-01,2021-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,2021-04-01,2022-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,2022-04-01,2023-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2023-04-01,2024-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2024-04-01,2025-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,66,Forecast,2025-04-01,2026-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2026-04-01,2027-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2027-04-01,2028-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2028-04-01,2029-03-31
-,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,2029-04-01,2030-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,2020-04-01,2021-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,2021-04-01,2022-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,2022-04-01,2023-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2023-04-01,2024-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2024-04-01,2025-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2025-04-01,2026-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2026-04-01,2027-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2027-04-01,2028-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,2028-04-01,2029-03-31
-Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,44,Forecast,2029-04-01,2030-03-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-01,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-02,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-03,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-04,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-05,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-06,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-07,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-08,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-09,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-10,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-11,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2020-01-12,2020-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-01,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-02,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-03,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-04,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-05,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-06,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-07,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-08,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-09,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-10,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-11,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2021-01-12,2021-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2023-01-01,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2023-01-02,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2023-01-03,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-04,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-05,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-06,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-07,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-08,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-09,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-10,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-11,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,2022-01-12,2022-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-01,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-02,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-03,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-04,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-05,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-06,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-07,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-08,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-09,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-10,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-11,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2023-01-12,2023-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-01,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-02,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-03,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-04,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-05,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-06,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-07,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-08,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-09,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-10,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-11,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2024-01-12,2024-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2026-01-01,2026-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2026-01-02,2026-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2026-01-03,2026-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-04,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-05,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-06,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-07,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-08,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-09,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-10,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-11,2025-01-31
-,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,2025-01-12,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-01,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-02,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-03,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-04,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-05,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-06,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-07,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-08,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-09,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-10,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-11,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2020-01-12,2020-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-01,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-02,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-03,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-04,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-05,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-06,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-07,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-08,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-09,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-10,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-11,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2021-01-12,2021-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2023-01-01,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2023-01-02,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2023-01-03,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-04,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-05,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,2022-01-06,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,2022-01-07,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,2022-01-08,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,2022-01-09,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-10,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-11,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,2022-01-12,2022-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-01,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-02,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-03,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-04,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-05,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-06,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-07,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-08,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Forecast,2023-01-09,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-10,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-11,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2023-01-12,2023-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-01,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-02,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-03,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-04,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-05,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-06,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-07,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-08,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-09,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-10,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-11,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2024-01-12,2024-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2026-01-01,2026-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2026-01-02,2026-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2026-01-03,2026-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-04,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-05,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-06,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-07,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-08,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Forecast,2025-01-09,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-10,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-11,2025-01-31
-,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,2025-01-12,2025-01-31
+,Higher Frequency,Project ID,Programme ID,Outcome,UnitofMeasurement,GeographyIndicator,Amount,Actual/Forecast,Start_Date,End_Date
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Actual,04/01/20,31/03/2021
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,04/01/20,31/03/2021
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Actual,04/01/20,31/03/2021
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,55,Actual,04/01/21,31/03/2022
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,04/01/21,31/03/2022
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Actual,04/01/21,31/03/2022
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Actual,04/01/22,31/03/2023
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Actual,04/01/22,31/03/2023
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Actual,04/01/22,31/03/2023
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/23,31/03/2024
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/23,31/03/2024
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Forecast,04/01/23,31/03/2024
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/24,31/03/2025
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,66,Forecast,04/01/24,31/03/2025
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,04/01/24,31/03/2025
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/25,31/03/2026
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/25,31/03/2026
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,04/01/25,31/03/2026
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/26,31/03/2027
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/26,31/03/2027
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,04/01/26,31/03/2027
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,44,Forecast,04/01/27,31/03/2028
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/27,31/03/2028
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,04/01/27,31/03/2028
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/28,31/03/2029
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/28,31/03/2029
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,,Forecast,04/01/28,31/03/2029
+21,Half yearly,TD-FAK-01,,Patronage of the public transport system in the area of interest (for public transport schemes),Number of passengers,Town,,Forecast,04/01/29,31/03/2030
+22,,TD-FAK-01,,Estimated carbon dioxide equivalent reductions as a result of support,Tonnes,Other / custom geography,,Forecast,04/01/29,31/03/2030
+41,Monthly or higher,TD-FAK-01,,test custom outcome,test unit,Locations provided in 'Project Admin' tab,44,Forecast,04/01/29,31/03/2030
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,04/01/20,31/03/2021
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,04/01/21,31/03/2022
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Actual,04/01/22,31/03/2023
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/23,31/03/2024
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/24,31/03/2025
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,66,Forecast,04/01/25,31/03/2026
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/26,31/03/2027
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/27,31/03/2028
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/28,31/03/2029
+23,,TD-FAK-02,,Road traffic flows in corridors of interest (for road schemes),Vehicles per day,Town,,Forecast,04/01/29,31/03/2030
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,04/01/20,31/03/2021
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,04/01/21,31/03/2022
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Actual,04/01/22,31/03/2023
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/23,31/03/2024
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/24,31/03/2025
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/25,31/03/2026
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/26,31/03/2027
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/27,31/03/2028
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,,Forecast,04/01/28,31/03/2029
+20,Half yearly,,TD-FAK,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Number of pedestrians and cyclists,Travel corridor,44,Forecast,04/01/29,31/03/2030
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/01/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/02/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/03/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/04/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/05/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/06/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/07/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/08/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/09/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/10/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/11/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/12/20,31/01/2020
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/01/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/02/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/03/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/04/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/05/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/06/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/07/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/08/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/09/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/10/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/11/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/12/21,31/01/2021
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/01/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/02/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/03/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/04/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/05/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/06/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/07/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/08/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/09/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/10/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/11/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Actual,01/12/22,31/01/2022
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/01/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/02/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/03/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/04/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/05/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/06/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/07/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/08/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/09/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/10/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/11/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/12/23,31/01/2023
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/01/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/02/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/03/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/04/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/05/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/06/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/07/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/08/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/09/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/10/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/11/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/12/24,31/01/2024
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/01/26,31/01/2026
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/02/26,31/01/2026
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/03/26,31/01/2026
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/04/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/05/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/06/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/07/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/08/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/09/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/10/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/11/25,31/01/2025
+0,,TD-FAK-01,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Output area,,Forecast,01/12/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/01/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/02/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/03/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/04/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/05/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/06/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/07/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/08/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/09/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/10/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/11/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/12/20,31/01/2020
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/01/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/02/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/03/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/04/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/05/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/06/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/07/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/08/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/09/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/10/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/11/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/12/21,31/01/2021
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/01/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/02/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/03/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/04/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/05/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,01/06/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,01/07/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,01/08/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Actual,01/09/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/10/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/11/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Actual,01/12/22,31/01/2022
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/01/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/02/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/03/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/04/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/05/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/06/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/07/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/08/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Forecast,01/09/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/10/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/11/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/12/23,31/01/2023
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/01/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/02/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/03/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/04/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/05/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/06/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/07/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/08/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/09/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/10/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/11/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/12/24,31/01/2024
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/01/26,31/01/2026
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/02/26,31/01/2026
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/03/26,31/01/2026
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/04/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/05/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/06/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/07/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/08/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,55,Forecast,01/09/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/10/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/11/25,31/01/2025
+0,,TD-FAK-03,,Year on Year monthly % change in footfall,Year-on-year % change in monthly footfall,Lower layer super output area,,Forecast,01/12/25,31/01/2025

--- a/tests/extraction_tests/resources/assertion_data/round_three/outcomes_ref_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/outcomes_ref_expected.csv
@@ -1,7 +1,7 @@
-Outcome_Name,Outcome_Category
-Patronage of the public transport system in the area of interest (for public transport schemes),Transport
-Estimated carbon dioxide equivalent reductions as a result of support,Health & Wellbeing
-test custom outcome,Custom
-Road traffic flows in corridors of interest (for road schemes),Transport
-Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Transport
-Year on Year monthly % change in footfall,Place
+,Outcome_Name,Outcome_Category
+21,Patronage of the public transport system in the area of interest (for public transport schemes),Transport
+22,Estimated carbon dioxide equivalent reductions as a result of support,Health & Wellbeing
+41,test custom outcome,Custom
+23,Road traffic flows in corridors of interest (for road schemes),Transport
+20,Automatic / manual counts of pedestrians and cyclists (for active travel schemes),Transport
+0,Year on Year monthly % change in footfall,Place

--- a/tests/extraction_tests/resources/assertion_data/round_three/outputs_data_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/outputs_data_expected.csv
@@ -1,170 +1,170 @@
-Additional Information,Project ID,Output,Unit of Measurement,Amount,Actual/Forecast,Start_Date,End_Date
-,TD-FAK-01,# of temporary FT jobs supported,Number,,,2026-04-01,
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,44,,2026-04-01,
-,TD-FAK-01,# of new public transport routes,Number of routes,,,2026-04-01,
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,,2026-04-01,
-,TD-FAK-01,test custom 1,test unit,,,2026-04-01,
-,TD-FAK-01,# of temporary FT jobs supported,Number,55,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,test custom 1,test unit,,Actual,2020-04-01,2020-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,55,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,11,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,test custom 1,test unit,44,Actual,2020-10-01,2021-03-31
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,66,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,22,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,test custom 1,test unit,,Actual,2021-04-01,2021-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,test custom 1,test unit,,Actual,2021-10-01,2022-03-31
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,test custom 1,test unit,,Actual,2022-04-01,2022-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,77,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,test custom 1,test unit,,Actual,2022-10-01,2023-03-31
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,test custom 1,test unit,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,55,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,22,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,test custom 1,test unit,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,test custom 1,test unit,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,44,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,test custom 1,test unit,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,test custom 1,test unit,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-01,test custom 1,test unit,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,,2026-04-01,
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2020-04-01,2020-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2020-10-01,2021-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2021-04-01,2021-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2021-04-01,2021-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-04-01,2021-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2021-10-01,2022-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2022-04-01,2022-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,2022-10-01,2023-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-10-01,2023-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2022-10-01,2023-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,,2026-04-01,
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,2026-04-01,
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2020-04-01,2020-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-04-01,2020-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2020-10-01,2021-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2020-10-01,2021-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2021-04-01,2021-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2021-04-01,2021-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-04-01,2021-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2021-10-01,2022-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2021-10-01,2022-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2022-04-01,2022-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2022-04-01,2022-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,2022-10-01,2023-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,2022-10-01,2023-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,2022-10-01,2023-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-04-01,2023-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2023-10-01,2024-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2024-04-01,2024-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2024-10-01,2025-03-31
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-04-01,2025-09-30
-,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
-,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,2025-10-01,2026-03-31
+,Additional Information,Project ID,Output,Unit of Measurement,Amount,Actual/Forecast,Start_Date,End_Date
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,,04/01/26,
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,04/01/26,
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,04/01/26,
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,44,,04/01/26,
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,,04/01/26,
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,,04/01/26,
+42,,TD-FAK-01,test custom 1,test unit,,,04/01/26,
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,55,Actual,04/01/20,30/09/2020
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,04/01/20,30/09/2020
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,04/01/20,30/09/2020
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,04/01/20,30/09/2020
+42,,TD-FAK-01,test custom 1,test unit,,Actual,04/01/20,30/09/2020
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,55,Actual,10/01/20,31/03/2021
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,10/01/20,31/03/2021
+27,,TD-FAK-01,# of new public transport routes,Number of routes,11,Actual,10/01/20,31/03/2021
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,10/01/20,31/03/2021
+42,,TD-FAK-01,test custom 1,test unit,44,Actual,10/01/20,31/03/2021
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,04/01/21,30/09/2021
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,66,Actual,04/01/21,30/09/2021
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/21,30/09/2021
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,04/01/21,30/09/2021
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,04/01/21,30/09/2021
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,22,Actual,04/01/21,30/09/2021
+42,,TD-FAK-01,test custom 1,test unit,,Actual,04/01/21,30/09/2021
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,10/01/21,31/03/2022
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,10/01/21,31/03/2022
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,10/01/21,31/03/2022
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,10/01/21,31/03/2022
+42,,TD-FAK-01,test custom 1,test unit,,Actual,10/01/21,31/03/2022
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,04/01/22,30/09/2022
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,04/01/22,30/09/2022
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,04/01/22,30/09/2022
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,04/01/22,30/09/2022
+42,,TD-FAK-01,test custom 1,test unit,,Actual,04/01/22,30/09/2022
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Actual,10/01/22,31/03/2023
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/22,31/03/2023
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,77,Actual,10/01/22,31/03/2023
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Actual,10/01/22,31/03/2023
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Actual,10/01/22,31/03/2023
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Actual,10/01/22,31/03/2023
+42,,TD-FAK-01,test custom 1,test unit,,Actual,10/01/22,31/03/2023
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,04/01/23,30/09/2023
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,04/01/23,30/09/2023
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,04/01/23,30/09/2023
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,04/01/23,30/09/2023
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,04/01/23,30/09/2023
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,10/01/23,31/03/2024
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,55,Forecast,10/01/23,31/03/2024
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/23,31/03/2024
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,10/01/23,31/03/2024
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,10/01/23,31/03/2024
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,22,Forecast,10/01/23,31/03/2024
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,10/01/23,31/03/2024
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,04/01/24,30/09/2024
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,04/01/24,30/09/2024
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,04/01/24,30/09/2024
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,04/01/24,30/09/2024
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,04/01/24,30/09/2024
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,10/01/24,31/03/2025
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/24,31/03/2025
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,44,Forecast,10/01/24,31/03/2025
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,10/01/24,31/03/2025
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,10/01/24,31/03/2025
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,10/01/24,31/03/2025
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,10/01/24,31/03/2025
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,04/01/25,30/09/2025
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,04/01/25,30/09/2025
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,04/01/25,30/09/2025
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,04/01/25,30/09/2025
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,04/01/25,30/09/2025
+22,,TD-FAK-01,# of temporary FT jobs supported,Number,,Forecast,10/01/25,31/03/2026
+23,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026
+24,,TD-FAK-01,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026
+26,,TD-FAK-01,Total length of improved cycle ways,Km of cycle way,,Forecast,10/01/25,31/03/2026
+27,,TD-FAK-01,# of new public transport routes,Number of routes,,Forecast,10/01/25,31/03/2026
+28,,TD-FAK-01,# of learners/trainees/students enrolled at new education and training facilities,Number of learners / participants,,Forecast,10/01/25,31/03/2026
+42,,TD-FAK-01,test custom 1,test unit,,Forecast,10/01/25,31/03/2026
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,,04/01/26,
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,04/01/26,
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,04/01/26,
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,04/01/20,30/09/2020
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,10/01/20,31/03/2021
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,04/01/21,30/09/2021
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/21,30/09/2021
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/21,30/09/2021
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,10/01/21,31/03/2022
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,04/01/22,30/09/2022
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Actual,10/01/22,31/03/2023
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/22,31/03/2023
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/22,31/03/2023
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,04/01/23,30/09/2023
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,10/01/23,31/03/2024
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/23,31/03/2024
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/23,31/03/2024
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,04/01/24,30/09/2024
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,10/01/24,31/03/2025
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/24,31/03/2025
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/24,31/03/2025
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,04/01/25,30/09/2025
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+60,,TD-FAK-02,# of temporary FT jobs supported,Number,,Forecast,10/01/25,31/03/2026
+61,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026
+62,,TD-FAK-02,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,,04/01/26,
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,,04/01/26,
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,,04/01/26,
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,04/01/20,30/09/2020
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/20,30/09/2020
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,10/01/20,31/03/2021
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/20,31/03/2021
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,04/01/21,30/09/2021
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/21,30/09/2021
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/21,30/09/2021
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,10/01/21,31/03/2022
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/21,31/03/2022
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,04/01/22,30/09/2022
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,04/01/22,30/09/2022
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Actual,10/01/22,31/03/2023
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Actual,10/01/22,31/03/2023
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Actual,10/01/22,31/03/2023
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,04/01/23,30/09/2023
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/23,30/09/2023
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,10/01/23,31/03/2024
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/23,31/03/2024
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/23,31/03/2024
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,04/01/24,30/09/2024
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/24,30/09/2024
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,10/01/24,31/03/2025
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/24,31/03/2025
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/24,31/03/2025
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,04/01/25,30/09/2025
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,04/01/25,30/09/2025
+98,,TD-FAK-03,# of temporary FT jobs supported,Number,,Forecast,10/01/25,31/03/2026
+99,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs created through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026
+100,,TD-FAK-03,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Number of FTE jobs,,Forecast,10/01/25,31/03/2026

--- a/tests/extraction_tests/resources/assertion_data/round_three/outputs_ref_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/outputs_ref_expected.csv
@@ -1,8 +1,8 @@
-Output Name,Output Category
-# of temporary FT jobs supported,Mandatory
-# of full-time equivalent (FTE) permanent jobs created through the project,Mandatory
-# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Mandatory
-Total length of improved cycle ways,Transport
-# of new public transport routes,Transport
-# of learners/trainees/students enrolled at new education and training facilities,Education
-test custom 1,Custom
+,Output Name,Output Category
+22,# of temporary FT jobs supported,Mandatory
+23,# of full-time equivalent (FTE) permanent jobs created through the project,Mandatory
+24,# of full-time equivalent (FTE) permanent jobs safeguarded through the project,Mandatory
+26,Total length of improved cycle ways,Transport
+27,# of new public transport routes,Transport
+28,# of learners/trainees/students enrolled at new education and training facilities,Education
+42,test custom 1,Custom

--- a/tests/extraction_tests/resources/assertion_data/round_three/place_details_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/place_details_expected.csv
@@ -1,17 +1,17 @@
-Question,Indicator,Answer
-Are you filling this in for a Town Deal or Future High Street Fund?,Select from the drop down list provided,Town_Deal
-Please select your place name,Select from the drop down list provided,Fake Town
-"Grant Recipient:
+,Question,Indicator,Answer
+5,Are you filling this in for a Town Deal or Future High Street Fund?,Select from the drop down list provided,Town_Deal
+6,Please select your place name,Select from the drop down list provided,Fake Town
+7,"Grant Recipient:
 (your organisation's name)",Organisation Name,Test Org
-Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Name,Test name 1
-Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Email,test1@test.org
-Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Telephone,07777777777
-Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Name,Test name 2
-Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Email,test2@test.org
-Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Telephone,06666666666
-S151 Officer / Chief Finance Officer:,Name,Test name 3
-S151 Officer / Chief Finance Officer:,Email,test3@test.org
-S151 Officer / Chief Finance Officer:,Telephone,07676767676
-Monitoring & Evaluation Contact:,Name,Test name 1
-Monitoring & Evaluation Contact:,Email,test1@test.org
-Monitoring & Evaluation Contact:,Telephone,07777777777
+8,Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Name,Test name 1
+9,Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Email,test1@test.org
+10,Grant Recipient's Nominated Single Point of Contact (project manager where relevant):,Telephone,07777777777
+11,Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Name,Test name 2
+12,Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Email,test2@test.org
+13,Programme Senior Responsible Owner (SRO) [This may be for example the Local Authority Chief Executive or the TD Board Chair]:,Telephone,06666666666
+14,S151 Officer / Chief Finance Officer:,Name,Test name 3
+15,S151 Officer / Chief Finance Officer:,Email,test3@test.org
+16,S151 Officer / Chief Finance Officer:,Telephone,07676767676
+17,Monitoring & Evaluation Contact:,Name,Test name 1
+18,Monitoring & Evaluation Contact:,Email,test1@test.org
+19,Monitoring & Evaluation Contact:,Telephone,07777777777

--- a/tests/extraction_tests/resources/assertion_data/round_three/programme_progress_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/programme_progress_expected.csv
@@ -1,8 +1,8 @@
-Question,Answer,Programme ID
-How is your programme progressing,some comment on profile / forecast,TD-FAK
-Please provide a progress update,Test comment progress update,TD-FAK
-What are the key challenges you,"Test comment, challenges",TD-FAK
-What challenges do you expect to,"Test comment, expected challenges",TD-FAK
-Please provide an update on your,"Test comment, evaluation activities",TD-FAK
-Please provide any key milestones,"Test comment, key milestones",TD-FAK
-If any support is required from the,"Test comment, support",TD-FAK
+,Question,Answer,Programme ID
+5,How is your programme progressing,some comment on profile / forecast,TD-FAK
+6,Please provide a progress update,Test comment progress update,TD-FAK
+7,What are the key challenges you,"Test comment, challenges",TD-FAK
+8,What challenges do you expect to,"Test comment, expected challenges",TD-FAK
+9,Please provide an update on your,"Test comment, evaluation activities",TD-FAK
+10,Please provide any key milestones,"Test comment, key milestones",TD-FAK
+11,If any support is required from the,"Test comment, support",TD-FAK

--- a/tests/extraction_tests/resources/assertion_data/round_three/project_details_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/project_details_expected.csv
@@ -1,10 +1,10 @@
-Project Name,Primary Intervention Theme,Single or Multiple Locations,GIS Provided,Locations,Postcodes,Lat/Long,Project ID,Programme ID
-Test Project 1,Transport,Multiple,No,"1. postcode1
+,Project Name,Primary Intervention Theme,Single or Multiple Locations,GIS Provided,Locations,Postcodes,Lat/Long,Project ID,Programme ID
+25,Test Project 1,Transport,Multiple,No,"1. postcode1
 AB1 1BA (bloat text);
 2. test pc 2
 AB2 2BA;
 AA2 2DD (test bloat);
 ","AB1 1BA,AB2 2BA,AA2 2DD",,TD-FAK-01,TD-FAK
-Test Project 2,Regeneration ,Multiple,No,Various AA2 Postcodes to be confirmed in future for the Business Grants Programme dependent on business success in securing grants,,"60.066, 0.055 (Some text);
+26,Test Project 2,Regeneration ,Multiple,No,Various AA2 Postcodes to be confirmed in future for the Business Grants Programme dependent on business success in securing grants,,"60.066, 0.055 (Some text);
 Various locations to be confirmed in future",TD-FAK-02,TD-FAK
-Test Project 3,Regeneration ,Single,,AA1 1AB,AA1 1AB,"66.666, 0.05",TD-FAK-03,TD-FAK
+27,Test Project 3,Regeneration ,Single,,AA1 1AB,AA1 1AB,"66.666, 0.05",TD-FAK-03,TD-FAK

--- a/tests/extraction_tests/resources/assertion_data/round_three/project_progress_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/project_progress_expected.csv
@@ -1,4 +1,4 @@
-Start Date,Completion Date,Project Adjustment Request Status,Project Delivery Status,Delivery (RAG),Spend (RAG),Risk (RAG),Commentary on Status and RAG Ratings,Most Important Upcoming Comms Milestone,Date of Most Important Upcoming Comms Milestone (e.g. Dec-22),Project ID
-44562,46082,PAR not required,2. Ongoing - on track,3,2,,test comment 1,milestone 1,45078,TD-FAK-01
-44562,46082,PAR submitted - approved,3. Ongoing - delayed,2,2,3,test comment 2,milestone 2,45139,TD-FAK-02
-44593,46082,PAR submitted - awaiting approval,1. Not yet started,2,2,3,test comment 3,milestone 3,45261,TD-FAK-03
+,Start Date,Completion Date,Project Adjustment Request Status,Project Delivery Status,Delivery (RAG),Spend (RAG),Risk (RAG),Commentary on Status and RAG Ratings,Most Important Upcoming Comms Milestone,Date of Most Important Upcoming Comms Milestone (e.g. Dec-22),Project ID
+18,44562,46082,PAR not required,2. Ongoing - on track,3,2,,test comment 1,milestone 1,45078,TD-FAK-01
+19,44562,46082,PAR submitted - approved,3. Ongoing - delayed,2,2,3,test comment 2,milestone 2,45139,TD-FAK-02
+20,44593,46082,PAR submitted - awaiting approval,1. Not yet started,2,2,3,test comment 3,milestone 3,45261,TD-FAK-03

--- a/tests/extraction_tests/resources/assertion_data/round_three/psi_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/psi_expected.csv
@@ -1,4 +1,4 @@
-Project ID,Total Project Value,Townsfund Funding,Private Sector Funding Required,Private Sector Funding Secured,Additional Comments
-TD-FAK-01,6666,77777,,,
-TD-FAK-02,4444,55555,,,
-TD-FAK-03,0,0,11111,2222,test comment
+,Project ID,Total Project Value,Townsfund Funding,Private Sector Funding Required,Private Sector Funding Secured,Additional Comments
+11,TD-FAK-01,6666,77777,,,
+12,TD-FAK-02,4444,55555,,,
+13,TD-FAK-03,0,0,11111,2222,test comment

--- a/tests/extraction_tests/resources/assertion_data/round_three/risks_expected.csv
+++ b/tests/extraction_tests/resources/assertion_data/round_three/risks_expected.csv
@@ -1,8 +1,8 @@
-Programme ID,Project ID,RiskName,RiskCategory,Short Description,Full Description,Consequences,Pre-mitigatedImpact,Pre-mitigatedLikelihood,Mitigatons,PostMitigatedImpact,PostMitigatedLikelihood,Proximity,RiskOwnerRole
-TD-FAK,,test programme risk 1,Client Mistreatment,test comment 1,full desc test text 1,consequence test 1,3 - Medium impact,2 - Medium,test mitigation comment 1,1- Marginal impact,3 - High,2 - Distant: next 12 months,test 1
-TD-FAK,,test programme risk 2,Business Continuity & Disaster Recovery,test comment 2,full desc test text 2,consequence test 2,4 - Significant impact ,1 - Low,test mitigation comment 2,2 - Low impact,1 - Low,1 - Remote,
-TD-FAK,,test programme risk 3,Environment,test comment 3,full desc test text 3,consequence test 3,1- Marginal impact,4 - Almost Certain,test mitigation comment 3,3 - Medium impact,1 - Low,2 - Distant: next 12 months,test 3
-,TD-FAK-01,project risk test 1,Credit Losses,test desc,,,3 - Medium impact,4 - Almost Certain,test mit,1- Marginal impact,2 - Medium,3 - Approaching: next 6 months,test own
-,TD-FAK-01,project risk test 2,Business Continuity & Disaster Recovery,,dest desc,test cons,4 - Significant impact ,2 - Medium,,1- Marginal impact,1 - Low,1 - Remote,test own
-,TD-FAK-01,project risk test 3,Covid Disruption,,,test cons,6 - Critical impact,1 - Low,,2 - Low impact,2 - Medium,2 - Distant: next 12 months,
-,TD-FAK-02,project risk tess a,Client Mistreatment,test desc,test desc,test desc,2 - Low impact,,test desc,1- Marginal impact,,3 - Approaching: next 6 months,test desc
+,Programme ID,Project ID,RiskName,RiskCategory,Short Description,Full Description,Consequences,Pre-mitigatedImpact,Pre-mitigatedLikelihood,Mitigatons,PostMitigatedImpact,PostMitigatedLikelihood,Proximity,RiskOwnerRole
+10,TD-FAK,,test programme risk 1,Client Mistreatment,test comment 1,full desc test text 1,consequence test 1,3 - Medium impact,2 - Medium,test mitigation comment 1,1- Marginal impact,3 - High,2 - Distant: next 12 months,test 1
+11,TD-FAK,,test programme risk 2,Business Continuity & Disaster Recovery,test comment 2,full desc test text 2,consequence test 2,4 - Significant impact ,1 - Low,test mitigation comment 2,2 - Low impact,1 - Low,1 - Remote,
+12,TD-FAK,,test programme risk 3,Environment,test comment 3,full desc test text 3,consequence test 3,1- Marginal impact,4 - Almost Certain,test mitigation comment 3,3 - Medium impact,1 - Low,2 - Distant: next 12 months,test 3
+21,,TD-FAK-01,project risk test 1,Credit Losses,test desc,,,3 - Medium impact,4 - Almost Certain,test mit,1- Marginal impact,2 - Medium,3 - Approaching: next 6 months,test own
+22,,TD-FAK-01,project risk test 2,Business Continuity & Disaster Recovery,,dest desc,test cons,4 - Significant impact ,2 - Medium,,1- Marginal impact,1 - Low,1 - Remote,test own
+23,,TD-FAK-01,project risk test 3,Covid Disruption,,,test cons,6 - Critical impact,1 - Low,,2 - Low impact,2 - Medium,2 - Distant: next 12 months,
+29,,TD-FAK-02,project risk tess a,Client Mistreatment,test desc,test desc,test desc,2 - Low impact,,test desc,1- Marginal impact,,3 - Approaching: next 6 months,test desc

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -75,7 +75,7 @@ def test_place_extract(mock_place_extract):
     """Test extract_place_details simple extraction."""
 
     extracted_place_df = mock_place_extract
-    expected_place_df = pd.read_csv(resources_assertions / "place_details_expected.csv")
+    expected_place_df = pd.read_csv(resources_assertions / "place_details_expected.csv", index_col=0)
     assert_frame_equal(extracted_place_df, expected_place_df)
 
 
@@ -95,7 +95,7 @@ def test_project_lookup(mock_place_extract):
     }
 
     # test with Future high street (extend fixture data)
-    mock_place_extract.Answer[0] = "Future_High_Street_Fund"
+    mock_place_extract.Answer.iloc[0] = "Future_High_Street_Fund"
     test_vals_future_high_street = tf.extract_project_lookup(test_project_identifiers, mock_place_extract)
     assert test_vals_future_high_street == {
         "Test Project 1": "HS-FAK-01",
@@ -124,14 +124,14 @@ def test_extract_projects(mock_project_lookup, mock_programme_lookup):
     """Test projects extracted as expected."""
     mock_project_admin_tab = pd.read_csv(resources_mocks / "project_admin_sheet_mock.csv")
     test_extracted_projects_df = tf.extract_project(mock_project_admin_tab, mock_project_lookup, mock_programme_lookup)
-    expected_project_details_df = pd.read_csv(resources_assertions / "project_details_expected.csv")
+    expected_project_details_df = pd.read_csv(resources_assertions / "project_details_expected.csv", index_col=0)
     assert_frame_equal(test_extracted_projects_df, expected_project_details_df)
 
 
 def test_extract_programme_progress(mock_progress_sheet, mock_programme_lookup):
     """Test programme progress rows extracted as expected."""
     extracted_programme_progress = tf.extract_programme_progress(mock_progress_sheet, mock_programme_lookup)
-    expected_programme_progress = pd.read_csv(resources_assertions / "programme_progress_expected.csv")
+    expected_programme_progress = pd.read_csv(resources_assertions / "programme_progress_expected.csv", index_col=0)
     assert_frame_equal(extracted_programme_progress, expected_programme_progress)
 
 
@@ -139,7 +139,9 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
     """Test project progress rows extracted as expected."""
 
     extracted_project_progress = tf.extract_project_progress(mock_progress_sheet, mock_project_lookup)
-    expected_project_progress = pd.read_csv(resources_assertions / "project_progress_expected.csv", dtype=str)
+    expected_project_progress = pd.read_csv(
+        resources_assertions / "project_progress_expected.csv", index_col=0, dtype=str
+    )
 
     # set expected RAG columns to Int64 type in line with transformation logic
     expected_project_progress[["Delivery (RAG)", "Spend (RAG)", "Risk (RAG)"]] = expected_project_progress[
@@ -152,7 +154,9 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
 def test_extract_funding_questions(mock_funding_sheet, mock_programme_lookup):
     """Test programme level funding questions extracted as expected."""
     extracted_funding_questions = tf.extract_funding_questions(mock_funding_sheet, mock_programme_lookup)
-    expected_funding_questions = pd.read_csv(resources_assertions / "funding_questions_expected.csv")
+    expected_funding_questions = pd.read_csv(
+        resources_assertions / "funding_questions_expected.csv", index_col="original_index"
+    )
     assert_frame_equal(extracted_funding_questions, expected_funding_questions)
 
 
@@ -173,14 +177,18 @@ def test_extract_funding_questions_fhsf(mock_funding_sheet, mock_programme_looku
 def test_extract_funding_comments(mock_funding_sheet, mock_project_lookup):
     """Test project level funding comments extracted as expected."""
     extracted_funding_comments = tf.extract_funding_comments(mock_funding_sheet, mock_project_lookup)
-    expected_funding_comments = pd.read_csv(resources_assertions / "funding_comments_expected.csv")
+    expected_funding_comments = pd.read_csv(
+        resources_assertions / "funding_comments_expected.csv", index_col="original_index"
+    )
     assert_frame_equal(extracted_funding_comments, expected_funding_comments)
 
 
 def test_extract_funding_data(mock_funding_sheet, mock_project_lookup):
     """Test project level funding data extracted as expected."""
     extracted_funding_data = tf.extract_funding_data(mock_funding_sheet, mock_project_lookup)
-    expected_funding_data = pd.read_csv(resources_assertions / "funding_data_expected.csv", dtype=str)
+    expected_funding_data = pd.read_csv(
+        resources_assertions / "funding_data_expected.csv", index_col="original_index", dtype=str
+    )
     # convert to datetime - datetime object serialization slightly different in csv parsing vs Excel.
     expected_funding_data["Start_Date"] = pd.to_datetime(expected_funding_data["Start_Date"], format="%d/%m/%Y")
     expected_funding_data["End_Date"] = pd.to_datetime(expected_funding_data["End_Date"], format="%d/%m/%Y")
@@ -255,7 +263,7 @@ def test_no_extra_projects_in_funding(mock_funding_sheet, mock_project_lookup):
 def test_extract_psi(mock_psi_sheet, mock_project_lookup):
     """Test PSI data extracted as expected."""
     extracted_psi = tf.extract_psi(mock_psi_sheet, mock_project_lookup)
-    expected_psi = pd.read_csv(resources_assertions / "psi_expected.csv", dtype=str)
+    expected_psi = pd.read_csv(resources_assertions / "psi_expected.csv", index_col=0, dtype=str)
 
     assert_frame_equal(extracted_psi, expected_psi)
 
@@ -263,7 +271,7 @@ def test_extract_psi(mock_psi_sheet, mock_project_lookup):
 def test_extract_outputs(mock_outputs_sheet, mock_project_lookup):
     """Test Outputs data and outputs ref extracted as expected."""
     extracted_output_data = tf.extract_outputs(mock_outputs_sheet, mock_project_lookup)
-    expected_output_data = pd.read_csv(resources_assertions / "outputs_data_expected.csv", dtype=str)
+    expected_output_data = pd.read_csv(resources_assertions / "outputs_data_expected.csv", index_col=0, dtype=str)
 
     # convert to datetime - datetime object serialization slightly different in csv parsing vs Excel.
     expected_output_data["Start_Date"] = pd.to_datetime(expected_output_data["Start_Date"])
@@ -273,7 +281,7 @@ def test_extract_outputs(mock_outputs_sheet, mock_project_lookup):
 
     # test ref table / categories extracted as expected
     extracted_output_ref = tf.extract_output_categories(extracted_output_data)
-    expected_output_ref = pd.read_csv(resources_assertions / "outputs_ref_expected.csv")
+    expected_output_ref = pd.read_csv(resources_assertions / "outputs_ref_expected.csv", index_col=0)
 
     assert_frame_equal(extracted_output_ref, expected_output_ref)
 
@@ -286,7 +294,7 @@ def test_extract_outputs(mock_outputs_sheet, mock_project_lookup):
 def test_extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup):
     """Test Outcome data and outcome ref extracted as expected."""
     extracted_outcome_data = tf.combine_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
-    expected_outcome_data = pd.read_csv(resources_assertions / "outcomes_data_expected.csv", dtype=str)
+    expected_outcome_data = pd.read_csv(resources_assertions / "outcomes_data_expected.csv", index_col=0, dtype=str)
 
     # convert to datetime - datetime object serialization slightly different in csv parsing vs Excel.
     expected_outcome_data["Start_Date"] = pd.to_datetime(expected_outcome_data["Start_Date"])
@@ -296,7 +304,7 @@ def test_extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_program
 
     # test ref table / categories extracted as expected
     extracted_outcome_ref = tf.extract_outcome_categories(extracted_outcome_data)
-    expected_outcome_ref = pd.read_csv(resources_assertions / "outcomes_ref_expected.csv")
+    expected_outcome_ref = pd.read_csv(resources_assertions / "outcomes_ref_expected.csv", index_col=0)
 
     assert_frame_equal(extracted_outcome_ref, expected_outcome_ref)
 
@@ -338,7 +346,7 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
 def test_extract_risk(mock_risk_sheet, mock_project_lookup, mock_programme_lookup):
     """Test risk data extracted as expected."""
     extracted_risk_data = tf.extract_risks(mock_risk_sheet, mock_project_lookup, mock_programme_lookup)
-    expected_risk_data = pd.read_csv(resources_assertions / "risks_expected.csv")
+    expected_risk_data = pd.read_csv(resources_assertions / "risks_expected.csv", index_col=0)
     assert_frame_equal(extracted_risk_data, expected_risk_data)
 
     # check rows with no risk name entered are dropped/not extracted
@@ -371,7 +379,7 @@ def test_full_ingest(mock_ingest_full_extract):
     assert not set(mock_ingest_full_extract["RiskRegister"]["Project ID"]) - valid_projects_for_extract
 
     # test only valid programmes for this extract are in programme-level tables
-    valid_programmes_for_extract = {mock_ingest_full_extract["Place Details"]["Programme ID"][0]}
+    valid_programmes_for_extract = {mock_ingest_full_extract["Place Details"]["Programme ID"].iloc[0]}
     assert not set(mock_ingest_full_extract["Programme_Ref"]["Programme ID"]) - valid_programmes_for_extract
     assert not set(mock_ingest_full_extract["Project Details"]["Programme ID"]) - valid_programmes_for_extract
     assert not set(mock_ingest_full_extract["Programme Progress"]["Programme ID"]) - valid_programmes_for_extract


### PR DESCRIPTION
Retains the original indexes of the DataFrames in df_ingest. Upon ingest, the indexes are decremented by two, and so when we relay the original_index information to validation messages it will have to be incremented by two. 

Points of note:
- Footfall outcomes are more difficult to retrieve specific row numbers for as their values span multiple rows in the original spreadsheet. They are therefore not accounted for in this PR.
- The original index is not retained for Project Details, but is instead added on after the transformation occurs. We know that Project 1 will always begin at line 27 of the spreadsheet, and that each project is incremented by 1, and can set the index accordingly. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")