### PR TITLE
[SMD-391]: remove submission id autoincrement

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 EXCEL_MIMETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 DATETIME_ISO_8601 = "%Y-%m-%dT%H:%M:%S%z"
-SUBMISSION_ID_FORMAT = "S-R{0:0=2d}-{1}"
+SUBMISSION_ID_FORMAT = "S-R{0:0=2d}-{hash}"
 FAILED_FILE_S3_NAME_FORMAT = "{}_{}.xlsx"
 TF_ROUND_4_TEMPLATE_VERSION = "v4.3"
 


### PR DESCRIPTION
Remove autoincremented generation of submission id and replace it with a randomly generated 6 character hash at the end.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
