### PR TITLE
Feature/smd 87 funding spent vs funding allocated validation

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -7,3 +7,4 @@ AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
 AWS_ENDPOINT_OVERRIDE=http://127.0.0.1:4566/
 AWS_S3_BUCKET_FAILED_FILES=data-store-failed-files-dev
+AWS_S3_BUCKET_FILE_ASSETS=data-store-file-assets-dev

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -18,3 +18,4 @@ class DefaultConfig(object):
 
     AWS_REGION = os.getenv("AWS_REGION")
     AWS_S3_BUCKET_FAILED_FILES = os.getenv("AWS_S3_BUCKET_FAILED_FILES")
+    AWS_S3_BUCKET_FILE_ASSETS = os.getenv("AWS_S3_BUCKET_FILE_ASSETS")

--- a/core/const.py
+++ b/core/const.py
@@ -7,6 +7,8 @@ SUBMISSION_ID_FORMAT = "S-R{0:0=2d}-{1}"
 FAILED_FILE_S3_NAME_FORMAT = "{}_{}.xlsx"
 TF_ROUND_4_TEMPLATE_VERSION = "v4.3"
 
+TF_FUNDING_ALLOCATED_FILE = "TF-grant-awarded.csv"
+
 
 class ProjectAdjustmentRequestStatus(StrEnum):
     NOT_REQUIRED = "PAR not required"
@@ -849,6 +851,7 @@ TABLE_AND_COLUMN_TO_ORIGINAL_COLUMN_LETTER = {
         "Private Sector Funding Required": "G{i}",
         "Private Sector Funding Secured": "H{i}",
         "Additional Comments": "J{i}",
+        "Grand Total": "Z{i}",
     },
     "Output_Data": {
         "Output": "C{i}",

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -47,7 +47,7 @@ def test_list_buckets():
 
 @pytest.mark.skipif(S3_NOT_ACCESSIBLE, reason="Cannot access S3.")
 def test_extract_file_from_bucket():
-    obj = _S3_CLIENT.get_object(Bucket="data-store-file-assets-dev", Key="example-template.xlsx")
+    obj = _S3_CLIENT.get_object(Bucket="data-store-file-assets-dev", Key="TF-grant-awarded.csv")
     data = obj["Body"].read()
 
     df = pd.read_excel(io.BytesIO(data))


### PR DESCRIPTION
PR to add a r4 specific validation of funding spent vs funding allocated pulled from a seperate csv stored on s3

Still need to properly implement unit tests by mocking the s3 connection. so only a draft PR for now.

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
