### PR TITLE
BAU: match expected S3 bucket names

### DIFF
--- a/copilot/data-store/addons/data-store-failed-files.yml
+++ b/copilot/data-store/addons/data-store-failed-files.yml
@@ -79,6 +79,9 @@ Outputs:
   datastorefailedfilesName:
     Description: "The name of a user-defined bucket."
     Value: !Ref datastorefailedfilesBucket
+  AwsS3BucketFailedFiles:
+    Description: "The name of a user-defined bucket."
+    Value: !Ref datastorefailedfilesBucket
   datastorefailedfilesAccessPolicy:
     Description: "The IAM::ManagedPolicy to attach to the task role"
     Value: !Ref datastorefailedfilesAccessPolicy

--- a/copilot/data-store/addons/data-store-file-assets.yml
+++ b/copilot/data-store/addons/data-store-file-assets.yml
@@ -79,6 +79,9 @@ Outputs:
   datastorefileassetsName:
     Description: "The name of a user-defined bucket."
     Value: !Ref datastorefileassetsBucket
+  AwsS3BucketAssets:
+    Description: "The name of a user-defined bucket."
+    Value: !Ref datastorefileassetsBucket
   datastorefileassetsAccessPolicy:
     Description: "The IAM::ManagedPolicy to attach to the task role"
     Value: !Ref datastorefileassetsAccessPolicy


### PR DESCRIPTION
### Change description
Previously the S3 integration would have failed on AWS as the env vars did not match those the app expected e.g. in: https://github.com/communitiesuk/funding-service-design-post-award-data-store/blob/ef0bc0ce26d4144937dcee0648b81f3ea32506f6/config/envs/default.py#L20

This makes copilot set the expected env vars. Note these are converted to screaming snake case env vars by Copilot

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have tested by deploying branch


### Screenshots of UI changes (if applicable)
