### PR TITLE
FMD-105: override load balancer timeout

### DIFF
--- a/copilot/environments/overrides/cfn.patches.yml
+++ b/copilot/environments/overrides/cfn.patches.yml
@@ -21,3 +21,9 @@
 - op: replace
   path: /Resources/CloudFrontDistribution/Properties/DistributionConfig/Origins/0/CustomOriginConfig
   value: { OriginProtocolPolicy: match-viewer, OriginReadTimeout: 180 }
+
+- op: add
+  path: /Resources/PublicLoadBalancer/Properties/LoadBalancerAttributes
+  value:
+    - Key: idle_timeout.timeout_seconds
+      Value: 180


### PR DESCRIPTION
### Change description
We need this to match the Cloudfront timeout to maximise the request time as otherwise loadbalancer will timeout requests after 60 seconds.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have tested by running on pre-production environment
Have also run diff to check change e.g.
```
$ copilot env deploy --diff                         
Found only one environment, defaulting to: production
~ Metadata:
    ~ Version: v1.30.0 -> v1.30.1
~ Resources/PublicLoadBalancer/Properties:
    + LoadBalancerAttributes:
    +     - Key: idle_timeout.timeout_seconds
    +       Value: 180
```


### Screenshots of UI changes (if applicable)
