### PR TITLE
[SMD-386]: make cols nullable depending on if project is complete

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -1047,6 +1047,7 @@ PLACE_TO_FUND_TYPE = {
     "Barrow": {"TD"},
 }
 
+
 FUND_TYPE_TO_TD_OR_HS = {"Future_High_Street_Fund": "HS", "Town_Deal": "TD"}
 
 

--- a/core/validation/const.py
+++ b/core/validation/const.py
@@ -1,0 +1,5 @@
+import numpy as np
+import pandas as pd
+
+# values we treat as null
+NA_VALUES = {"", np.nan, None, pd.NA}

--- a/core/validation/messages.py
+++ b/core/validation/messages.py
@@ -2,6 +2,7 @@ from core.const import TF_ROUND_4_TEMPLATE_VERSION
 
 # BLANK MESSAGES
 BLANK = "The cell is blank but is required."
+BLANK_IF_PROJECT_INCOMPLETE = "The cell is blank but is required for incomplete projects."
 BLANK_UNIT_OF_MEASUREMENT = (
     BLANK + "Check you’ve entered or generated a unit of measurement.\n"
     "If it’s for a custom indicator, enter the unit of measurement into the blank cell.\n"

--- a/core/validation/utils.py
+++ b/core/validation/utils.py
@@ -8,6 +8,7 @@ from core.const import (
     FINANCIAL_YEAR_TO_ORIGINAL_COLUMN_LETTER_FOR_NON_FOOTFALL_OUTCOMES,
     MONTH_TO_ORIGINAL_COLUMN_LETTER_FOR_FOOTFALL_OUTCOMES,
 )
+from core.validation.const import NA_VALUES
 
 
 def remove_duplicate_indexes(df: pd.DataFrame):
@@ -110,3 +111,14 @@ def get_uk_financial_year_start(start_date: datetime) -> int:
 
     financial_year = start_date.year if start_date.month >= 4 else start_date.year - 1
     return financial_year
+
+
+def find_null_values(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """
+    Helper function to find rows with null values in a specified column.
+
+    :param df: DataFrame to search for invalid rows.
+    :param column: Column name to check for null values.
+    :return: DataFrame containing rows with null values in the specified column.
+    """
+    return df[df[column].isin(NA_VALUES)]

--- a/core/validation_schema.py
+++ b/core/validation_schema.py
@@ -144,7 +144,7 @@ ROUND_FOUR_TF_SCHEMA = {
             "Project ID",
             "Start Date",
             "Completion Date",
-            "Current Project Delivery Stage",
+            # Current Project Delivery Status is sometimes nullable so has its own specific validation
             "Project Delivery Status",
             # Leading Factor of Delay is sometimes nullable so has its own specific validation
             "Project Adjustment Request Status",
@@ -152,9 +152,8 @@ ROUND_FOUR_TF_SCHEMA = {
             "Spend (RAG)",
             "Risk (RAG)",
             "Commentary on Status and RAG Ratings",
-            "Most Important Upcoming Comms Milestone",
-            "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
-            # TODO: Added all fields for Round 4 (was previously only Project ID)
+            # Most Important Upcoming Comms Milestone is sometimes nullable so has its own specific validation
+            # This also applies to Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)
         ],
     },
     "Funding": {

--- a/tests/validation_tests/test_utils.py
+++ b/tests/validation_tests/test_utils.py
@@ -8,6 +8,7 @@ from pandas._testing import assert_frame_equal
 
 from core.util import get_project_number_by_id, get_project_number_by_position
 from core.validation.utils import (
+    find_null_values,
     get_cell_indexes_for_outcomes,
     get_uk_financial_year_start,
     is_blank,
@@ -164,3 +165,25 @@ def test_get_uk_financial_year_start():
     start_date_4 = pd.to_datetime("2023-03-01 00:00:00")
     result_4 = get_uk_financial_year_start(start_date_4)
     assert result_4 == 2022
+
+
+def test_find_null_values():
+    df = pd.DataFrame(
+        index=[7, 9],
+        data=[
+            {"not-nullable": "", "nullable": ""},
+            {"not-nullable": "random input", "nullable": ""},
+        ],
+    )
+    column = "not-nullable"
+
+    invalid_rows = find_null_values(df, column)
+
+    expected_invalid_rows = pd.DataFrame(
+        index=[7],
+        data=[
+            {"not-nullable": "", "nullable": ""},
+        ],
+    )
+
+    assert_frame_equal(invalid_rows, expected_invalid_rows)


### PR DESCRIPTION
When a project is complete, "Currently Project Delivery Stage" and columns pertaining to upcoming comms milestones are now nullable.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
