### PR TITLE
fix cell off by 2 bug for outcome project failure

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -864,7 +864,7 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
                 vf.InvalidOutcomeProjectFailure(
                     invalid_project=row["Relevant project(s)"],
                     section="Outcome Indicators (excluding footfall)",
-                    row_indexes=[idx],
+                    row_indexes=[idx + 2],  # +2 here as caught mid-ingest before post-transformation incrementation
                 )
                 for idx, row in outcomes_df.loc[outcomes_df["Relevant project(s)"].isin(invalid_projects)].iterrows()
             ]

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -193,11 +193,11 @@ def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lo
     assert str(ve.value) == (
         (
             "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[21]), "
+            "Indicators (excluding footfall)', row_indexes=[23]), "
             "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[22]), "
+            "Indicators (excluding footfall)', row_indexes=[24]), "
             "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[41])]"
+            "Indicators (excluding footfall)', row_indexes=[43])]"
         )
     )
 

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -334,11 +334,11 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
     assert str(ve.value) == (
         (
             "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[21]), "
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[23]), "
             "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[22]), "
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[24]), "
             "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[41])]"
+            "section='Outcome Indicators (excluding footfall)', row_indexes=[43])]"
         )
     )
 


### PR DESCRIPTION
Fixes issue whereby cell rows are off by two for outcome project failures.

This was happening because we need to increment +2 in our DataFrames to match original Excel row. However, we currently do this incrementation post-transformation, but InvalidOutcomeProjectFailures are caught mid-transformation, hence lacking the increment.

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
