### PR TITLE
BAU: fix ints being cast to floats bug

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -361,6 +361,13 @@ def extract_project_progress(df_data: pd.DataFrame, project_lookup: dict, round_
     df_data = df_data.drop(["Project Name"], axis=1)
     df_data = df_data.replace("< Select >", "")
 
+    whole_nums_to_integers_cols = ("Delivery (RAG)", "Spend (RAG)", "Risk (RAG)")
+
+    # RAG ratings of user input '4' can be read into a DataFrame as '4.0'
+    for col in whole_nums_to_integers_cols:
+        if col in df_data.columns:
+            df_data[col] = df_data[col].astype(str).str.rstrip(".0")
+
     return df_data
 
 

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -93,6 +93,9 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
     )
 
     # fix assertion data
+    expected_project_progress["Delivery (RAG)"] = expected_project_progress["Delivery (RAG)"].astype(str)
+    expected_project_progress["Spend (RAG)"] = expected_project_progress["Spend (RAG)"].astype(str)
+    expected_project_progress["Risk (RAG)"] = expected_project_progress["Risk (RAG)"].astype(str)
     expected_project_progress["Leading Factor of Delay"] = expected_project_progress["Leading Factor of Delay"].fillna(
         ""
     )

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -143,17 +143,26 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
         resources_assertions / "project_progress_expected.csv", index_col=0, dtype=str
     )
 
+    # fix assertion data
+    expected_project_progress["Delivery (RAG)"] = expected_project_progress["Delivery (RAG)"].astype(str)
+    expected_project_progress["Spend (RAG)"] = expected_project_progress["Spend (RAG)"].astype(str)
+    expected_project_progress["Risk (RAG)"] = expected_project_progress["Risk (RAG)"].astype(str)
+
     assert_frame_equal(extracted_project_progress, expected_project_progress)
 
 
 def test_extract_project_progress_with_float(mock_progress_sheet, mock_project_lookup):
     """Test project progress rows extracted without raising a 500 when with a float type in a rag rating column."""
 
-    mock_progress_sheet.iloc[19, 15] = 5.5
+    mock_progress_sheet.iloc[19, 7] = 5.5
+    mock_progress_sheet.iloc[18, 7] = 3.0
+    mock_progress_sheet.iloc[19, 8] = "text"
+    mock_progress_sheet.iloc[18, 8] = ""
 
     extracted_project_progress = tf.extract_project_progress(mock_progress_sheet, mock_project_lookup)
 
-    assert extracted_project_progress["Risk (RAG)"].dtype != int
+    assert list(extracted_project_progress["Delivery (RAG)"]) == ["3", "5.5", "2"]
+    assert list(extracted_project_progress["Spend (RAG)"]) == ["", "text", "2"]
 
 
 def test_extract_funding_questions(mock_funding_sheet, mock_programme_lookup):


### PR DESCRIPTION
Fixes ints being cast to floats for RAG rating columns.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")