### PR TITLE
[SMD-269] added function for combining validation messages

### DIFF
--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -526,3 +526,25 @@ def failures_to_messages(
         tab: group_by_first_element(failures) for tab, failures in failures_grouped_by_tab.items()
     }
     return {"TabErrors": failures_grouped_by_tab_and_section}
+
+
+def group_validation_messages(validation_messages: list[tuple[str, str, str, str]]) -> list[tuple[str, str, str, str]]:
+    """Groups validation messages by concatenating the cell indexes together on identical sheet, section and description
+
+    :param validation_messages: a list of tuples representing validation messages: sheet, section, description, cell
+    :return: grouped validation messages
+    """
+    grouped_dict = {}
+    for item in validation_messages:
+        key = item[:3]  # use the first three values as the key - sheet, section and description
+        value = item[3]  # use the cell index as the value
+        if key in grouped_dict:
+            grouped_dict[key].append(value)  # collect cells to concatenate
+        else:
+            grouped_dict[key] = [value]
+
+    grouped_messages = [
+        (sheet, section, desc, ", ".join(cells)) for (sheet, section, desc), cells in grouped_dict.items()
+    ]
+
+    return grouped_messages

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -14,6 +14,7 @@ from core.validation.failures import (
     WrongInputFailure,
     WrongTypeFailure,
     failures_to_messages,
+    group_validation_messages,
 )
 
 
@@ -893,3 +894,31 @@ def test_sign_off_failure():
         "'Date' for 'Town Board Chair'. "
         "You need to get sign off from a programme SRO",
     )
+
+
+def test_group_validation_messages():
+    data = [
+        # A - combine these
+        ("Project Admin", "Project Details", "You left cells blank.", "A1"),
+        ("Project Admin", "Project Details", "You left cells blank.", "A2"),
+        # B - combine these
+        ("Project Admin", "Programme Details", "You left cells blank.", "D4"),
+        ("Project Admin", "Programme Details", "You left cells blank.", "D4, D5, D7"),
+        # C - do not combine these due to different sections
+        ("Risk Register", "Project Risks - Project 1", "Select from the dropdown.", "G24"),
+        ("Risk Register", "Project Risks - Project 2", "Select from the dropdown.", "G43"),
+        # D - do not combine these due to different descriptions
+        ("Outcomes", "Programme-level Outcomes", "You left cells blank.", "E5"),
+        ("Outcomes", "Programme-level Outcomes", "Select from the dropdown.", "E7"),
+    ]
+
+    grouped = group_validation_messages(data)
+
+    assert grouped == [
+        ("Project Admin", "Project Details", "You left cells blank.", "A1, A2"),
+        ("Project Admin", "Programme Details", "You left cells blank.", "D4, D4, D5, D7"),
+        ("Risk Register", "Project Risks - Project 1", "Select from the dropdown.", "G24"),
+        ("Risk Register", "Project Risks - Project 2", "Select from the dropdown.", "G43"),
+        ("Outcomes", "Programme-level Outcomes", "You left cells blank.", "E5"),
+        ("Outcomes", "Programme-level Outcomes", "Select from the dropdown.", "E7"),
+    ]


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-269

### Change description
- adds a function for combing validation messages that have identical sheet, section and description by concatenating the cell values together.
- this function is currently unused

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
