### PR TITLE
[BAU] return fund type id in ingest response payload

### DIFF
--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -32,8 +32,8 @@ components:
         properties:
           detail:
             type: string
-          programme:
-            type: string
+          metadata:
+            type: object
           title:
             type: string
           status:
@@ -41,7 +41,10 @@ components:
             format: int32
       example: {
         "detail": "Spreadsheet successfully uploaded",
-        "programme": "Blackfriars - Northern City Centre",
+        "metadata": {
+          "programme": "Blackfriars - Northern City Centre",
+          "fund_type": "HS",
+        },
         "status": 200,
         "title": "success",
       }

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -13,6 +13,7 @@ from werkzeug.datastructures import FileStorage
 from core.const import EXCEL_MIMETYPE
 from core.controllers.ingest import (
     extract_data,
+    get_metadata,
     next_submission_id,
     remove_unreferenced_organisations,
     save_submission_file,
@@ -59,6 +60,7 @@ def test_ingest_endpoint(test_client, example_data_model_file):
     assert response.status_code == 200, f"{response.json}"
     assert response.json == {
         "detail": "Spreadsheet successfully uploaded",
+        "metadata": {},
         "status": 200,
         "title": "success",
     }
@@ -618,3 +620,19 @@ def test_remove_unreferenced_org(test_client):
 
     org_3 = Organisation.query.filter_by(organisation_name="Romulan Star Empire").first()
     assert org_3 is None
+
+
+def test_get_metadata():
+    mock_workbook = {
+        "Programme_Ref": pd.DataFrame(data=[{"Programme Name": "Test Programme", "FundType_ID": "Test FundType"}])
+    }
+    metadata = get_metadata(mock_workbook, reporting_round=None)
+    assert metadata == {}
+    metadata = get_metadata(mock_workbook, reporting_round=1)
+    assert metadata == {}
+    metadata = get_metadata(mock_workbook, reporting_round=2)
+    assert metadata == {}
+    metadata = get_metadata(mock_workbook, reporting_round=3)
+    assert metadata == {"Programme Name": "Test Programme", "FundType_ID": "Test FundType"}
+    metadata = get_metadata(mock_workbook, reporting_round=4)
+    assert metadata == {"Programme Name": "Test Programme", "FundType_ID": "Test FundType"}


### PR DESCRIPTION
### Change description
- ingest now returns a metadata JSON object that can contain general information on a submission
- this allows us to add fund type ID to the response for Submit to use to further personalise emails to LAs and TF

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
