### PR TITLE
[SMD-236]: put indexes in validation messages for non-R4 specific errors

### DIFF
--- a/core/extraction/towns_fund_round_four.py
+++ b/core/extraction/towns_fund_round_four.py
@@ -66,6 +66,10 @@ def ingest_round_four_data_towns_fund(df_ingest: dict[str, pd.DataFrame]) -> dic
         df_ingest["7 - Risk Register"], project_lookup, programme_id, round_four=True
     )
 
+    # incremented by 2 in order to match original Excel index
+    for sheet_name, df in towns_fund_extracted.items():
+        towns_fund_extracted[sheet_name] = df.set_index(df.index + 2)
+
     return towns_fund_extracted
 
 

--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -862,9 +862,11 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
         raise ValidationError(
             [
                 vf.InvalidOutcomeProjectFailure(
-                    invalid_project=project, section="Outcome Indicators (excluding footfall)"
+                    invalid_project=row["Relevant project(s)"],
+                    section="Outcome Indicators (excluding footfall)",
+                    row_indexes=[idx],
                 )
-                for project in invalid_projects
+                for idx, row in outcomes_df.loc[outcomes_df["Relevant project(s)"].isin(invalid_projects)].iterrows()
             ]
         )
     # Drop rows with Section header selected as the outcome from dropdown on form - This is not a valid outcome option.
@@ -959,7 +961,8 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
     if invalid_projects := relevant_projects - set(project_lookup.keys()):
         raise ValidationError(
             [
-                vf.InvalidOutcomeProjectFailure(invalid_project=project, section="Footfall Indicator")
+                vf.InvalidOutcomeProjectFailure(invalid_project=project, section="Footfall Indicator", row_indexes=None)
+                # TODO: add index for footfalls
                 for project in invalid_projects
             ]
         )

--- a/core/util.py
+++ b/core/util.py
@@ -78,5 +78,5 @@ def construct_index(section: str, column: str, rows: list[int]) -> str:
     """
 
     column_letter = TABLE_AND_COLUMN_TO_ORIGINAL_COLUMN_LETTER[section][column]
-    indexes = ", ".join([column_letter.format(i=row + 2) for row in rows])
+    indexes = ", ".join([column_letter.format(i=row) for row in rows])
     return indexes

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -135,6 +135,7 @@ class NonUniqueCompositeKeyFailure(ValidationFailure):
     sheet: str
     cols: tuple
     row: list
+    row_indexes: list[int]
 
     def __str__(self):
         """Method to get the string representation of the non-unique-composite_key failure."""
@@ -197,7 +198,7 @@ class WrongTypeFailure(ValidationFailure):
     column: str
     expected_type: str
     actual_type: str
-    index: list[int]
+    row_indexes: list[int]
 
     def __str__(self):
         """Method to get the string representation of the wrong type failure."""
@@ -259,7 +260,7 @@ class OrphanedRowFailure(ValidationFailure):
         """Method to get the string representation of the orphaned row failure."""
         return (
             f'Orphaned Row Failure: Sheet "{self.sheet}" Column "{self.foreign_key}" '
-            f"Row {self.row + 2} "  # +2 for Excel 1-index and table header row
+            f"Row {self.row} "
             f'Value "{self.fk_value}" not in parent table '
             f'"{self.parent_table}" where PK "{self.parent_pk}"'
         )
@@ -274,7 +275,7 @@ class InvalidEnumValueFailure(ValidationFailure):
 
     sheet: str
     column: str
-    row: int
+    row_indexes: list[int]
     row_values: tuple
     value: Any
 
@@ -282,7 +283,7 @@ class InvalidEnumValueFailure(ValidationFailure):
         """Method to get the string representation of the invalid enum value failure."""
         return (
             f'Enum Value Failure: Sheet "{self.sheet}" Column "{self.column}" '
-            f"Row {self.row + 2} "  # +2 for Excel 1-index and table header row
+            f"Row {self.row_indexes[0] + 2} "
             f'Value "{self.value}" is not a valid enum value.'
         )
 
@@ -316,6 +317,7 @@ class NonNullableConstraintFailure(ValidationFailure):
 
     sheet: str
     column: str
+    row_indexes: list[int]
 
     def __str__(self):
         """Method to get the string representation of the non-nullable constraint failure."""
@@ -422,6 +424,7 @@ class InvalidOutcomeProjectFailure(ValidationFailure):
 
     invalid_project: str
     section: str
+    row_indexes: list[int]
 
     def __str__(self):
         """Method to get the string representation of the invalid outcome project failure."""

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -378,7 +378,9 @@ def test_ingest_endpoint_returns_validation_errors(test_client, example_data_mod
     mocker.patch(
         "core.controllers.ingest.validate",
         side_effect=ValidationError(
-            validation_failures=[NonNullableConstraintFailure(sheet="Project Progress", column="Start Date")]
+            validation_failures=[
+                NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[5])
+            ]
         ),
     )
 

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -191,7 +191,14 @@ def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lo
     with pytest.raises(ValidationError) as ve:
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 4)
     assert str(ve.value) == (
-        "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome Indicators (excluding " "footfall)')]"
+        (
+            "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
+            "Indicators (excluding footfall)', row_indexes=[21]), "
+            "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
+            "Indicators (excluding footfall)', row_indexes=[22]), "
+            "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
+            "Indicators (excluding footfall)', row_indexes=[41])]"
+        )
     )
 
 
@@ -202,115 +209,115 @@ def test_original_indexes_retained(mock_ingest_full_extract):
     first extracted. This test looks up the first and last indexes, and asserts that they equal the number of the
     indexes for the first and last values of a given DataFrame before transformation.
     """
-    assert mock_ingest_full_extract["Project Details"].index[0] == 25
-    assert mock_ingest_full_extract["Project Details"].index[-1] == 27
-    assert mock_ingest_full_extract["Place Details"].index[0] == 5
-    assert mock_ingest_full_extract["Place Details"].index[-1] == 19
-    assert mock_ingest_full_extract["Programme Progress"].index[0] == 5
-    assert mock_ingest_full_extract["Programme Progress"].index[-1] == 11
-    assert mock_ingest_full_extract["Project Progress"].index[0] == 18
-    assert mock_ingest_full_extract["Project Progress"].index[-1] == 20
-    assert mock_ingest_full_extract["Funding Questions"].index[0] == 13
-    assert mock_ingest_full_extract["Funding Questions"].index[-1] == 17
-    assert mock_ingest_full_extract["Funding Comments"].index[0] == 57
-    assert mock_ingest_full_extract["Funding Comments"].index[-1] == 113
-    assert mock_ingest_full_extract["Funding"].index[0] == 38
-    assert mock_ingest_full_extract["Funding"].index[-1] == 96
-    assert mock_ingest_full_extract["Private Investments"].index[0] == 11
-    assert mock_ingest_full_extract["Private Investments"].index[-1] == 13
-    assert mock_ingest_full_extract["Output_Data"].index[0] == 22
-    assert mock_ingest_full_extract["Output_Data"].index[-1] == 100
-    assert mock_ingest_full_extract["Outcome_Data"].index[0] == 21
-    assert mock_ingest_full_extract["RiskRegister"].index[0] == 10
-    assert mock_ingest_full_extract["RiskRegister"].index[-1] == 30
+    assert mock_ingest_full_extract["Project Details"].index[0] == 27
+    assert mock_ingest_full_extract["Project Details"].index[-1] == 29
+    assert mock_ingest_full_extract["Place Details"].index[0] == 7
+    assert mock_ingest_full_extract["Place Details"].index[-1] == 21
+    assert mock_ingest_full_extract["Programme Progress"].index[0] == 7
+    assert mock_ingest_full_extract["Programme Progress"].index[-1] == 13
+    assert mock_ingest_full_extract["Project Progress"].index[0] == 20
+    assert mock_ingest_full_extract["Project Progress"].index[-1] == 22
+    assert mock_ingest_full_extract["Funding Questions"].index[0] == 15
+    assert mock_ingest_full_extract["Funding Questions"].index[-1] == 19
+    assert mock_ingest_full_extract["Funding Comments"].index[0] == 59
+    assert mock_ingest_full_extract["Funding Comments"].index[-1] == 115
+    assert mock_ingest_full_extract["Funding"].index[0] == 40
+    assert mock_ingest_full_extract["Funding"].index[-1] == 98
+    assert mock_ingest_full_extract["Private Investments"].index[0] == 13
+    assert mock_ingest_full_extract["Private Investments"].index[-1] == 15
+    assert mock_ingest_full_extract["Output_Data"].index[0] == 24
+    assert mock_ingest_full_extract["Output_Data"].index[-1] == 102
+    assert mock_ingest_full_extract["Outcome_Data"].index[0] == 23
+    assert mock_ingest_full_extract["RiskRegister"].index[0] == 12
+    assert mock_ingest_full_extract["RiskRegister"].index[-1] == 32
 
 
 def test_project_details_indexes(mock_ingest_full_extract):
     """Test that the indexes for Project Details are not lost in transformation."""
-    assert mock_ingest_full_extract["Project Details"]["Project Name"][25] == "Test Project 1"
-    assert mock_ingest_full_extract["Project Details"]["Project Name"][26] == "Test Project 2"
-    assert mock_ingest_full_extract["Project Details"]["Project Name"][27] == "Test Project 3"
+    assert mock_ingest_full_extract["Project Details"]["Project Name"][27] == "Test Project 1"
+    assert mock_ingest_full_extract["Project Details"]["Project Name"][28] == "Test Project 2"
+    assert mock_ingest_full_extract["Project Details"]["Project Name"][29] == "Test Project 3"
 
 
 def test_place_details_indexes(mock_ingest_full_extract):
     """Test that the indexes for Place Details are not lost in transformation."""
-    assert mock_ingest_full_extract["Place Details"]["Answer"][5] == "Town_Deal"
-    assert mock_ingest_full_extract["Place Details"]["Answer"][6] == "Fake Town"
-    assert mock_ingest_full_extract["Place Details"]["Answer"][7] == "Test Org"
+    assert mock_ingest_full_extract["Place Details"]["Answer"][7] == "Town_Deal"
+    assert mock_ingest_full_extract["Place Details"]["Answer"][8] == "Fake Town"
+    assert mock_ingest_full_extract["Place Details"]["Answer"][9] == "Test Org"
 
 
 def test_programme_progress_indexes(mock_ingest_full_extract):
     """Test that the indexes for Programme Progress are not lost in transformation."""
-    assert mock_ingest_full_extract["Programme Progress"]["Answer"][5] == "some comment on profile / forecast"
-    assert mock_ingest_full_extract["Programme Progress"]["Answer"][6] == "Test comment progress update"
-    assert mock_ingest_full_extract["Programme Progress"]["Answer"][7] == "Test comment, challenges"
+    assert mock_ingest_full_extract["Programme Progress"]["Answer"][7] == "some comment on profile / forecast"
+    assert mock_ingest_full_extract["Programme Progress"]["Answer"][8] == "Test comment progress update"
+    assert mock_ingest_full_extract["Programme Progress"]["Answer"][9] == "Test comment, challenges"
 
 
 def test_project_progress_indexes(mock_ingest_full_extract):
     """Test that the indexes for Project Progress are not lost in transformation."""
-    assert mock_ingest_full_extract["Project Progress"]["Project ID"][18] == "TD-FAK-01"
-    assert mock_ingest_full_extract["Project Progress"]["Project ID"][19] == "TD-FAK-02"
-    assert mock_ingest_full_extract["Project Progress"]["Project ID"][20] == "TD-FAK-03"
+    assert mock_ingest_full_extract["Project Progress"]["Project ID"][20] == "TD-FAK-01"
+    assert mock_ingest_full_extract["Project Progress"]["Project ID"][21] == "TD-FAK-02"
+    assert mock_ingest_full_extract["Project Progress"]["Project ID"][22] == "TD-FAK-03"
 
 
 def test_funding_questions_indexes(mock_ingest_full_extract):
     """Test that the indexes for Funding Questions are not lost in transformation."""
-    assert mock_ingest_full_extract["Funding Questions"]["Question"][13] == (
+    assert mock_ingest_full_extract["Funding Questions"]["Question"][15] == (
         "Beyond these three funding types, have " "you received any payments for specific " "projects?"
     )
-    assert mock_ingest_full_extract["Funding Questions"]["Question"][15].iloc[0] == (
+    assert mock_ingest_full_extract["Funding Questions"]["Question"][17].iloc[0] == (
         "Please confirm whether the amount " "utilised represents your entire " "allocation"
     )
-    assert mock_ingest_full_extract["Funding Questions"]["Question"][18].iloc[0] == (
+    assert mock_ingest_full_extract["Funding Questions"]["Question"][20].iloc[0] == (
         "Please explain in detail how the " "funding has, or will be, " "utilised"
     )
 
 
 def test_funding_comments_indexes(mock_ingest_full_extract):
     """Test that the indexes for Funding Comments are not lost in transformation."""
-    assert mock_ingest_full_extract["Funding Comments"]["Comment"][57] == "Test comment 1"
-    assert mock_ingest_full_extract["Funding Comments"]["Comment"][85] == "Test comment 2"
-    assert str(mock_ingest_full_extract["Funding Comments"]["Comment"][113]) == "nan"
+    assert mock_ingest_full_extract["Funding Comments"]["Comment"][59] == "Test comment 1"
+    assert mock_ingest_full_extract["Funding Comments"]["Comment"][87] == "Test comment 2"
+    assert str(mock_ingest_full_extract["Funding Comments"]["Comment"][115]) == "nan"
 
 
 def test_funding_indexes(mock_ingest_full_extract):
     """Test that the indexes for Funding are not lost in transformation."""
-    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][50].iloc[0] == "Source 2"
-    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][76].iloc[0] == "Test source project 2"
-    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][48].iloc[0] == "Test source"
+    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][52].iloc[0] == "Source 2"
+    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][78].iloc[0] == "Test source project 2"
+    assert mock_ingest_full_extract["Funding"]["Funding Source Name"][50].iloc[0] == "Test source"
 
 
 def test_private_investments_indexes(mock_ingest_full_extract):
     """Test that the indexes for Private Investments are not lost in transformation."""
-    assert mock_ingest_full_extract["Private Investments"]["Project ID"][11] == "TD-FAK-01"
-    assert mock_ingest_full_extract["Private Investments"]["Project ID"][12] == "TD-FAK-02"
-    assert mock_ingest_full_extract["Private Investments"]["Project ID"][13] == "TD-FAK-03"
+    assert mock_ingest_full_extract["Private Investments"]["Project ID"][13] == "TD-FAK-01"
+    assert mock_ingest_full_extract["Private Investments"]["Project ID"][14] == "TD-FAK-02"
+    assert mock_ingest_full_extract["Private Investments"]["Project ID"][15] == "TD-FAK-03"
 
 
 def test_outputs_indexes(mock_ingest_full_extract):
     """Test that the indexes for Outputs are not lost in transformation."""
-    assert mock_ingest_full_extract["Output_Data"]["Output"][22].iloc[0] == "# of temporary FT jobs supported"
-    assert mock_ingest_full_extract["Output_Data"]["Output"][23].iloc[0] == (
+    assert mock_ingest_full_extract["Output_Data"]["Output"][24].iloc[0] == "# of temporary FT jobs supported"
+    assert mock_ingest_full_extract["Output_Data"]["Output"][25].iloc[0] == (
         "# of full-time equivalent (FTE) permanent " "jobs " "created through the project"
     )
-    assert mock_ingest_full_extract["Output_Data"]["Output"][24].iloc[0] == (
+    assert mock_ingest_full_extract["Output_Data"]["Output"][26].iloc[0] == (
         "# of full-time equivalent (FTE) permanent " "jobs safeguarded through the project"
     )
 
 
 def test_outcomes_indexes(mock_ingest_full_extract):
     """Test that the indexes for Outcomes are not lost in transformation."""
-    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][21].iloc[0] == (
+    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][23].iloc[0] == (
         "Patronage of the public transport system in " "the area of interest (for public transport " "schemes)"
     )
-    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][41].iloc[0] == "test custom outcome"
-    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][22].iloc[0] == (
+    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][43].iloc[0] == "test custom outcome"
+    assert mock_ingest_full_extract["Outcome_Data"]["Outcome"][24].iloc[0] == (
         "Estimated carbon dioxide equivalent reductions as a result of support"
     )
 
 
 def test_risk_indexes(mock_ingest_full_extract):
     """Test that the indexes for Risks are not lost in transformation."""
-    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][10] == "test programme risk 1"
-    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][21] == "project risk test 1"
-    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][22] == "project risk test 2"
+    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][12] == "test programme risk 1"
+    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][23] == "project risk test 1"
+    assert mock_ingest_full_extract["RiskRegister"]["RiskName"][24] == "project risk test 2"

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -332,14 +332,21 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
     with pytest.raises(ValidationError) as ve:
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 3)
     assert str(ve.value) == (
-        "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Outcome Indicators (excluding "
-        "footfall)')]"
+        (
+            "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[21]), "
+            "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[22]), "
+            "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[41])]"
+        )
     )
 
     with pytest.raises(ValidationError) as ve:
         tf.extract_footfall_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
     assert str(ve.value) == (
-        "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Footfall Indicator')]"
+        "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Footfall Indicator', "
+        "row_indexes=None)]"
     )
 
 

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -21,30 +21,29 @@ def test_test_failures_to_messages():
     failure1 = InvalidEnumValueFailure(
         sheet="Project Details",
         column="Single or Multiple Locations",
-        row=1,
+        row_indexes=[1],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
-    failure2 = NonNullableConstraintFailure(
-        sheet="Project Details",
-        column="Lat/Long",
-    )
+    failure2 = NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_indexes=[1])
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
+        row_indexes=[1],
     )
     failure5 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
+        row_indexes=[1],
     )  # intentional duplicate message, should only show up as a single message in the assertion
 
     failures = [failure1, failure2, failure3, failure4, failure5]
@@ -115,140 +114,140 @@ def test_failures_to_messages_pre_transformation_failures():
 def test_construct_index():
     # single index
     test_index1 = construct_index("Place Details", "Question", [1])
-    assert test_index1 == "C3"
+    assert test_index1 == "C1"
 
     test_index2 = construct_index("Project Details", "Locations", [2])
-    assert test_index2 == "H4/K4"
+    assert test_index2 == "H2/K2"
 
     test_index3 = construct_index("Programme Progress", "Answer", [3])
-    assert test_index3 == "D5"
+    assert test_index3 == "D3"
 
     test_index4 = construct_index("Project Progress", "Delivery (RAG)", [4])
-    assert test_index4 == "J6"
+    assert test_index4 == "J4"
 
     test_index5 = construct_index("Funding Questions", "Response", [5])
-    assert test_index5 == "E7-L7"
+    assert test_index5 == "E5-L5"
 
     test_index6 = construct_index("Funding Comments", "Comment", [6])
-    assert test_index6 == "C8-E8"
+    assert test_index6 == "C6-E6"
 
     # multi-index
     test_index7 = construct_index("Funding", "Funding Source Type", [7, 8])
-    assert test_index7 == "D9, D10"
+    assert test_index7 == "D7, D8"
 
     test_index8 = construct_index("Private Investments", "Private Sector Funding Required", [9, 10])
-    assert test_index8 == "G11, G12"
+    assert test_index8 == "G9, G10"
 
     test_index9 = construct_index("Output_Data", "Amount", [11, 12, 13])
-    assert test_index9 == "E13-W13, E14-W14, E15-W15"
+    assert test_index9 == "E11-W11, E12-W12, E13-W13"
 
     test_index10 = construct_index("Outcome_Data", "Higher Frequency", [8, 2, 11, 5, 9])
-    assert test_index10 == "P10, P4, P13, P7, P11"
+    assert test_index10 == "P8, P2, P11, P5, P9"
 
 
 def test_invalid_enum_messages():
     failure1 = InvalidEnumValueFailure(
         sheet="Project Details",
         column="Single or Multiple Locations",
-        row=1,
+        row_indexes=[1],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure3 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Project Delivery Status",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure4 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Delivery (RAG)",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure5 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Spend (RAG)",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure6 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Risk (RAG)",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure7 = InvalidEnumValueFailure(
         sheet="Funding",
         column="Secured",
-        row=2,
+        row_indexes=[2],
         row_values=("TD-ABC-1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure8 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedImpact",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure9 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedLikelihood",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure10 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedImpact",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure11 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedLikelihood",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure12 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Proximity",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure13 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Project Adjustment Request Status",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure14 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Current Project Delivery Stage",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure15 = InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Leading Factor of Delay",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure16 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="RiskCategory",
-        row=2,
+        row_indexes=[2],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
@@ -348,14 +347,8 @@ def test_invalid_enum_messages():
 
 
 def test_non_nullable_messages_project_details():
-    failure1 = NonNullableConstraintFailure(
-        sheet="Project Details",
-        column="Locations",
-    )
-    failure2 = NonNullableConstraintFailure(
-        sheet="Project Details",
-        column="Lat/Long",
-    )
+    failure1 = NonNullableConstraintFailure(sheet="Project Details", column="Locations", row_indexes=[15, 16])
+    failure2 = NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_indexes=[21, 22])
 
     assert failure1.to_message() == (
         "Project Admin",
@@ -372,15 +365,23 @@ def test_non_nullable_messages_project_details():
 
 
 def test_non_nullable_messages_project_progress():
-    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date")
-    failure2 = NonNullableConstraintFailure(sheet="Project Progress", column="Completion Date")
-    failure3 = NonNullableConstraintFailure(sheet="Project Progress", column="Commentary on Status and RAG Ratings")
-    failure4 = NonNullableConstraintFailure(sheet="Project Progress", column="Most Important Upcoming Comms Milestone")
-    failure5 = NonNullableConstraintFailure(
-        sheet="Project Progress", column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)"
+    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[1, 2])
+    failure2 = NonNullableConstraintFailure(sheet="Project Progress", column="Completion Date", row_indexes=[4])
+    failure3 = NonNullableConstraintFailure(
+        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_indexes=[2]
     )
-    failure6 = NonNullableConstraintFailure(sheet="Programme Progress", column="Answer")
-    failure7 = NonNullableConstraintFailure(sheet="Project Progress", column="Current Project Delivery Stage")
+    failure4 = NonNullableConstraintFailure(
+        sheet="Project Progress", column="Most Important Upcoming Comms Milestone", row_indexes=[7]
+    )
+    failure5 = NonNullableConstraintFailure(
+        sheet="Project Progress",
+        column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
+        row_indexes=[6],
+    )
+    failure6 = NonNullableConstraintFailure(sheet="Programme Progress", column="Answer", row_indexes=[4])
+    failure7 = NonNullableConstraintFailure(
+        sheet="Project Progress", column="Current Project Delivery Stage", row_indexes=[3]
+    )
 
     assert failure1.to_message() == (
         "Programme Progress",
@@ -430,14 +431,8 @@ def test_non_nullable_messages_unit_of_measurement():
     Alternative message should be displayed for null values of unit of measurement - this means the user hasn't
     selected an indicator from the dropdown.
     """
-    failure1 = NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="UnitofMeasurement",
-    )
-    failure2 = NonNullableConstraintFailure(
-        sheet="Output_Data",
-        column="Unit of Measurement",
-    )
+    failure1 = NonNullableConstraintFailure(sheet="Outcome_Data", column="UnitofMeasurement", row_indexes=[16, 21])
+    failure2 = NonNullableConstraintFailure(sheet="Output_Data", column="Unit of Measurement", row_indexes=[17, 22])
 
     assert failure1.to_message() == (
         "Outcomes",
@@ -459,10 +454,7 @@ def test_non_nullable_messages_outcomes():
     """
     Validation error should be raise if user leaves geography indicator blank
     """
-    failure1 = NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="GeographyIndicator",
-    )
+    failure1 = NonNullableConstraintFailure(sheet="Outcome_Data", column="GeographyIndicator", row_indexes=[5, 6])
     assert failure1.to_message() == (
         "Outcomes",
         "Outcome Indicators (excluding footfall)",
@@ -472,13 +464,15 @@ def test_non_nullable_messages_outcomes():
 
 
 def test_non_nullable_messages_risk_register():
-    failure1 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description")
-    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Full Description")
-    failure3 = NonNullableConstraintFailure(sheet="RiskRegister", column="Consequences")
-    failure4 = NonNullableConstraintFailure(sheet="RiskRegister", column="Mitigatons")  # typo throughout code
-    failure5 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskOwnerRole")
-    failure6 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName")
-    failure7 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskCategory")
+    failure1 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description", row_indexes=[20])
+    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Full Description", row_indexes=[21])
+    failure3 = NonNullableConstraintFailure(sheet="RiskRegister", column="Consequences", row_indexes=[22])
+    failure4 = NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Mitigatons", row_indexes=[23]
+    )  # typo throughout code
+    failure5 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskOwnerRole", row_indexes=[24])
+    failure6 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName", row_indexes=[25])
+    failure7 = NonNullableConstraintFailure(sheet="RiskRegister", column="RiskCategory", row_indexes=[26])
 
     assert failure1.to_message() == (
         "Risk Register",
@@ -523,9 +517,9 @@ def test_non_nullable_messages_risk_register():
 
 
 def test_non_nullable_fill_rows():
-    failure1 = NonNullableConstraintFailure(sheet="Outcome_Data", column="Amount")
-    failure2 = NonNullableConstraintFailure(sheet="Output_Data", column="Amount")
-    failure3 = NonNullableConstraintFailure(sheet="Funding", column="Spend for Reporting Period")
+    failure1 = NonNullableConstraintFailure(sheet="Outcome_Data", column="Amount", row_indexes=[5])
+    failure2 = NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_indexes=[6])
+    failure3 = NonNullableConstraintFailure(sheet="Funding", column="Spend for Reporting Period", row_indexes=[7])
 
     assert failure1.to_message() == (
         "Outcomes",
@@ -548,8 +542,8 @@ def test_non_nullable_fill_rows():
 
 
 def test_non_nullable_messages_multiple_tabs():
-    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date")
-    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description")
+    failure1 = NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[2, 3])
+    failure2 = NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description", row_indexes=[5, 6])
 
     assert failure1.to_message() == (
         "Programme Progress",
@@ -619,70 +613,70 @@ def test_wrong_type_messages():
         column="Start Date",
         expected_type="datetime64[ns]",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure2 = WrongTypeFailure(
         sheet="Project Progress",
         column="Completion Date",
         expected_type="datetime64[ns]",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure4 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Required",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure5 = WrongTypeFailure(
         sheet="Private Investments",
         column="Private Sector Funding Secured",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure6 = WrongTypeFailure(
         sheet="Funding",
         column="Spend for Reporting Period",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure7 = WrongTypeFailure(
         sheet="Output_Data",
         column="Amount",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure8 = WrongTypeFailure(
         sheet="Outcome_Data",
         column="Amount",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure9 = WrongTypeFailure(
         sheet="Project Details",
         column="Spend for Reporting Period",
         expected_type="float64",
         actual_type="string",
-        index=[22],
+        row_indexes=[22],
     )
     failure10 = WrongTypeFailure(
         sheet="Outcome_Data",
         column="Amount",
         expected_type="float64",
         actual_type="object",
-        index=[22],
+        row_indexes=[22],
     )
 
     assert failure1.to_message() == (
@@ -761,6 +755,7 @@ def test_non_unique_composite_key_messages():
             "2021-04-01 00:00:00",
             "2021-09-30 00:00:00",
         ],
+        row_indexes=[2],
     )
     failure2 = NonUniqueCompositeKeyFailure(
         sheet="Output_Data",
@@ -773,6 +768,7 @@ def test_non_unique_composite_key_messages():
             "Km of cycle way",
             "Actual",
         ],
+        row_indexes=[3],
     )
     failure3 = NonUniqueCompositeKeyFailure(
         sheet="Outcome_Data",
@@ -783,21 +779,25 @@ def test_non_unique_composite_key_messages():
             "2020-04-01 00:00:00",
             "Travel corridor",
         ],
+        row_indexes=[1],
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=["HS-GRA", pd.NA, "Delivery Timeframe"],
+        row_indexes=[1],
     )
     failure5 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
+        row_indexes=[3],
     )
     failure6 = NonUniqueCompositeKeyFailure(
         sheet="Project Progress",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
+        row_indexes=[7],
     )
 
     assert failure1.to_message() == (
@@ -836,9 +836,11 @@ def test_non_unique_composite_key_messages():
 
 def test_invalid_project_outcome_failure():
     failure1 = InvalidOutcomeProjectFailure(
-        invalid_project="Invalid Project", section="Outcome Indicators (excluding footfall)"
+        invalid_project="Invalid Project", section="Outcome Indicators (excluding footfall)", row_indexes=[5]
     )
-    failure2 = InvalidOutcomeProjectFailure(invalid_project="Invalid Project", section="Footfall Indicator")
+    failure2 = InvalidOutcomeProjectFailure(
+        invalid_project="Invalid Project", section="Footfall Indicator", row_indexes=[6]
+    )
 
     assert failure1.to_message() == (
         "Outcomes",


### PR DESCRIPTION
Relay the indexes of where an error has occurred to the validation failures for non R4-specific validation failures. Excludes WrongTypeFailure.


- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

