### PR TITLE
[SMD-147] Fix project numbers in the wrong place in validation

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 import re
 from typing import Any
 
@@ -58,13 +59,36 @@ def group_by_first_element(tuples: list[tuple]) -> dict[str, list[tuple | Any]]:
     return nested
 
 
-def get_project_number(project_id):
-    """Extracts the project number from a project ID.
+def get_project_number_by_position(row_index: int, sheet: str):
+    """Extracts the project number from the row index and table name of a row by mapping it's on page position
 
-    :param project_id: A project ID code
+    :param row_index: row number on Excel sheet that row has come from
+    :param sheet: name of the database table the row has come from
     :return: project number
     """
-    return int(project_id.split("-")[2])
+    match sheet:
+        case "Funding" | "Funding Comments":
+            project_number = math.ceil((row_index - 32) / 28)
+        case "Output_Data":
+            project_number = math.ceil((row_index - 17) / 38)
+        case "RiskRegister":
+            project_number = math.ceil((row_index - 19) / 8) if row_index < 44 else math.ceil((row_index - 20) / 8)
+        case _:
+            raise ValueError
+
+    return project_number
+
+
+def get_project_number_by_id(project_id: str, active_project_ids: list[str]) -> int:
+    """Map project ID to it's on page position using position in list of active projects
+
+    :param project_id: A project ID code
+    :param active_project_ids: A list of project ID's in the sheet in order
+    :return: project number
+    """
+    project_number = active_project_ids.index(project_id) + 1
+
+    return project_number
 
 
 def construct_index(section: str, column: str, rows: list[int]) -> str:

--- a/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
@@ -135,19 +135,19 @@ def test_validate_project_risks_returns_correct_failure_no_risks():
         ),
         TownsFundRoundFourValidationFailure(
             sheet="RiskRegister",
+            section="Project Risks - Project 2",
+            column="RiskName",
+            message="You have not entered any risks for this project. You must enter at least 1 risk per non-complete "
+            "project",
+            row_indexes=[29],
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="RiskRegister",
             section="Project Risks - Project 3",
             column="RiskName",
             message="You have not entered any risks for this project. You must enter at least 1 risk per non-complete "
             "project",
             row_indexes=[37],
-        ),
-        TownsFundRoundFourValidationFailure(
-            sheet="RiskRegister",
-            section="Project Risks - Project 4",
-            column="RiskName",
-            message="You have not entered any risks for this project. You must enter at least 1 risk per non-complete "
-            "project",
-            row_indexes=[46],
         ),
     ]
 
@@ -225,7 +225,7 @@ def test_validate_programme_risks_returns_no_failure():
 
 def test_validate_funding_profiles_funding_source_failure():
     funding_df = pd.DataFrame(
-        index=[5, 6],
+        index=[48, 49],
         data=[
             # Pre-defined Funding Source
             {
@@ -252,14 +252,14 @@ def test_validate_funding_profiles_funding_source_failure():
             column="Funding Source Type",
             message='For column "Funding Source", you have entered "Invalid Funding Source Type" which isn\'t '
             "correct. You must select an option from the list provided",
-            row_indexes=[6],
+            row_indexes=[49],
         )
     ]
 
 
 def test_validate_funding_profiles_funding_source_failure_multiple():
     funding_df = pd.DataFrame(
-        index=[3, 5, 7],
+        index=[48, 49, 106],
         data=[
             # Pre-defined Funding Source
             {
@@ -269,13 +269,13 @@ def test_validate_funding_profiles_funding_source_failure_multiple():
             },
             # Invalid "Other Funding Source" 1
             {
-                "Project ID": "TD-ABC-03",
+                "Project ID": "TD-ABC-01",
                 "Funding Source Type": "Invalid Funding Source Type 1",
                 "Funding Source Name": "Some Other Funding Source",
             },
             # Invalid "Other Funding Source" 2
             {
-                "Project ID": "TD-ABC-01",
+                "Project ID": "TD-ABC-03",
                 "Funding Source Type": "Invalid Funding Source Type 2",
                 "Funding Source Name": "Some Other Funding Source",
             },
@@ -288,19 +288,19 @@ def test_validate_funding_profiles_funding_source_failure_multiple():
     assert failures == [
         TownsFundRoundFourValidationFailure(
             sheet="Funding",
-            section="Project Funding Profiles - Project 3",
+            section="Project Funding Profiles - Project 1",
             column="Funding Source Type",
             message='For column "Funding Source", you have entered "Invalid Funding Source Type 1" which isn\'t '
             "correct. You must select an option from the list provided",
-            row_indexes=[5],
+            row_indexes=[49],
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Funding",
-            section="Project Funding Profiles - Project 1",
+            section="Project Funding Profiles - Project 3",
             column="Funding Source Type",
             message='For column "Funding Source", you have entered "Invalid Funding Source Type 2" which isn\'t '
             "correct. You must select an option from the list provided",
-            row_indexes=[7],
+            row_indexes=[106],
         ),
     ]
 

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -37,13 +37,13 @@ def test_test_failures_to_messages():
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[1],
+        row_indexes=[23],
     )
     failure5 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[1],
+        row_indexes=[25],
     )  # intentional duplicate message, should only show up as a single message in the assertion
 
     failures = [failure1, failure2, failure3, failure4, failure5]
@@ -184,42 +184,42 @@ def test_invalid_enum_messages():
     failure7 = InvalidEnumValueFailure(
         sheet="Funding",
         column="Secured",
-        row_indexes=[2],
+        row_indexes=[50],
         row_values=("TD-ABC-1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
     failure8 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedImpact",
-        row_indexes=[2],
+        row_indexes=[23],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure9 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedLikelihood",
-        row_indexes=[2],
+        row_indexes=[24],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure10 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedImpact",
-        row_indexes=[2],
+        row_indexes=[25],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure11 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedLikelihood",
-        row_indexes=[2],
+        row_indexes=[23],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
     failure12 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Proximity",
-        row_indexes=[2],
+        row_indexes=[24],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
@@ -247,7 +247,7 @@ def test_invalid_enum_messages():
     failure16 = InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="RiskCategory",
-        row_indexes=[2],
+        row_indexes=[25],
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
         value="Value",
     )
@@ -755,7 +755,7 @@ def test_non_unique_composite_key_messages():
             "2021-04-01 00:00:00",
             "2021-09-30 00:00:00",
         ],
-        row_indexes=[2],
+        row_indexes=[78],
     )
     failure2 = NonUniqueCompositeKeyFailure(
         sheet="Output_Data",
@@ -768,7 +768,7 @@ def test_non_unique_composite_key_messages():
             "Km of cycle way",
             "Actual",
         ],
-        row_indexes=[3],
+        row_indexes=[82],
     )
     failure3 = NonUniqueCompositeKeyFailure(
         sheet="Outcome_Data",
@@ -791,7 +791,7 @@ def test_non_unique_composite_key_messages():
         sheet="RiskRegister",
         cols=("Programme ID", "Project ID", "RiskName"),
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[3],
+        row_indexes=[23],
     )
     failure6 = NonUniqueCompositeKeyFailure(
         sheet="Project Progress",

--- a/tests/validation_tests/test_utils.py
+++ b/tests/validation_tests/test_utils.py
@@ -1,0 +1,47 @@
+import pytest
+
+from core.util import get_project_number_by_id, get_project_number_by_position
+
+MOCK_ACTIVE_PROJECT_IDS = ["TD-ABC-01", "TD-ABC-03", "TD-ABC-05", "TD-ABC-07", "TD-ABC-08"]
+
+
+def test_get_project_number_by_position():
+    assert get_project_number_by_position(33, "Funding") == 1
+    assert get_project_number_by_position(60, "Funding") == 1
+    assert get_project_number_by_position(61, "Funding Comments") == 2
+    assert get_project_number_by_position(88, "Funding") == 2
+    assert get_project_number_by_position(89, "Funding") == 3
+    assert get_project_number_by_position(116, "Funding Comments") == 3
+    assert get_project_number_by_position(117, "Funding") == 4
+
+    assert get_project_number_by_position(18, "Output_Data") == 1
+    assert get_project_number_by_position(55, "Output_Data") == 1
+    assert get_project_number_by_position(56, "Output_Data") == 2
+    assert get_project_number_by_position(93, "Output_Data") == 2
+    assert get_project_number_by_position(94, "Output_Data") == 3
+    assert get_project_number_by_position(132, "Output_Data") == 4
+    assert get_project_number_by_position(170, "Output_Data") == 5
+
+    assert get_project_number_by_position(20, "RiskRegister") == 1
+    assert get_project_number_by_position(27, "RiskRegister") == 1
+    assert get_project_number_by_position(28, "RiskRegister") == 2
+    assert get_project_number_by_position(35, "RiskRegister") == 2
+    assert get_project_number_by_position(36, "RiskRegister") == 3
+    assert get_project_number_by_position(44, "RiskRegister") == 3
+    assert get_project_number_by_position(45, "RiskRegister") == 4
+    assert get_project_number_by_position(52, "RiskRegister") == 4
+    assert get_project_number_by_position(53, "RiskRegister") == 5
+
+    with pytest.raises(ValueError):
+        get_project_number_by_position(10, "other_Sheet")
+
+
+def test_get_project_number_by_id():
+    assert get_project_number_by_id("TD-ABC-01", MOCK_ACTIVE_PROJECT_IDS) == 1
+    assert get_project_number_by_id("TD-ABC-03", MOCK_ACTIVE_PROJECT_IDS) == 2
+    assert get_project_number_by_id("TD-ABC-05", MOCK_ACTIVE_PROJECT_IDS) == 3
+    assert get_project_number_by_id("TD-ABC-07", MOCK_ACTIVE_PROJECT_IDS) == 4
+    assert get_project_number_by_id("TD-ABC-08", MOCK_ACTIVE_PROJECT_IDS) == 5
+
+    with pytest.raises(ValueError):
+        get_project_number_by_id("TD-ABC-02", MOCK_ACTIVE_PROJECT_IDS)


### PR DESCRIPTION
This PR fixes a bug where the project number in the section field for some of the validation errors displayed does not match their on page position, for background this is because the projects in the sheet could be for example:
TD-ABC-01 - project 1
TD-ABC-03 - project 2
TD-ABC-05 - project 3

so we can't simple read the final part of the ID to get project number as we have done so far.

To fix this I have implemented two functions
- get_project_number_by_cell()

This uses the row index to get project number

- get_project_number_by_id()

this uses the project ID and the list of active ids

Then in the code wherever we need project number I have used which ever function is best for a given use case.

In the future we hope to refactor the to_message() and validatiion functions to only need one of these functions as maintaining both options is overly complex. However for now we are keeping both.
