### PR TITLE
[SMD-248] return the name of the programme being submitted upon succe…

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -60,13 +60,17 @@ def ingest(body: dict, excel_file: FileStorage) -> Response:
     submission_id = workbook["Submission_Ref"]["Submission ID"].iloc[0]
     save_submission_file(excel_file, submission_id)
 
-    return jsonify(
-        {
-            "detail": "Spreadsheet successfully uploaded",
-            "status": 200,
-            "title": "success",
-        }
-    )
+    success_payload = {
+        "detail": "Spreadsheet successfully uploaded",
+        "status": 200,
+        "title": "success",
+    }
+
+    # if non-historical rounds then return the submission's programme name
+    if reporting_round in [3, 4]:
+        success_payload.update({"programme": workbook["Programme_Ref"].iloc[0]["Programme Name"]})
+
+    return jsonify(success_payload)
 
 
 def extract_data(excel_file: FileStorage) -> dict[str, pd.DataFrame]:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -32,6 +32,8 @@ components:
         properties:
           detail:
             type: string
+          programme:
+            type: string
           title:
             type: string
           status:
@@ -39,6 +41,7 @@ components:
             format: int32
       example: {
         "detail": "Spreadsheet successfully uploaded",
+        "programme": "Blackfriars - Northern City Centre",
         "status": 200,
         "title": "success",
       }


### PR DESCRIPTION
…ssful ingest

https://dluhcdigital.atlassian.net/browse/SMD-248

We need to return the place name of the successfully ingested submission to Submit users in a confirmation email. Submit doesn't currently have this information.

### Change description
- return programme name upon successful ingest

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
