### PR TITLE
[SMD-312] fix duplicate cell indexes in messages for funding source e…

### DIFF
--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -136,6 +136,11 @@ def validate_funding_profiles_funding_source(
     invalid_source_mask = ~funding_df["Funding Source Type"].isin(set(FundingSourceCategoryEnum))
 
     invalid_rows = funding_df[non_pre_defined_source_mask & invalid_source_mask]
+
+    # due to the pd.melt during transformation that maps a single spreadsheet row to multiple df rows, here we just keep
+    # the first of each unique index (this refers to the spreadsheet row number). This ensures we only produce one error
+    # for a single incorrect row in the spreadsheet
+    invalid_rows = invalid_rows[~invalid_rows.index.duplicated(keep="first")]
     if len(invalid_rows) > 0:
         return [
             TownsFundRoundFourValidationFailure(

--- a/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
@@ -253,13 +253,13 @@ def test_validate_funding_profiles_funding_source_failure():
 
 def test_validate_funding_profiles_funding_source_failure_multiple():
     funding_df = pd.DataFrame(
-        index=[48, 49, 106],
+        index=[48, 48, 106],  # includes duplicate indexes
         data=[
             # Pre-defined Funding Source
             {
                 "Project ID": "TD-ABC-01",
-                "Funding Source Type": "Towns Fund",
-                "Funding Source Name": PRE_DEFINED_FUNDING_SOURCES[0],
+                "Funding Source Type": "Invalid Funding Source Type 1",
+                "Funding Source Name": "Some Other Funding Source",
             },
             # Invalid "Other Funding Source" 1
             {
@@ -285,7 +285,7 @@ def test_validate_funding_profiles_funding_source_failure_multiple():
             section="Project Funding Profiles - Project 1",
             column="Funding Source Type",
             message=msgs.DROPDOWN,
-            row_indexes=[49],
+            row_indexes=[48],
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Funding",


### PR DESCRIPTION
…num failures

https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?selectedIssue=SMD-312

### Change description
- fixes a bug where funding source enum validation messages contained duplicate cell indexes

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
