### PR TITLE
[SMD-238] ingest an extra half of funding data for round 4

### DIFF
--- a/core/extraction/towns_fund_round_four.py
+++ b/core/extraction/towns_fund_round_four.py
@@ -53,8 +53,7 @@ def ingest_round_four_data_towns_fund(df_ingest: dict[str, pd.DataFrame]) -> dic
         project_lookup,
     )
     towns_fund_extracted["Funding"] = r3.extract_funding_data(
-        df_ingest["4a - Funding Profiles"],
-        project_lookup,
+        df_ingest["4a - Funding Profiles"], project_lookup, round_four=True
     )
     towns_fund_extracted["Private Investments"] = r3.extract_psi(df_ingest["4b - PSI"], project_lookup)
     towns_fund_extracted["Output_Data"] = r3.extract_outputs(df_ingest["5 - Project Outputs"], project_lookup)

--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -453,7 +453,7 @@ def extract_funding_comments(df_input: pd.DataFrame, project_lookup: dict) -> pd
     return df_fund_comments
 
 
-def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.DataFrame:
+def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict, round_four: bool = False) -> pd.DataFrame:
     """
     Extract funding data (excluding comments) from a DataFrame.
 
@@ -547,6 +547,8 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.Dat
     df_funding.drop(unused_mask.index, inplace=True)
 
     if fund_type == "HS":
+        # Round 3 collects up to H2 23/24, Round 4 collects up to a Half later (H1 of 24/25)
+        start_date_cut_off = datetime(2024, 4, 1) if round_four else datetime(2023, 10, 1)
         unused_fhsf_mask = df_funding.loc[
             # drop unused FHSF Questions
             (
@@ -563,7 +565,7 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict) -> pd.Dat
             )
             |
             # drop unused FHSF forcast cells
-            ((df_funding["Funding Source Type"] == "Towns Fund") & (df_funding["Start_Date"] > datetime(2023, 10, 1)))
+            ((df_funding["Funding Source Type"] == "Towns Fund") & (df_funding["Start_Date"] > start_date_cut_off))
             # TODO: Review logic for future forcast in reporting round 5
         ]
         df_funding.drop(unused_fhsf_mask.index, inplace=True)

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -3,6 +3,7 @@ Round 4 extraction is almost identical to Round 3 and so re-uses many components
 
 The tests in this module cover new functionality unique to Round 4.
 """
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -101,6 +102,22 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
         ""
     )
     assert_frame_equal(extracted_project_progress, expected_project_progress)
+
+
+def test_extract_funding_data_fhsf(mock_funding_sheet, mock_project_lookup):
+    """Round 4 param for extract_funding_data should retain an extra half of funding data."""
+    mock_project_lookup = {key: value.replace("TD", "HS") for (key, value) in mock_project_lookup.items()}
+    extracted_funding_data = tf.extract_funding_data(mock_funding_sheet, mock_project_lookup, round_four=True)
+
+    assert (
+        len(
+            extracted_funding_data[
+                (extracted_funding_data["Funding Source Type"] == "Towns Fund")
+                & (extracted_funding_data["Start_Date"] >= datetime(year=2024, month=4, day=1))
+            ]
+        )
+        != 0
+    )
 
 
 def test_extract_risk(mock_risk_sheet, mock_project_lookup, mock_programme_lookup):


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-238

### Change description
- For Round 4 we need to collect an extra half of data where TF have un-greyed out the cells in the form for FHSF H1 24/25

The cells in red below used to be 
![image](https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/22678716/75845a71-3551-41de-a083-009cc1052ecc)

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
