### PR TITLE
[SMD-336]: accurate cell mappings for outcomes amount col

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -1037,3 +1037,34 @@ PLACE_TO_FUND_TYPE = {
 }
 
 FUND_TYPE_TO_TD_OR_HS = {"Future_High_Street_Fund": "HS", "Town_Deal": "TD"}
+
+
+# maps the financial year's start year back to original col letter for non-footfall outcomes
+FINANCIAL_YEAR_TO_ORIGINAL_COLUMN_LETTER_FOR_NON_FOOTFALL_OUTCOMES = {
+    2020: "F{i}",
+    2021: "G{i}",
+    2022: "H{i}",
+    2023: "I{i}",
+    2024: "J{i}",
+    2025: "K{i}",
+    2026: "L{i}",
+    2027: "M{i}",
+    2028: "N{i}",
+    2029: "O{i}",
+}
+
+# maps the month of the financial year's start year back to the original column for footfall outcomes
+MONTH_TO_ORIGINAL_COLUMN_LETTER_FOR_FOOTFALL_OUTCOMES = {
+    4: "D{i}",
+    5: "E{i}",
+    6: "F{i}",
+    7: "G{i}",
+    8: "H{i}",
+    9: "I{i}",
+    10: "J{i}",
+    11: "K{i}",
+    12: "L{i}",
+    1: "M{i}",
+    2: "N{i}",
+    3: "O{i}",
+}

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -20,6 +20,7 @@ from core.const import (
 from core.extraction.utils import join_as_string
 from core.util import get_project_number_by_position
 from core.validation.exceptions import UnimplementedErrorMessageException
+from core.validation.utils import get_cell_indexes_for_outcomes
 
 
 class ValidationFailure(ABC):
@@ -191,6 +192,7 @@ class WrongTypeFailure(ValidationFailure):
     expected_type: str
     actual_type: str
     row_indexes: list[int]
+    failed_row: pd.Series | None
 
     def __str__(self):
         """Method to get the string representation of the wrong type failure."""
@@ -203,10 +205,13 @@ class WrongTypeFailure(ValidationFailure):
         sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
         _, section = INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION[self.column]
         actual_type = INTERNAL_TYPE_TO_MESSAGE_FORMAT[self.actual_type]
+        cell_index = construct_cell_index(table=self.sheet, column=self.column, row_indexes=self.row_indexes)
+
         if sheet == "Outcomes":
             _, section = "Financial Year 2022/21 - Financial Year 2029/30", (
                 "Outcome Indicators (excluding " "footfall) and Footfall Indicator"
             )
+            cell_index = get_cell_indexes_for_outcomes(self.failed_row)
 
         if self.expected_type == "datetime64[ns]":
             message = msgs.WRONG_TYPE_DATE.format(wrong_type=actual_type)
@@ -218,8 +223,6 @@ class WrongTypeFailure(ValidationFailure):
             message = msgs.WRONG_TYPE_NUMERICAL
         else:
             message = msgs.WRONG_TYPE_UNKNOWN
-
-        cell_index = construct_cell_index(table=self.sheet, column=self.column, row_indexes=self.row_indexes)
 
         return sheet, section, cell_index, message
 
@@ -293,6 +296,7 @@ class NonNullableConstraintFailure(ValidationFailure):
     sheet: str
     column: str
     row_indexes: list[int]
+    failed_row: pd.Series | None
 
     def to_message(self) -> tuple[str, str, str, str]:
         """Generate error message components for NonNullableConstraintFailure.
@@ -320,6 +324,7 @@ class NonNullableConstraintFailure(ValidationFailure):
             if column == "Financial Year 2022/21 - Financial Year 2025/26":
                 section = "Outcome Indicators (excluding footfall) / Footfall Indicator"
                 message = msgs.BLANK_ZERO
+                cell_index = get_cell_indexes_for_outcomes(self.failed_row)
         elif sheet == "Funding Profiles":
             message = msgs.BLANK_ZERO
         elif section == "Programme-Wide Progress Summary":

--- a/core/validation/utils.py
+++ b/core/validation/utils.py
@@ -1,4 +1,11 @@
+from datetime import datetime
+
 import pandas as pd
+
+from core.const import (
+    FINANCIAL_YEAR_TO_ORIGINAL_COLUMN_LETTER_FOR_NON_FOOTFALL_OUTCOMES,
+    MONTH_TO_ORIGINAL_COLUMN_LETTER_FOR_FOOTFALL_OUTCOMES,
+)
 
 
 def remove_duplicate_indexes(df: pd.DataFrame):
@@ -12,3 +19,47 @@ def remove_duplicate_indexes(df: pd.DataFrame):
     :return: the DataFrame without duplicate indexes
     """
     return df[~df.index.duplicated(keep="first")]
+
+
+def get_cell_indexes_for_outcomes(failed_row: pd.Series) -> str:
+    """
+    Constructs cell indexes for outcomes based on the provided failed row.
+
+    The function determines whether the error occurred in footfall outcomes (starting from row 60)
+    or non-footfall outcomes. If the index is greater than or equal to 60, it calculates the cell
+    index for footfall outcomes based on the provided 'Start_Date'. If the index is less than 60,
+    it calculates the cell index for non-footfall outcomes.
+
+    For footfall outcomes, the cell index is determined by adding a row index gap calculated from
+    the start year of the UK financial year as each year represents an additional 5 rows in the
+    original spreadsheet from the row where the entry for a given footfall outcome's data begins.
+
+    :param failed_row: A pandas Series representing a row where an error has occurred.
+    :return: A string containing the constructed cell index for outcomes.
+    """
+    start_date = failed_row["Start_Date"]
+    financial_year = get_uk_financial_year_start(start_date)
+    index = failed_row.name
+
+    # footfall outcomes starts from row 60
+    if index >= 60:
+        # row for 'Amount' column is end number of start year of financial year * 5 + 'Footfall Indicator' index
+        row_index_gap = int(str(financial_year)[-1]) * 5
+        index = int(index) + row_index_gap
+        cell_index = MONTH_TO_ORIGINAL_COLUMN_LETTER_FOR_FOOTFALL_OUTCOMES[start_date.month].format(i=index)
+    else:
+        cell_index = FINANCIAL_YEAR_TO_ORIGINAL_COLUMN_LETTER_FOR_NON_FOOTFALL_OUTCOMES[financial_year].format(i=index)
+
+    return cell_index
+
+
+def get_uk_financial_year_start(start_date: datetime) -> int:
+    """
+    Gets the start year of the UK financial year based on the provided start date.
+
+    :param start_date: A datetime in the format '%Y-%m-%d %H:%M:%S'.
+    :return: An integer representing the start year of the UK financial year.
+    """
+
+    financial_year = start_date.year if start_date.month >= 4 else start_date.year - 1
+    return financial_year

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -409,7 +409,9 @@ def test_ingest_endpoint_returns_validation_errors(test_client, example_data_mod
         "core.controllers.ingest.validate",
         side_effect=ValidationError(
             validation_failures=[
-                NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[5])
+                NonNullableConstraintFailure(
+                    sheet="Project Progress", column="Start Date", row_indexes=[5], failed_row=None
+                )
             ]
         ),
     )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,11 @@
 import pandas as pd
 from pandas._testing import assert_frame_equal
 
-from core.validation.utils import remove_duplicate_indexes
+from core.validation.utils import (
+    get_cell_indexes_for_outcomes,
+    get_uk_financial_year_start,
+    remove_duplicate_indexes,
+)
 
 
 def test_remove_duplicate_indexes():
@@ -25,3 +29,42 @@ def test_remove_duplicate_indexes():
         ],
     )
     assert_frame_equal(df, expected_df)
+
+
+def test_get_cell_indexes_for_outcomes():
+    failed_row1 = pd.Series({"Start_Date": pd.to_datetime("2024-05-01 12:00:00")}, name=60)
+    failed_row2 = pd.Series({"Start_Date": pd.to_datetime("2022-05-01 12:00:00")}, name=60)
+    failed_row3 = pd.Series({"Start_Date": pd.to_datetime("2022-03-01 12:00:00")}, name=22)
+    failed_row4 = pd.Series({"Start_Date": pd.to_datetime("2021-12-01 12:00:00")}, name=23)
+
+    cell1 = get_cell_indexes_for_outcomes(failed_row1)
+    cell2 = get_cell_indexes_for_outcomes(failed_row2)
+    cell3 = get_cell_indexes_for_outcomes(failed_row3)
+    cell4 = get_cell_indexes_for_outcomes(failed_row4)
+
+    assert cell1 == "E80"
+    assert cell2 == "E70"
+    assert cell3 == "G22"
+    assert cell4 == "G23"
+
+
+def test_get_uk_financial_year_start():
+    # Test case where start_date is in the same financial year
+    start_date_1 = pd.to_datetime("2023-05-01 12:00:00")
+    result_1 = get_uk_financial_year_start(start_date_1)
+    assert result_1 == 2023
+
+    # Test case where start_date is in the previous financial year
+    start_date_2 = pd.to_datetime("2022-10-01 12:00:00")
+    result_2 = get_uk_financial_year_start(start_date_2)
+    assert result_2 == 2022
+
+    # Test case where start_date is exactly on the financial year start
+    start_date_3 = pd.to_datetime("2023-04-01 00:00:00")
+    result_3 = get_uk_financial_year_start(start_date_3)
+    assert result_3 == 2023
+
+    # Test case where start_date is before the financial year start
+    start_date_4 = pd.to_datetime("2023-03-01 00:00:00")
+    result_4 = get_uk_financial_year_start(start_date_4)
+    assert result_4 == 2022

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -171,51 +171,103 @@ def test_invalid_enum_messages():
 
 
 def test_non_nullable_messages_project_details():
-    NonNullableConstraintFailure(sheet="Project Details", column="Locations", row_indexes=[15, 16]).to_message()
-    NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_indexes=[21, 22]).to_message()
-    NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[1, 2]).to_message()
-    NonNullableConstraintFailure(sheet="Project Progress", column="Completion Date", row_indexes=[4]).to_message()
+    failed_rows = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=22)
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_indexes=[2]
+        sheet="Project Details", column="Locations", row_indexes=[15, 16], failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Most Important Upcoming Comms Milestone", row_indexes=[7]
+        sheet="Project Details", column="Lat/Long", row_indexes=[21, 22], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress", column="Start Date", row_indexes=[1, 2], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress", column="Completion Date", row_indexes=[4], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_indexes=[2], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress",
+        column="Most Important Upcoming Comms Milestone",
+        row_indexes=[7],
+        failed_row=None,
     ).to_message()
     NonNullableConstraintFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         row_indexes=[6],
+        failed_row=None,
     ).to_message()
-    NonNullableConstraintFailure(sheet="Programme Progress", column="Answer", row_indexes=[4]).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Current Project Delivery Stage", row_indexes=[3]
+        sheet="Programme Progress", column="Answer", row_indexes=[4], failed_row=None
     ).to_message()
-    NonNullableConstraintFailure(sheet="Outcome_Data", column="UnitofMeasurement", row_indexes=[16, 21]).to_message()
-    NonNullableConstraintFailure(sheet="Outcome_Data", column="Amount", row_indexes=[5]).to_message()
-    NonNullableConstraintFailure(sheet="Outcome_Data", column="GeographyIndicator", row_indexes=[5, 6]).to_message()
-    NonNullableConstraintFailure(sheet="Output_Data", column="Unit of Measurement", row_indexes=[17, 22]).to_message()
-    NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_indexes=[6]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description", row_indexes=[20]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="Full Description", row_indexes=[21]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="Consequences", row_indexes=[22]).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Mitigatons", row_indexes=[23]
+        sheet="Project Progress", column="Current Project Delivery Stage", row_indexes=[3], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Outcome_Data",
+        column="UnitofMeasurement",
+        row_indexes=[16, 21],
+        failed_row=failed_rows,
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Outcome_Data",
+        column="Amount",
+        row_indexes=[5],
+        failed_row=failed_rows,
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Outcome_Data",
+        column="GeographyIndicator",
+        row_indexes=[5, 6],
+        failed_row=failed_rows,
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Output_Data", column="Unit of Measurement", row_indexes=[17, 22], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_indexes=[6], failed_row=None).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Short Description", row_indexes=[20], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Full Description", row_indexes=[21], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Consequences", row_indexes=[22], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Mitigatons", row_indexes=[23], failed_row=None
     ).to_message()  # typo throughout code
-    NonNullableConstraintFailure(sheet="RiskRegister", column="RiskOwnerRole", row_indexes=[24]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName", row_indexes=[25]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="RiskCategory", row_indexes=[26]).to_message()
-    NonNullableConstraintFailure(sheet="Funding", column="Spend for Reporting Period", row_indexes=[7]).to_message()
-    NonNullableConstraintFailure(sheet="Project Progress", column="Start Date", row_indexes=[2, 3]).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="Short Description", row_indexes=[5, 6]).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="RiskOwnerRole", row_indexes=[24], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="RiskName", row_indexes=[25], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="RiskCategory", row_indexes=[26], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Funding", column="Spend for Reporting Period", row_indexes=[7], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress", column="Start Date", row_indexes=[2, 3], failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Short Description", row_indexes=[5, 6], failed_row=None
+    ).to_message()
 
 
 def test_wrong_type_messages():
+    failed_rows = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=22)
     WrongTypeFailure(
         sheet="Project Progress",
         column="Start Date",
         expected_type="datetime64[ns]",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Project Progress",
@@ -223,6 +275,7 @@ def test_wrong_type_messages():
         expected_type="datetime64[ns]",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Project Progress",
@@ -230,6 +283,7 @@ def test_wrong_type_messages():
         expected_type="datetime64[ns]",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Private Investments",
@@ -237,6 +291,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Private Investments",
@@ -244,6 +299,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Funding",
@@ -251,6 +307,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Output_Data",
@@ -258,6 +315,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     ).to_message()
     WrongTypeFailure(
         sheet="Outcome_Data",
@@ -265,6 +323,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="string",
         row_indexes=[22],
+        failed_row=failed_rows,
     ).to_message()
     WrongTypeFailure(
         sheet="Outcome_Data",
@@ -272,6 +331,7 @@ def test_wrong_type_messages():
         expected_type="float64",
         actual_type="object",
         row_indexes=[22],
+        failed_row=failed_rows,
     ).to_message()
 
 
@@ -391,13 +451,16 @@ def test_failures_to_messages():
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         value="Value",
     )
-    failure2 = NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_indexes=[1])
+    failure2 = NonNullableConstraintFailure(
+        sheet="Project Details", column="Lat/Long", row_indexes=[1], failed_row=None
+    )
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
         row_indexes=[22],
+        failed_row=None,
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
@@ -538,3 +601,35 @@ def test_remove_errors_already_caught_by_null_failure_risks():
         ("Tab 1", "Project Risks - Project 2", "C19", "Some other message"),
         ("Tab 1", "Programme / Project Risks", "C12, C13, C17", "The cell is blank but is required."),
     ]
+
+
+def test_failures_to_message_with_outcomes_column_amount():
+    failed_rows1 = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=60)
+    failed_rows2 = pd.Series({"Start_Date": pd.to_datetime("2023-06-01 12:00:00")}, name=23)
+    failure1 = NonNullableConstraintFailure(
+        sheet="Outcome_Data",
+        column="Amount",
+        row_indexes=[60],
+        failed_row=failed_rows1,
+    )
+    failure2 = WrongTypeFailure(
+        sheet="Outcome_Data",
+        column="Amount",
+        expected_type="float64",
+        actual_type="string",
+        row_indexes=[23],
+        failed_row=failed_rows2,
+    )
+
+    assert failure1.to_message() == (
+        "Outcomes",
+        "Outcome Indicators (excluding footfall) / Footfall Indicator",
+        "E75",
+        "The cell is blank but is required. Enter a value, even if it’s zero.",
+    )
+    assert failure2.to_message() == (
+        "Outcomes",
+        "Outcome Indicators (excluding footfall) and Footfall Indicator",
+        "I23",
+        "You entered text instead of a number. Remove any units of measurement and only use numbers, for example, 9.",
+    )

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -191,15 +191,15 @@ def test_validate_types_invalid_exp_str_got_int(valid_workbook_and_schema):
         column_to_type=schema["Project Sheet"]["columns"],
     )
 
-    assert failures == [
-        WrongTypeFailure(
-            sheet="Project Sheet",
-            column="Project_ID",
-            expected_type="string",
-            actual_type="int64",
-            row_indexes=[6],
-        )
-    ]
+    # unable to write a simple assertion when validation failure contains a Series
+    assert len(failures) == 1
+    assert isinstance(failures[0], WrongTypeFailure)
+    assert failures[0].sheet == "Project Sheet"
+    assert failures[0].column == "Project_ID"
+    assert failures[0].expected_type == "string"
+    assert failures[0].actual_type == "int64"
+    assert failures[0].row_indexes == [6]
+    assert "Start_Date" not in failures[0].failed_row
 
 
 def test_validate_types_invalid_exp_bool_got_str(valid_workbook_and_schema):
@@ -213,15 +213,14 @@ def test_validate_types_invalid_exp_bool_got_str(valid_workbook_and_schema):
         column_to_type=schema["Project Sheet"]["columns"],
     )
 
-    assert failures == [
-        WrongTypeFailure(
-            sheet="Project Sheet",
-            column="Project Started",
-            expected_type="bool",
-            actual_type="string",
-            row_indexes=[5],
-        )
-    ]
+    assert len(failures) == 1
+    assert isinstance(failures[0], WrongTypeFailure)
+    assert failures[0].sheet == "Project Sheet"
+    assert failures[0].column == "Project Started"
+    assert failures[0].expected_type == "bool"
+    assert failures[0].actual_type == "string"
+    assert failures[0].row_indexes == [5]
+    assert "Start_Date" not in failures[0].failed_row
 
 
 def test_validate_types_invalid_exp_datetime_got_str(valid_workbook_and_schema):
@@ -235,15 +234,14 @@ def test_validate_types_invalid_exp_datetime_got_str(valid_workbook_and_schema):
         column_to_type=schema["Project Sheet"]["columns"],
     )
 
-    assert failures == [
-        WrongTypeFailure(
-            sheet="Project Sheet",
-            column="Date Started",
-            expected_type="datetime64[ns]",
-            actual_type="string",
-            row_indexes=[7],
-        )
-    ]
+    assert len(failures) == 1
+    assert isinstance(failures[0], WrongTypeFailure)
+    assert failures[0].sheet == "Project Sheet"
+    assert failures[0].column == "Date Started"
+    assert failures[0].expected_type == "datetime64[ns]"
+    assert failures[0].actual_type == "string"
+    assert failures[0].row_indexes == [7]
+    assert "Start_Date" not in failures[0].failed_row
 
 
 def test_validate_types_invalid_float_type(valid_workbook_and_schema):
@@ -257,15 +255,14 @@ def test_validate_types_invalid_float_type(valid_workbook_and_schema):
         column_to_type=schema["Project Sheet"]["columns"],
     )
 
-    assert failures == [
-        WrongTypeFailure(
-            sheet="Project Sheet",
-            column="Funding Cost",
-            expected_type="float64",
-            actual_type="string",
-            row_indexes=[5],
-        )
-    ]
+    assert len(failures) == 1
+    assert isinstance(failures[0], WrongTypeFailure)
+    assert failures[0].sheet == "Project Sheet"
+    assert failures[0].column == "Funding Cost"
+    assert failures[0].expected_type == "float64"
+    assert failures[0].actual_type == "string"
+    assert failures[0].row_indexes == [5]
+    assert "Start_Date" not in failures[0].failed_row
 
 
 def test_validate_types_float_and_int_type(valid_workbook_and_schema):
@@ -280,6 +277,36 @@ def test_validate_types_float_and_int_type(valid_workbook_and_schema):
     )
 
     assert not failures
+
+
+def test_validate_wrong_type_captures_failed_row(valid_workbook_and_schema):
+    workbook, schema = valid_workbook_and_schema
+
+    workbook["Project Sheet"]["Funding Cost"] = [1002.2, 10.2, "0.1"]
+
+    failures = validate_types(
+        workbook=workbook,
+        sheet_name="Project Sheet",
+        column_to_type=schema["Project Sheet"]["columns"],
+    )
+
+    expected_failed_row = pd.Series(
+        {
+            "Project Started": True,
+            "Package_ID": "ABC003",
+            "Funding Cost": "0.1",
+            "Project_ID": "PID003",
+            "Amount of funds": 12,
+            "Date Started": DUMMY_DATETIME,
+            "Fund_ID": "F003",
+            "Lookup": "Lookup3",
+            "LookupNullable": "",
+            "ColumnOfEnums": "EnumValueB",
+        }
+    )
+
+    assert len(failures) == 1
+    assert failures[0].failed_row.equals(expected_failed_row)
 
 
 ####################################
@@ -723,13 +750,47 @@ def test_validate_non_nullable_failure(valid_workbook_and_schema):
         non_nullable=["Project_ID"],
     )
 
-    assert failures == [
-        NonNullableConstraintFailure(
-            sheet="Project Sheet",
-            column="Project_ID",
-            row_indexes=[6, 7],
-        )
-    ]
+    assert len(failures) == 2
+    assert isinstance(failures[0], NonNullableConstraintFailure)
+    assert failures[0].sheet == "Project Sheet"
+    assert failures[0].column == "Project_ID"
+    assert failures[0].row_indexes == [6]
+    assert "Start_Date" not in failures[0].failed_row
+
+    assert isinstance(failures[1], NonNullableConstraintFailure)
+    assert failures[1].sheet == "Project Sheet"
+    assert failures[1].column == "Project_ID"
+    assert failures[1].row_indexes == [7]
+    assert "Start_Date" not in failures[1].failed_row
+
+
+def test_validate_non_nullable_captures_failed_row(valid_workbook_and_schema):
+    workbook, schema = valid_workbook_and_schema
+    workbook["Project Sheet"]["Project_ID"] = ["PID001", "PID0002", ""]
+
+    failures = validate_nullable(
+        workbook=workbook,
+        sheet_name="Project Sheet",
+        non_nullable=["Project_ID"],
+    )
+
+    expected_failed_row = pd.Series(
+        {
+            "Project Started": True,
+            "Package_ID": "ABC003",
+            "Funding Cost": 112339.20000,
+            "Project_ID": "",
+            "Amount of funds": 12,
+            "Date Started": DUMMY_DATETIME,
+            "Fund_ID": "F003",
+            "Lookup": "Lookup3",
+            "LookupNullable": "",
+            "ColumnOfEnums": "EnumValueB",
+        }
+    )
+
+    assert len(failures) == 1
+    assert failures[0].failed_row.equals(expected_failed_row)
 
 
 ####################################


### PR DESCRIPTION
Implements functionality where by errors in the 'Amount' column for Outcomes are accurately mapped back to the original cell location in which that error has occurred.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")