### PR TITLE
[SMD-314]: prevent negative numbers in psi

### DIFF
--- a/core/validation/messages.py
+++ b/core/validation/messages.py
@@ -37,5 +37,6 @@ UNAUTHORISED = "You’re not authorised to submit for {wrong_place}. You can onl
 MISSING_OTHER_FUNDING_SOURCES = (
     "You’ve not entered any Other Funding Sources. You must enter at least 1 over all projects."
 )
+NEGATIVE_NUMBER = "You’ve entered a negative number. Enter a positive number."
 # PRE-TRANSFORMATION
 BLANK_SIGN_OFF = "In tab '8 - Review & Sign-Off', cell {cell} is blank but is required."

--- a/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
@@ -15,6 +15,7 @@ from core.validation.specific_validations.towns_fund_round_four import (
     validate_programme_risks,
     validate_project_risks,
     validate_psi_funding_gap,
+    validate_psi_funding_not_negative,
 )
 
 
@@ -31,6 +32,7 @@ def validation_functions_success_mock(mocker):
         "core.validation.specific_validations.towns_fund_round_four.validate_leading_factor_of_delay",
         "core.validation.specific_validations.towns_fund_round_four.validate_funding_spent",
         "core.validation.specific_validations.towns_fund_round_four.validate_funding_profiles_funding_secured_not_null",
+        "core.validation.specific_validations.towns_fund_round_four.validate_psi_funding_not_negative",
     ]
     for function in functions_to_mock:
         # mock function return value
@@ -803,3 +805,75 @@ def test_validate_funding_profiles_funding_secured_not_null():
             row_indexes=[49],
         )
     ]
+
+
+def test_validate_psi_funding_not_negative():
+    psi_df = pd.DataFrame(
+        index=[48, 49, 49],
+        data=[
+            {
+                "Private Sector Funding Required": -100,
+                "Private Sector Funding Secured": 0,
+            },
+            {
+                "Private Sector Funding Required": 0,
+                "Private Sector Funding Secured": 0,
+            },
+            {
+                "Private Sector Funding Required": -1,
+                "Private Sector Funding Secured": -2,
+            },
+        ],
+    )
+    workbook = {"Private Investments": psi_df}
+
+    failures = validate_psi_funding_not_negative(workbook)
+
+    assert failures == [
+        TownsFundRoundFourValidationFailure(
+            sheet="Private Investments",
+            section="Private Sector Investment",
+            column="Private Sector Funding Required",
+            message="You’ve entered a negative number. Enter a positive number.",
+            row_indexes=[48],
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Private Investments",
+            section="Private Sector Investment",
+            column="Private Sector Funding Required",
+            message="You’ve entered a negative number. Enter a positive number.",
+            row_indexes=[49],
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Private Investments",
+            section="Private Sector Investment",
+            column="Private Sector Funding Secured",
+            message="You’ve entered a negative number. Enter a positive number.",
+            row_indexes=[49],
+        ),
+    ]
+
+
+def test_validate_psi_funding_not_negative_with_strings():
+    psi_df = pd.DataFrame(
+        index=[48, 49, 49],
+        data=[
+            {
+                "Private Sector Funding Required": "invalid string",
+                "Private Sector Funding Secured": 0,
+            },
+            {
+                "Private Sector Funding Required": 0,
+                "Private Sector Funding Secured": 0,
+            },
+            {
+                "Private Sector Funding Required": 0,
+                "Private Sector Funding Secured": "invalid string",
+            },
+        ],
+    )
+    workbook = {"Private Investments": psi_df}
+
+    failures = validate_psi_funding_not_negative(workbook)
+
+    assert failures is None


### PR DESCRIPTION
Prevents negative numbers in PSI.

Part of this bug ticket: https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?selectedIssue=SMD-314

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

