### PR TITLE
[SMD-315]: float type in rag ratings bug fix

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -361,18 +361,6 @@ def extract_project_progress(df_data: pd.DataFrame, project_lookup: dict, round_
     df_data = df_data.drop(["Project Name"], axis=1)
     df_data = df_data.replace("< Select >", "")
 
-    # Fixes a validation edge case where a user enters a blank cell for a RAG. THis causes the column to be read as
-    # floats, because int type does not allow NAs. These floats are then checked against integer enum values, which fail
-    # validation. This fix works by forcing the type "Int64" (rather than int64), which allows NA integer values.
-    nullable_int_cols = ("Delivery (RAG)", "Spend (RAG)", "Risk (RAG)")
-    for col in nullable_int_cols:
-        try:
-            # use nullable "Int64" type to allow for empty cells in the submission whilst retaining data as ints
-            df_data[col] = df_data[col].astype("Int64")
-        except ValueError:
-            # cannot convert type due to non-numerical data in the cells so leave as object type
-            pass
-
     return df_data
 
 

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -92,11 +92,6 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
         resources_assertions / "project_progress_expected.csv", index_col=0, dtype=str
     )
 
-    # set expected RAG columns to Int64 type in line with transformation logic
-    expected_project_progress[["Delivery (RAG)", "Spend (RAG)", "Risk (RAG)"]] = expected_project_progress[
-        ["Delivery (RAG)", "Spend (RAG)", "Risk (RAG)"]
-    ].astype("Int64")
-
     # fix assertion data
     expected_project_progress["Leading Factor of Delay"] = expected_project_progress["Leading Factor of Delay"].fillna(
         ""

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -143,12 +143,17 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
         resources_assertions / "project_progress_expected.csv", index_col=0, dtype=str
     )
 
-    # set expected RAG columns to Int64 type in line with transformation logic
-    expected_project_progress[["Delivery (RAG)", "Spend (RAG)", "Risk (RAG)"]] = expected_project_progress[
-        ["Delivery (RAG)", "Spend (RAG)", "Risk (RAG)"]
-    ].astype("Int64")
-
     assert_frame_equal(extracted_project_progress, expected_project_progress)
+
+
+def test_extract_project_progress_with_float(mock_progress_sheet, mock_project_lookup):
+    """Test project progress rows extracted without raising a 500 when with a float type in a rag rating column."""
+
+    mock_progress_sheet.iloc[19, 15] = 5.5
+
+    extracted_project_progress = tf.extract_project_progress(mock_progress_sheet, mock_project_lookup)
+
+    assert extracted_project_progress["Risk (RAG)"].dtype != int
 
 
 def test_extract_funding_questions(mock_funding_sheet, mock_programme_lookup):


### PR DESCRIPTION
Fixes issue where putting a float into project progress rag ratings columns causes a 500.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
