### PR TITLE
BAU: refactor validate types & retain index in WrongTypeFailure

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -791,7 +791,13 @@ GET_FORM_VERSION_AND_REPORTING_PERIOD = {
     ),
 }
 
-INTERNAL_TYPE_TO_MESSAGE_FORMAT = {"datetime64[ns]": "a date", "float64": "a number", "object": "text"}
+INTERNAL_TYPE_TO_MESSAGE_FORMAT = {
+    "datetime64[ns]": "a date",
+    "float64": "a number",
+    "string": "text",
+    "int64": "a number",
+    "object": "an unknown datatype",
+}
 
 PRE_DEFINED_FUNDING_SOURCES = [
     "Commercial Income",

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -197,6 +197,7 @@ class WrongTypeFailure(ValidationFailure):
     column: str
     expected_type: str
     actual_type: str
+    index: list[int]
 
     def __str__(self):
         """Method to get the string representation of the wrong type failure."""

--- a/core/validation/schema.py
+++ b/core/validation/schema.py
@@ -79,4 +79,5 @@ _PY_TO_NUMPY_TYPES = {
     "int": "int64",
     "float": "float64",
     "datetime": "datetime64[ns]",
+    "Timestamp": "datetime64[ns]",
 }

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -3,6 +3,8 @@
 Provides functionality for validating a workbook against a schema. Any schema offense
 cause the validation to fail. Details of these failures are captured and returned.
 """
+import numbers
+
 import pandas as pd
 from numpy.typing import NDArray
 
@@ -140,9 +142,8 @@ def validate_types(
                 continue
             got_type = _PY_TO_NUMPY_TYPES.get(type(got_value).__name__, "object")
 
-            # TODO: refactor such that we no longer use string representations of datatypes and can compare with
-            #  number.Number
-            if got_type in ["int64", "float64"] and exp_type in ["int64", "float64"]:
+            # TODO: refactor such that we no longer use string representations of datatypes
+            if isinstance(got_value, numbers.Number) and exp_type in ["int64", "float64"]:
                 continue
 
             if got_type != exp_type:
@@ -152,6 +153,7 @@ def validate_types(
                         column=column,
                         expected_type=exp_type,
                         actual_type=got_type,
+                        index=[index],
                     )
                 )
 

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -7,6 +7,7 @@ import pandas as pd
 from numpy.typing import NDArray
 
 import core.validation.failures as vf
+from core.validation.schema import _PY_TO_NUMPY_TYPES
 
 
 def validate_workbook(workbook: dict[str, pd.DataFrame], schema: dict) -> list[vf.ValidationFailure]:
@@ -131,12 +132,18 @@ def validate_types(
                            expected data types.
     :return: A list of wrong type failures, if any.
     """
-    sheet_types = workbook[sheet_name].dtypes
-
     wrong_type_failures = []
-    for column, exp_type in column_to_type.items():
-        if column in sheet_types.keys():
-            got_type = sheet_types[column]
+    for index, row in workbook[sheet_name].iterrows():
+        for column, exp_type in column_to_type.items():
+            got_value = row.get(column)
+            if got_value is None or pd.isna(got_value):
+                continue
+            got_type = _PY_TO_NUMPY_TYPES.get(type(got_value).__name__, "object")
+
+            # TODO: refactor such that we no longer use string representations of datatypes and can compare with
+            #  number.Number
+            if got_type in ["int64", "float64"] and exp_type in ["int64", "float64"]:
+                continue
 
             if got_type != exp_type:
                 wrong_type_failures.append(
@@ -144,7 +151,7 @@ def validate_types(
                         sheet=sheet_name,
                         column=column,
                         expected_type=exp_type,
-                        actual_type=str(got_type),
+                        actual_type=got_type,
                     )
                 )
 

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -32,7 +32,7 @@ def test_test_failures_to_messages():
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
-        actual_type="object",
+        actual_type="string",
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
@@ -579,36 +579,36 @@ def test_pretransformation_messages():
 
 def test_wrong_type_messages():
     failure1 = WrongTypeFailure(
-        sheet="Project Progress", column="Start Date", expected_type="datetime64[ns]", actual_type="object"
+        sheet="Project Progress", column="Start Date", expected_type="datetime64[ns]", actual_type="string"
     )
     failure2 = WrongTypeFailure(
-        sheet="Project Progress", column="Completion Date", expected_type="datetime64[ns]", actual_type="object"
+        sheet="Project Progress", column="Completion Date", expected_type="datetime64[ns]", actual_type="string"
     )
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
-        actual_type="object",
+        actual_type="string",
     )
     failure4 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Required",
         expected_type="float64",
-        actual_type="object",
+        actual_type="string",
     )
     failure5 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Secured",
         expected_type="float64",
-        actual_type="object",
+        actual_type="string",
     )
     failure6 = WrongTypeFailure(
-        sheet="Funding", column="Spend for Reporting Period", expected_type="float64", actual_type="object"
+        sheet="Funding", column="Spend for Reporting Period", expected_type="float64", actual_type="string"
     )
-    failure7 = WrongTypeFailure(sheet="Output_Data", column="Amount", expected_type="float64", actual_type="object")
-    failure8 = WrongTypeFailure(sheet="Outcome_Data", column="Amount", expected_type="float64", actual_type="object")
+    failure7 = WrongTypeFailure(sheet="Output_Data", column="Amount", expected_type="float64", actual_type="string")
+    failure8 = WrongTypeFailure(sheet="Outcome_Data", column="Amount", expected_type="float64", actual_type="string")
     failure9 = WrongTypeFailure(
-        sheet="Project Details", column="Spend for Reporting Period", expected_type="float64", actual_type="object"
+        sheet="Project Details", column="Spend for Reporting Period", expected_type="float64", actual_type="string"
     )
 
     assert failure1.to_message() == (

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -33,6 +33,7 @@ def test_test_failures_to_messages():
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
+        index=[22],
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
@@ -579,36 +580,74 @@ def test_pretransformation_messages():
 
 def test_wrong_type_messages():
     failure1 = WrongTypeFailure(
-        sheet="Project Progress", column="Start Date", expected_type="datetime64[ns]", actual_type="string"
+        sheet="Project Progress",
+        column="Start Date",
+        expected_type="datetime64[ns]",
+        actual_type="string",
+        index=[22],
     )
     failure2 = WrongTypeFailure(
-        sheet="Project Progress", column="Completion Date", expected_type="datetime64[ns]", actual_type="string"
+        sheet="Project Progress",
+        column="Completion Date",
+        expected_type="datetime64[ns]",
+        actual_type="string",
+        index=[22],
     )
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
+        index=[22],
     )
     failure4 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Required",
         expected_type="float64",
         actual_type="string",
+        index=[22],
     )
     failure5 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Secured",
         expected_type="float64",
         actual_type="string",
+        index=[22],
     )
     failure6 = WrongTypeFailure(
-        sheet="Funding", column="Spend for Reporting Period", expected_type="float64", actual_type="string"
+        sheet="Funding",
+        column="Spend for Reporting Period",
+        expected_type="float64",
+        actual_type="string",
+        index=[22],
     )
-    failure7 = WrongTypeFailure(sheet="Output_Data", column="Amount", expected_type="float64", actual_type="string")
-    failure8 = WrongTypeFailure(sheet="Outcome_Data", column="Amount", expected_type="float64", actual_type="string")
+    failure7 = WrongTypeFailure(
+        sheet="Output_Data",
+        column="Amount",
+        expected_type="float64",
+        actual_type="string",
+        index=[22],
+    )
+    failure8 = WrongTypeFailure(
+        sheet="Outcome_Data",
+        column="Amount",
+        expected_type="float64",
+        actual_type="string",
+        index=[22],
+    )
     failure9 = WrongTypeFailure(
-        sheet="Project Details", column="Spend for Reporting Period", expected_type="float64", actual_type="string"
+        sheet="Project Details",
+        column="Spend for Reporting Period",
+        expected_type="float64",
+        actual_type="string",
+        index=[22],
+    )
+    failure10 = WrongTypeFailure(
+        sheet="Outcome_Data",
+        column="Amount",
+        expected_type="float64",
+        actual_type="object",
+        index=[22],
     )
 
     assert failure1.to_message() == (
@@ -665,6 +704,14 @@ def test_wrong_type_messages():
 
     with pytest.raises(UnimplementedErrorMessageException):
         failure9.to_message()
+
+    assert failure10.to_message() == (
+        "Outcomes",
+        "Outcome Indicators (excluding footfall) and Footfall Indicator",
+        'Between columns "Financial Year 2022/21 - Financial Year 2029/30" you entered an unknown datatype when we '
+        "expected a number. You must enter data using the correct format, for example, 9 rather than 9m2. "
+        "Only use numbers",
+    )
 
 
 def test_non_unique_composite_key_messages():

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -68,6 +68,10 @@ def valid_workbook_and_schema():
         ),
     }
 
+    # Increment indexes by 5 to ensure they do not reset to being 0-indexed
+    for sheet_name, df in workbook.items():
+        workbook[sheet_name] = df.set_index(df.index + 5)
+
     schema = {
         "Project Sheet": {
             "columns": {
@@ -186,6 +190,7 @@ def test_validate_types_invalid_exp_str_got_int(valid_workbook_and_schema):
             column="Project_ID",
             expected_type="string",
             actual_type="int64",
+            index=[6],
         )
     ]
 
@@ -207,6 +212,7 @@ def test_validate_types_invalid_exp_bool_got_str(valid_workbook_and_schema):
             column="Project Started",
             expected_type="bool",
             actual_type="string",
+            index=[5],
         )
     ]
 
@@ -228,6 +234,7 @@ def test_validate_types_invalid_exp_datetime_got_str(valid_workbook_and_schema):
             column="Date Started",
             expected_type="datetime64[ns]",
             actual_type="string",
+            index=[7],
         )
     ]
 
@@ -249,6 +256,7 @@ def test_validate_types_invalid_float_type(valid_workbook_and_schema):
             column="Funding Cost",
             expected_type="float64",
             actual_type="string",
+            index=[5],
         )
     ]
 


### PR DESCRIPTION
validate_types() requires a refactor as it was working at the column-level and therefore incapable of bringing through row indexes. The function now works row by row within a given column, and can therefore return more responsive error messages.

This also includes retaining the index in validate_types() such that it can be passed onto WrongTypeFailure.

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
