### PR TITLE
fix duplicated cell bugs on composite keys

### DIFF
--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -198,7 +198,9 @@ def validate_unique_composite_key(
 
     # filter dataframe by these columns and find duplicated rows including NaN/Empty
     mask = sheet[composite_key_list].duplicated(keep="first")
-    duplicated_rows = sheet[mask].drop_duplicates(subset=composite_key_list)[composite_key_list]
+    index_mask = sheet.index.duplicated(keep="first")
+    duplicated_rows = sheet[mask & ~index_mask][composite_key_list]
+
     if mask.any():
         failures = [
             vf.NonUniqueCompositeKeyFailure(

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -333,9 +333,9 @@ def test_validate_unique_composite_keys_valid(valid_workbook_and_schema):
 def test_validate_unique_composite_keys_invalid(valid_workbook_and_schema):
     workbook, schema = valid_workbook_and_schema
 
-    workbook["Project Sheet"]["Fund_ID"] = ["F001", "F002", "F001"]
-    workbook["Project Sheet"]["Package_ID"] = ["ABC001", "ABC002", "ABC001"]
-    workbook["Project Sheet"]["Project_ID"] = ["PID001", "PID002", "PID001"]
+    workbook["Project Sheet"]["Fund_ID"] = ["F001", "F001", "F001"]
+    workbook["Project Sheet"]["Package_ID"] = ["ABC001", "ABC001", "ABC001"]
+    workbook["Project Sheet"]["Project_ID"] = ["PID001", "PID001", "PID001"]
 
     failures = validate_unique_composite_key(
         workbook=workbook,
@@ -344,6 +344,12 @@ def test_validate_unique_composite_keys_invalid(valid_workbook_and_schema):
     )
 
     assert failures == [
+        NonUniqueCompositeKeyFailure(
+            sheet="Project Sheet",
+            cols=("Project_ID", "Fund_ID", "Package_ID"),
+            row=["PID001", "F001", "ABC001"],
+            row_indexes=[6],
+        ),
         NonUniqueCompositeKeyFailure(
             sheet="Project Sheet",
             cols=("Project_ID", "Fund_ID", "Package_ID"),


### PR DESCRIPTION
Fixes issue of composite keys returning multiple of the same cell. This was because of melting behaviour on the DataFrames.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")