### PR TITLE
[BAU] validation failure refactor

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas.tseries.offsets import MonthEnd
 
 import core.validation.failures as vf
+import core.validation.messages as msgs
 from core.const import (
     OUTCOME_CATEGORIES,
     OUTPUT_CATEGORIES,
@@ -856,14 +857,19 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
     if invalid_projects := relevant_projects - set(project_lookup.keys()):
         raise ValidationError(
             [
-                vf.InvalidOutcomeProjectFailure(
-                    invalid_project=row["Relevant project(s)"],
+                vf.GenericFailure(
+                    sheet="Outcomes",
                     section="Outcome Indicators (excluding footfall)",
-                    row_indexes=[idx + 2],  # +2 here as caught mid-ingest before post-transformation incrementation
+                    # +2 here as caught mid-ingest before post-transformation incrementation
+                    cell_index=vf.construct_cell_index(
+                        table="Outcome_Data", column="Relevant project(s)", row_index=idx + 2
+                    ),
+                    message=msgs.DROPDOWN,
                 )
-                for idx, row in outcomes_df.loc[outcomes_df["Relevant project(s)"].isin(invalid_projects)].iterrows()
+                for idx, _ in outcomes_df.loc[outcomes_df["Relevant project(s)"].isin(invalid_projects)].iterrows()
             ]
         )
+
     # Drop rows with Section header selected as the outcome from dropdown on form - This is not a valid outcome option.
     outcomes_df.drop(outcomes_df[outcomes_df["Relevant project(s)"] == "*** ORIGINAL: ***"].index, inplace=True)
     outcomes_df.insert(0, "Project ID", outcomes_df["Relevant project(s)"].map(project_lookup))
@@ -959,9 +965,13 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
         # validation error raised here as post-transformation the project lookup information is lost
         raise ValidationError(
             [
-                vf.InvalidOutcomeProjectFailure(
-                    invalid_project=row["Relevant Project(s)"], section="Footfall Indicator", row_indexes=[idx + 2 + 5]
-                )  # +2 to match original spreadsheet index, extra +5 for Outcome -> Project row
+                vf.GenericFailure(
+                    sheet="Outcomes",
+                    section="Footfall Indicator",
+                    # +2 to match original spreadsheet index, extra +5 for Outcome -> Project row
+                    cell_index=f"B{idx + 2 + 5}",
+                    message=msgs.DROPDOWN,
+                )
                 for idx, row in footfall_df.loc[footfall_df["Relevant Project(s)"].isin(invalid_projects)].iterrows()
             ]
         )

--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from pandas.tseries.offsets import MonthEnd
 
-import core.validation.failures as vf
+import core.validation.failures.user as uf
 import core.validation.messages as msgs
 from core.const import (
     OUTCOME_CATEGORIES,
@@ -857,11 +857,11 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
     if invalid_projects := relevant_projects - set(project_lookup.keys()):
         raise ValidationError(
             [
-                vf.GenericFailure(
+                uf.GenericFailure(
                     sheet="Outcomes",
                     section="Outcome Indicators (excluding footfall)",
                     # +2 here as caught mid-ingest before post-transformation incrementation
-                    cell_index=vf.construct_cell_index(
+                    cell_index=uf.construct_cell_index(
                         table="Outcome_Data", column="Relevant project(s)", row_index=idx + 2
                     ),
                     message=msgs.DROPDOWN,
@@ -965,7 +965,7 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
         # validation error raised here as post-transformation the project lookup information is lost
         raise ValidationError(
             [
-                vf.GenericFailure(
+                uf.GenericFailure(
                     sheet="Outcomes",
                     section="Footfall Indicator",
                     # +2 to match original spreadsheet index, extra +5 for Outcome -> Project row

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -8,7 +8,7 @@ from config import Config
 from core.aws import upload_file
 from core.const import DATETIME_ISO_8601, FAILED_FILE_S3_NAME_FORMAT
 from core.exceptions import ValidationError
-from core.validation.failures import failures_to_messages
+from core.validation.failures.user import failures_to_messages
 
 
 def handle_validation_error(validation_error: ValidationError) -> Exception | tuple[dict, int]:

--- a/core/validation/failures.py
+++ b/core/validation/failures.py
@@ -39,89 +39,6 @@ class PreTransFormationFailure(ValidationFailure, ABC):
 
 
 @dataclass
-class ExtraSheetFailure(ValidationFailure):
-    """Class representing an extra sheet failure."""
-
-    extra_sheet: str
-
-    def __str__(self):
-        """
-        Method to get the string representation of the extra sheet failure.
-        """
-        return (
-            "Extra Sheets Failure: The workbook included a sheet named"
-            f'"{self.extra_sheet}" but it is not in the schema.'
-        )
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
-class EmptySheetFailure(ValidationFailure):
-    """Class representing an empty sheet failure."""
-
-    empty_sheet: str
-
-    def __str__(self):
-        """Method to get the string representation of the empty sheet failure."""
-        return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contains no ' "data."
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
-class ExtraColumnFailure(ValidationFailure):
-    """Class representing an extra column failure."""
-
-    sheet: str
-    extra_column: str
-
-    def __str__(self):
-        """
-        Method to get the string representation of the extra column failure.
-        """
-        return f'Extra Column Failure: Sheet "{self.sheet}" Column' f' "{self.extra_column}" is not in the schema.'
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
-class MissingColumnFailure(ValidationFailure):
-    """Class representing a missing column failure."""
-
-    sheet: str
-    missing_column: str
-
-    def __str__(self):
-        """Method to get the string representation of the missing column failure."""
-        return (
-            f'Missing Column Failure: Sheet "{self.sheet}" Column'
-            f' "{self.missing_column}" is missing from the schema.'
-        )
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
-class NonUniqueFailure(ValidationFailure):
-    """Class representing a non-unique value failure."""
-
-    sheet: str
-    column: str
-
-    def __str__(self):
-        """Method to get the string representation of the non-unique value failure."""
-        return f'Non Unique Failure: Sheet "{self.sheet}" column "{self.column}" should ' f"contain only unique values."
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
 class NonUniqueCompositeKeyFailure(ValidationFailure):
     """Class representing a non-unique-composite_key failure."""
 
@@ -228,30 +145,6 @@ class WrongTypeFailure(ValidationFailure):
 
 
 @dataclass
-class OrphanedRowFailure(ValidationFailure):
-    """Class representing an orphaned row failure."""
-
-    sheet: str
-    row: int
-    foreign_key: str
-    fk_value: Any
-    parent_table: str
-    parent_pk: str
-
-    def __str__(self):
-        """Method to get the string representation of the orphaned row failure."""
-        return (
-            f'Orphaned Row Failure: Sheet "{self.sheet}" Column "{self.foreign_key}" '
-            f"Row {self.row} "
-            f'Value "{self.fk_value}" not in parent table '
-            f'"{self.parent_table}" where PK "{self.parent_pk}"'
-        )
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
-
-@dataclass
 class InvalidEnumValueFailure(ValidationFailure):
     """Class representing an invalid enum value failure."""
 
@@ -343,23 +236,6 @@ class WrongInputFailure(PreTransFormationFailure):
 
     def to_message(self) -> tuple[str | None, str | None, str]:
         return None, None, msgs.PRE_TRANSFORMATION_MESSAGES[self.value_descriptor]
-
-
-@dataclass
-class InvalidSheetFailure(ValidationFailure):
-    """Class representing an invalid sheet failure."""
-
-    invalid_sheet: str
-
-    def __str__(self):
-        """Method to get the string representation of the empty sheet failure."""
-        return (
-            f"Invalid Sheets Failure: The sheet named {self.invalid_sheet} is invalid "
-            f"as it is missing expected values"
-        )
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
 
 
 @dataclass

--- a/core/validation/failures/dev.py
+++ b/core/validation/failures/dev.py
@@ -2,12 +2,14 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
-from core.validation.exceptions import UnimplementedErrorMessageException
-from core.validation.failures import ValidationFailureMixin
+from core.validation.failures.user import ValidationFailureMixin
 
 
-class NonUserFacingValidationFailure(ValidationFailureMixin):
-    """Historical Validation Failures do not support validation messages."""
+class DevValidationFailure(ValidationFailureMixin):
+    """Validation Failures that do not support validation messages.
+
+    These are only raised during the development and testing of new validation pipelines.
+    """
 
     @abstractmethod
     def __str__(self):
@@ -15,7 +17,7 @@ class NonUserFacingValidationFailure(ValidationFailureMixin):
 
 
 @dataclass
-class ExtraSheetFailure(NonUserFacingValidationFailure):
+class ExtraSheetFailure(DevValidationFailure):
     """Class representing an extra sheet failure."""
 
     extra_sheet: str
@@ -29,12 +31,9 @@ class ExtraSheetFailure(NonUserFacingValidationFailure):
             f'"{self.extra_sheet}" but it is not in the schema.'
         )
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class EmptySheetFailure(NonUserFacingValidationFailure):
+class EmptySheetFailure(DevValidationFailure):
     """Class representing an empty sheet failure."""
 
     empty_sheet: str
@@ -43,12 +42,9 @@ class EmptySheetFailure(NonUserFacingValidationFailure):
         """Method to get the string representation of the empty sheet failure."""
         return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contains no ' "data."
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class ExtraColumnFailure(NonUserFacingValidationFailure):
+class ExtraColumnFailure(DevValidationFailure):
     """Class representing an extra column failure."""
 
     sheet: str
@@ -60,12 +56,9 @@ class ExtraColumnFailure(NonUserFacingValidationFailure):
         """
         return f'Extra Column Failure: Sheet "{self.sheet}" Column' f' "{self.extra_column}" is not in the schema.'
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class MissingColumnFailure(NonUserFacingValidationFailure):
+class MissingColumnFailure(DevValidationFailure):
     """Class representing a missing column failure."""
 
     sheet: str
@@ -78,12 +71,9 @@ class MissingColumnFailure(NonUserFacingValidationFailure):
             f' "{self.missing_column}" is missing from the schema.'
         )
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class NonUniqueFailure(NonUserFacingValidationFailure):
+class NonUniqueFailure(DevValidationFailure):
     """Class representing a non-unique value failure."""
 
     sheet: str
@@ -93,12 +83,9 @@ class NonUniqueFailure(NonUserFacingValidationFailure):
         """Method to get the string representation of the non-unique value failure."""
         return f'Non Unique Failure: Sheet "{self.sheet}" column "{self.column}" should ' f"contain only unique values."
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class OrphanedRowFailure(NonUserFacingValidationFailure):
+class OrphanedRowFailure(DevValidationFailure):
     """Class representing an orphaned row failure."""
 
     sheet: str
@@ -117,12 +104,9 @@ class OrphanedRowFailure(NonUserFacingValidationFailure):
             f'"{self.parent_table}" where PK "{self.parent_pk}"'
         )
 
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException
-
 
 @dataclass
-class InvalidSheetFailure(NonUserFacingValidationFailure):
+class InvalidSheetFailure(DevValidationFailure):
     """Class representing an invalid sheet failure."""
 
     invalid_sheet: str
@@ -133,6 +117,3 @@ class InvalidSheetFailure(NonUserFacingValidationFailure):
             f"Invalid Sheets Failure: The sheet named {self.invalid_sheet} is invalid "
             f"as it is missing expected values"
         )
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        raise UnimplementedErrorMessageException

--- a/core/validation/historical.py
+++ b/core/validation/historical.py
@@ -1,13 +1,21 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
-from core.validation import messages as msgs
 from core.validation.exceptions import UnimplementedErrorMessageException
-from core.validation.failures import PreTransFormationFailure, ValidationFailure
+from core.validation.failures import ValidationFailureMixin
+
+
+class NonUserFacingValidationFailure(ValidationFailureMixin):
+    """Historical Validation Failures do not support validation messages."""
+
+    @abstractmethod
+    def __str__(self):
+        pass
 
 
 @dataclass
-class ExtraSheetFailure(ValidationFailure):
+class ExtraSheetFailure(NonUserFacingValidationFailure):
     """Class representing an extra sheet failure."""
 
     extra_sheet: str
@@ -26,7 +34,7 @@ class ExtraSheetFailure(ValidationFailure):
 
 
 @dataclass
-class EmptySheetFailure(ValidationFailure):
+class EmptySheetFailure(NonUserFacingValidationFailure):
     """Class representing an empty sheet failure."""
 
     empty_sheet: str
@@ -40,7 +48,7 @@ class EmptySheetFailure(ValidationFailure):
 
 
 @dataclass
-class ExtraColumnFailure(ValidationFailure):
+class ExtraColumnFailure(NonUserFacingValidationFailure):
     """Class representing an extra column failure."""
 
     sheet: str
@@ -57,7 +65,7 @@ class ExtraColumnFailure(ValidationFailure):
 
 
 @dataclass
-class MissingColumnFailure(ValidationFailure):
+class MissingColumnFailure(NonUserFacingValidationFailure):
     """Class representing a missing column failure."""
 
     sheet: str
@@ -75,7 +83,7 @@ class MissingColumnFailure(ValidationFailure):
 
 
 @dataclass
-class NonUniqueFailure(ValidationFailure):
+class NonUniqueFailure(NonUserFacingValidationFailure):
     """Class representing a non-unique value failure."""
 
     sheet: str
@@ -90,7 +98,7 @@ class NonUniqueFailure(ValidationFailure):
 
 
 @dataclass
-class OrphanedRowFailure(ValidationFailure):
+class OrphanedRowFailure(NonUserFacingValidationFailure):
     """Class representing an orphaned row failure."""
 
     sheet: str
@@ -114,19 +122,7 @@ class OrphanedRowFailure(ValidationFailure):
 
 
 @dataclass
-class WrongInputFailure(PreTransFormationFailure):
-    """Class representing a wrong input pre-transformation failure."""
-
-    value_descriptor: str
-    entered_value: str
-    expected_values: set
-
-    def to_message(self) -> tuple[str | None, str | None, str]:
-        return None, None, msgs.PRE_TRANSFORMATION_MESSAGES[self.value_descriptor]
-
-
-@dataclass
-class InvalidSheetFailure(ValidationFailure):
+class InvalidSheetFailure(NonUserFacingValidationFailure):
     """Class representing an invalid sheet failure."""
 
     invalid_sheet: str

--- a/core/validation/historical.py
+++ b/core/validation/historical.py
@@ -1,0 +1,142 @@
+from dataclasses import dataclass
+from typing import Any
+
+from core.validation import messages as msgs
+from core.validation.exceptions import UnimplementedErrorMessageException
+from core.validation.failures import PreTransFormationFailure, ValidationFailure
+
+
+@dataclass
+class ExtraSheetFailure(ValidationFailure):
+    """Class representing an extra sheet failure."""
+
+    extra_sheet: str
+
+    def __str__(self):
+        """
+        Method to get the string representation of the extra sheet failure.
+        """
+        return (
+            "Extra Sheets Failure: The workbook included a sheet named"
+            f'"{self.extra_sheet}" but it is not in the schema.'
+        )
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class EmptySheetFailure(ValidationFailure):
+    """Class representing an empty sheet failure."""
+
+    empty_sheet: str
+
+    def __str__(self):
+        """Method to get the string representation of the empty sheet failure."""
+        return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contains no ' "data."
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class ExtraColumnFailure(ValidationFailure):
+    """Class representing an extra column failure."""
+
+    sheet: str
+    extra_column: str
+
+    def __str__(self):
+        """
+        Method to get the string representation of the extra column failure.
+        """
+        return f'Extra Column Failure: Sheet "{self.sheet}" Column' f' "{self.extra_column}" is not in the schema.'
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class MissingColumnFailure(ValidationFailure):
+    """Class representing a missing column failure."""
+
+    sheet: str
+    missing_column: str
+
+    def __str__(self):
+        """Method to get the string representation of the missing column failure."""
+        return (
+            f'Missing Column Failure: Sheet "{self.sheet}" Column'
+            f' "{self.missing_column}" is missing from the schema.'
+        )
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class NonUniqueFailure(ValidationFailure):
+    """Class representing a non-unique value failure."""
+
+    sheet: str
+    column: str
+
+    def __str__(self):
+        """Method to get the string representation of the non-unique value failure."""
+        return f'Non Unique Failure: Sheet "{self.sheet}" column "{self.column}" should ' f"contain only unique values."
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class OrphanedRowFailure(ValidationFailure):
+    """Class representing an orphaned row failure."""
+
+    sheet: str
+    row: int
+    foreign_key: str
+    fk_value: Any
+    parent_table: str
+    parent_pk: str
+
+    def __str__(self):
+        """Method to get the string representation of the orphaned row failure."""
+        return (
+            f'Orphaned Row Failure: Sheet "{self.sheet}" Column "{self.foreign_key}" '
+            f"Row {self.row} "
+            f'Value "{self.fk_value}" not in parent table '
+            f'"{self.parent_table}" where PK "{self.parent_pk}"'
+        )
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException
+
+
+@dataclass
+class WrongInputFailure(PreTransFormationFailure):
+    """Class representing a wrong input pre-transformation failure."""
+
+    value_descriptor: str
+    entered_value: str
+    expected_values: set
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        return None, None, msgs.PRE_TRANSFORMATION_MESSAGES[self.value_descriptor]
+
+
+@dataclass
+class InvalidSheetFailure(ValidationFailure):
+    """Class representing an invalid sheet failure."""
+
+    invalid_sheet: str
+
+    def __str__(self):
+        """Method to get the string representation of the empty sheet failure."""
+        return (
+            f"Invalid Sheets Failure: The sheet named {self.invalid_sheet} is invalid "
+            f"as it is missing expected values"
+        )
+
+    def to_message(self) -> tuple[str | None, str | None, str]:
+        raise UnimplementedErrorMessageException

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 import core.validation.failures as vf
+import core.validation.messages as msgs
 from core.const import (
     EXPECTED_ROUND_THREE_SHEETS,
     FUND_TYPE_TO_TD_OR_HS,
@@ -108,7 +109,7 @@ def extract_submission_details(
     return wrong_input_checks
 
 
-def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[vf.ValidationFailure]:
+def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[vf.PreTransFormationFailure]:
     """
     Perform pre-transformation checks on the given workbook.
 
@@ -170,7 +171,7 @@ def check_missing_sheets(expected_sheets: list[str], workbook: dict[str, pd.Data
     return missing_sheets
 
 
-def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[vf.SignOffFailure] | None:
+def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[vf.GenericFailure] | None:
     """Validates Name, Role, and Date for the Review & Sign-Off Section
 
     :param workbook: A dictionary where keys are sheet names and values are pandas
@@ -185,27 +186,11 @@ def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[vf.SignOffFailu
 
     failures = []
 
-    for y_axis in section_151_text_cells:
+    for y_axis in [*town_board_chair_cells, *section_151_text_cells]:
         if pd.isnull(sheet.iloc[y_axis, 2]):
             failures.append(
-                vf.SignOffFailure(
-                    tab="Review & Sign-Off",
-                    section="Section 151 Officer / Chief Finance Officer",
-                    missing_value=str(sheet.iloc[y_axis, 1]).strip(),
-                    sign_off_officer="an S151 Officer or Chief Finance Officer",
-                    cell="C" + str(y_axis + 2),
-                )
-            )
-
-    for y_axis in town_board_chair_cells:
-        if pd.isnull(sheet.iloc[y_axis, 2]):
-            failures.append(
-                vf.SignOffFailure(
-                    tab="Review & Sign-Off",
-                    section="Town Board Chair",
-                    missing_value=str(sheet.iloc[y_axis, 1]).strip(),
-                    sign_off_officer="a programme SRO",
-                    cell="C" + str(y_axis + 2),
+                vf.GenericFailure(
+                    sheet="Review & Sign-Off", section="-", cell_index="C" + str(y_axis + 2), message=msgs.BLANK
                 )
             )
 

--- a/core/validation/initial_check.py
+++ b/core/validation/initial_check.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-import core.validation.failures as vf
+import core.validation.failures.user as uf
 import core.validation.messages as msgs
 from core.const import (
     EXPECTED_ROUND_THREE_SHEETS,
@@ -109,7 +109,7 @@ def extract_submission_details(
     return wrong_input_checks
 
 
-def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[vf.PreTransFormationFailure]:
+def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> list[uf.PreTransFormationFailure]:
     """
     Perform pre-transformation checks on the given workbook.
 
@@ -118,11 +118,11 @@ def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> 
     """
 
     if submission_details.get("Missing Sheets") or submission_details.get("Invalid Sheets"):
-        return [vf.WrongInputFailure(value_descriptor="Form Version", expected_values=None, entered_value=None)]
+        return [uf.WrongInputFailure(value_descriptor="Form Version", expected_values=None, entered_value=None)]
 
     if place_names := submission_details.get("Unauthorised Place Name"):
         unauthorised_place_name, authorised_place_names = place_names
-        return [vf.UnauthorisedSubmissionFailure(unauthorised_place_name, authorised_place_names)]
+        return [uf.UnauthorisedSubmissionFailure(unauthorised_place_name, authorised_place_names)]
 
     failures = []
 
@@ -139,7 +139,7 @@ def pre_transformation_check(submission_details: dict[str, dict[str, dict]]) -> 
     return failures
 
 
-def check_values(value_descriptor: str, entered_value: str, expected_values: set) -> vf.WrongInputFailure | None:
+def check_values(value_descriptor: str, entered_value: str, expected_values: set) -> uf.WrongInputFailure | None:
     """
     Check the form input for pre-transformation failures.
 
@@ -150,7 +150,7 @@ def check_values(value_descriptor: str, entered_value: str, expected_values: set
     """
 
     if entered_value not in expected_values:
-        return vf.WrongInputFailure(
+        return uf.WrongInputFailure(
             value_descriptor=value_descriptor, entered_value=entered_value, expected_values=expected_values
         )
 
@@ -171,7 +171,7 @@ def check_missing_sheets(expected_sheets: list[str], workbook: dict[str, pd.Data
     return missing_sheets
 
 
-def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[vf.GenericFailure] | None:
+def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[uf.GenericFailure] | None:
     """Validates Name, Role, and Date for the Review & Sign-Off Section
 
     :param workbook: A dictionary where keys are sheet names and values are pandas
@@ -189,7 +189,7 @@ def validate_sign_off(workbook: dict[str, pd.DataFrame]) -> list[vf.GenericFailu
     for y_axis in [*town_board_chair_cells, *section_151_text_cells]:
         if pd.isnull(sheet.iloc[y_axis, 2]):
             failures.append(
-                vf.GenericFailure(
+                uf.GenericFailure(
                     sheet="Review & Sign-Off", section="-", cell_index="C" + str(y_axis + 2), message=msgs.BLANK
                 )
             )

--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -16,7 +16,7 @@ from core.const import (
 )
 from core.extraction.utils import POSTCODE_REGEX
 from core.util import get_project_number_by_id, get_project_number_by_position
-from core.validation.failures import ValidationFailure, construct_cell_index
+from core.validation.failures.user import UserValidationFailure, construct_cell_index
 from core.validation.utils import (
     find_null_values,
     is_blank,
@@ -600,7 +600,7 @@ def validate_project_progress(workbook: dict[str, pd.DataFrame]) -> list["TownsF
 
 
 @dataclass
-class TownsFundRoundFourValidationFailure(ValidationFailure):
+class TownsFundRoundFourValidationFailure(UserValidationFailure):
     """Generic Towns Fund Round 4 Validation Failure."""
 
     sheet: str

--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -354,6 +354,8 @@ def validate_funding_spent(workbook: dict[str, pd.DataFrame]) -> list["TownsFund
     funding_spent = {project: spend_per_project(funding_df, project) for project in project_ids}
     funding_spent[programme_id] = sum(funding_spent.values())
 
+    # TODO: create a single Failure instance for a single overspend error with a set of "locations" rather
+    #   than a Failure for each cell
     funding_spent_failures = []
     if fund_type == "HS":
         # check funding against programme wide funding allocated for Future High Street Fund submissions

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -213,6 +213,8 @@ def validate_unique_composite_key(
     duplicated_rows = remove_duplicate_indexes(duplicated_rows)
 
     if mask.any():
+        # TODO: create a single Failure instance for a single composite key failure with a set of "locations" rather
+        #   than a Failure for each cell
         failures = [
             vf.NonUniqueCompositeKeyFailure(
                 sheet=sheet_name, column=composite_key, row=duplicate.values.tolist(), row_index=idx

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -410,7 +410,7 @@ def test_ingest_endpoint_returns_validation_errors(test_client, example_data_mod
         side_effect=ValidationError(
             validation_failures=[
                 NonNullableConstraintFailure(
-                    sheet="Project Progress", column="Start Date", row_indexes=[5], failed_row=None
+                    sheet="Project Progress", column="Start Date", row_index=5, failed_row=None
                 )
             ]
         ),

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -31,7 +31,10 @@ from core.db.entities import (
 )
 from core.exceptions import ValidationError
 from core.validation.exceptions import UnimplementedErrorMessageException
-from core.validation.failures import NonNullableConstraintFailure, WrongInputFailure
+from core.validation.failures.user import (
+    NonNullableConstraintFailure,
+    WrongInputFailure,
+)
 
 resources = Path(__file__).parent / "resources"
 

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -190,12 +190,16 @@ def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lo
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 4)
     assert str(ve.value) == (
         (
-            "[InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[23]), "
-            "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[24]), "
-            "InvalidOutcomeProjectFailure(invalid_project=nan, section='Outcome "
-            "Indicators (excluding footfall)', row_indexes=[43])]"
+            "[GenericFailure(sheet='Outcomes', section='Outcome Indicators (excluding "
+            "footfall)', cell_index='D23', message='You’ve entered your own content, "
+            "instead of selecting from the dropdown list provided. Select an option from "
+            "the dropdown list.'), GenericFailure(sheet='Outcomes', section='Outcome "
+            "Indicators (excluding footfall)', cell_index='D24', message='You’ve entered "
+            "your own content, instead of selecting from the dropdown list provided. "
+            "Select an option from the dropdown list.'), GenericFailure(sheet='Outcomes', "
+            "section='Outcome Indicators (excluding footfall)', cell_index='D43', "
+            "message='You’ve entered your own content, instead of selecting from the "
+            "dropdown list provided. Select an option from the dropdown list.')]"
         )
     )
 

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -347,20 +347,26 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 3)
     assert str(ve.value) == (
         (
-            "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[23]), "
-            "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[24]), "
-            "InvalidOutcomeProjectFailure(invalid_project='Test Project 1', "
-            "section='Outcome Indicators (excluding footfall)', row_indexes=[43])]"
+            "[GenericFailure(sheet='Outcomes', section='Outcome Indicators (excluding "
+            "footfall)', cell_index='D23', message='You’ve entered your own content, "
+            "instead of selecting from the dropdown list provided. Select an option from "
+            "the dropdown list.'), GenericFailure(sheet='Outcomes', section='Outcome "
+            "Indicators (excluding footfall)', cell_index='D24', message='You’ve entered "
+            "your own content, instead of selecting from the dropdown list provided. "
+            "Select an option from the dropdown list.'), GenericFailure(sheet='Outcomes', "
+            "section='Outcome Indicators (excluding footfall)', cell_index='D43', "
+            "message='You’ve entered your own content, instead of selecting from the "
+            "dropdown list provided. Select an option from the dropdown list.')]"
         )
     )
 
     with pytest.raises(ValidationError) as ve:
         tf.extract_footfall_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup)
     assert str(ve.value) == (
-        "[InvalidOutcomeProjectFailure(invalid_project='Test Project 1', section='Footfall Indicator', "
-        "row_indexes=[65])]"
+        "[GenericFailure(sheet='Outcomes', section='Footfall Indicator', "
+        "cell_index='B65', message='You’ve entered your own content, instead of "
+        "selecting from the dropdown list provided. Select an option from the "
+        "dropdown list.')]"
     )
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from flask import g
 
 from core.handlers import handle_exception
-from core.validation.historical import ExtraSheetFailure
+from core.validation.failures.dev import ExtraSheetFailure
 
 
 def test_handle_exception_ingest_endpoint(test_client, mocker, caplog):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from flask import g
 
 from core.handlers import handle_exception
-from core.validation.failures import ExtraSheetFailure
+from core.validation.historical import ExtraSheetFailure
 
 
 def test_handle_exception_ingest_endpoint(test_client, mocker, caplog):

--- a/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
@@ -50,7 +50,7 @@ def validation_functions_success_mock(mocker):
 def test_validate_failure(mocker, validation_functions_success_mock):
     # overwrite success mocks with failures
     mocked_failure = TownsFundRoundFourValidationFailure(
-        sheet="Test sheet", section="Test Section", column="Test column", message="Test Message", row_indexes=[1]
+        sheet="Test sheet", section="Test Section", column="Test column", message="Test Message", row_index=1
     )
     mocker.patch(
         "core.validation.specific_validations.towns_fund_round_four.validate_project_risks",
@@ -107,7 +107,7 @@ def test_validate_project_risks_returns_correct_failure():
             section="Project Risks - Project 3",
             column="RiskName",
             message=msgs.PROJECT_RISKS,
-            row_indexes=[37],
+            row_index=37,
         )
     ]
 
@@ -141,21 +141,21 @@ def test_validate_project_risks_returns_correct_failure_no_risks():
             section="Project Risks - Project 1",
             column="RiskName",
             message=msgs.PROJECT_RISKS,
-            row_indexes=[21],
+            row_index=21,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="RiskRegister",
             section="Project Risks - Project 2",
             column="RiskName",
             message=msgs.PROJECT_RISKS,
-            row_indexes=[29],
+            row_index=29,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="RiskRegister",
             section="Project Risks - Project 3",
             column="RiskName",
             message=msgs.PROJECT_RISKS,
-            row_indexes=[37],
+            row_index=37,
         ),
     ]
 
@@ -190,7 +190,7 @@ def test_validate_programme_risks_returns_correct_failure():
             section="Programme Risks",
             column="RiskName",
             message=msgs.PROGRAMME_RISKS,
-            row_indexes=[10],
+            row_index=10,
         )
     ]
 
@@ -208,7 +208,7 @@ def test_validate_programme_risks_returns_correct_failure_no_risks():
             section="Programme Risks",
             column="RiskName",
             message=msgs.PROGRAMME_RISKS,
-            row_indexes=[10],
+            row_index=10,
         )
     ]
 
@@ -257,7 +257,7 @@ def test_validate_funding_profiles_funding_source_failure():
             section="Project Funding Profiles - Project 1",
             column="Funding Source Type",
             message=msgs.DROPDOWN,
-            row_indexes=[49],
+            row_index=49,
         )
     ]
 
@@ -296,14 +296,14 @@ def test_validate_funding_profiles_funding_source_failure_multiple():
             section="Project Funding Profiles - Project 1",
             column="Funding Source Type",
             message=msgs.DROPDOWN,
-            row_indexes=[48],
+            row_index=48,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Funding",
             section="Project Funding Profiles - Project 3",
             column="Funding Source Type",
             message=msgs.DROPDOWN,
-            row_indexes=[106],
+            row_index=106,
         ),
     ]
 
@@ -384,7 +384,7 @@ def test_validate_funding_profiles_at_least_one_other_funding_source_fhsf_failur
             section="Project Funding Profiles",
             column="Funding Source Type",
             message=msgs.MISSING_OTHER_FUNDING_SOURCES,
-            row_indexes=[],
+            row_index=None,
         )
     ]
 
@@ -410,7 +410,7 @@ def test_validate_psi_funding_gap():
             section="Private Sector Investment",
             column="Additional Comments",
             message=msgs.BLANK_PSI,
-            row_indexes=[10],
+            row_index=10,
         )
     ]
 
@@ -508,28 +508,42 @@ def test_validate_locations_failure():
             section="Project Details",
             column="Locations",
             message=msgs.BLANK,
-            row_indexes=[3],
+            row_index=3,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Project Details",
             section="Project Details",
             column="Locations",
             message=msgs.BLANK,
-            row_indexes=[1, 2],
+            row_index=1,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Project Details",
+            section="Project Details",
+            column="Locations",
+            message=msgs.BLANK,
+            row_index=2,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Project Details",
             section="Project Details",
             column="GIS Provided",
             message=msgs.BLANK,
-            row_indexes=[1, 2],
+            row_index=1,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Project Details",
+            section="Project Details",
+            column="GIS Provided",
+            message=msgs.BLANK,
+            row_index=2,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Project Details",
             section="Project Details",
             column="GIS Provided",
             message=msgs.DROPDOWN,
-            row_indexes=[4],
+            row_index=4,
         ),
     ]
 
@@ -596,14 +610,14 @@ def test_validate_funding_spent(mocker, allocated_funding):
             section="Project Funding Profiles - Project 1",
             column="Grand Total",
             message=msgs.OVERSPEND_PROJECT,
-            row_indexes=[45],
+            row_index=45,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Funding",
             section="Project Funding Profiles - Project 3",
             column="Grand Total",
             message=msgs.OVERSPEND_PROJECT,
-            row_indexes=[101],
+            row_index=101,
         ),
     ]
 
@@ -657,8 +671,22 @@ def test_validate_funding_spent_FHSF(mocker, allocated_funding):
             section="Project Funding Profiles",
             column="Grand Total",
             message=msgs.OVERSPEND_PROGRAMME,
-            row_indexes=[45, 73, 101],
-        )
+            row_index=45,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Funding",
+            section="Project Funding Profiles",
+            column="Grand Total",
+            message=msgs.OVERSPEND_PROGRAMME,
+            row_index=73,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Funding",
+            section="Project Funding Profiles",
+            column="Grand Total",
+            message=msgs.OVERSPEND_PROGRAMME,
+            row_index=101,
+        ),
     ]
 
 
@@ -706,7 +734,7 @@ def test_validate_funding_profiles_funding_secured_not_null():
             section="Project Funding Profiles - Project 1",
             column="Secured",
             message="The cell is blank but is required.",
-            row_indexes=[49],
+            row_index=49,
         )
     ]
 
@@ -739,21 +767,21 @@ def test_validate_psi_funding_not_negative():
             section="Private Sector Investment",
             column="Private Sector Funding Required",
             message="You’ve entered a negative number. Enter a positive number.",
-            row_indexes=[48],
+            row_index=48,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Private Investments",
             section="Private Sector Investment",
             column="Private Sector Funding Required",
             message="You’ve entered a negative number. Enter a positive number.",
-            row_indexes=[49],
+            row_index=49,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Private Investments",
             section="Private Sector Investment",
             column="Private Sector Funding Secured",
             message="You’ve entered a negative number. Enter a positive number.",
-            row_indexes=[49],
+            row_index=49,
         ),
     ]
 
@@ -839,8 +867,22 @@ def test_validate_postcodes():
             section="Project Details",
             column="Postcodes",
             message="You entered an invalid postcode. Enter a full UK postcode, for example SW1A 2AA.",
-            row_indexes=[12, 13, 14],
-        )
+            row_index=12,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Project Details",
+            section="Project Details",
+            column="Postcodes",
+            message="You entered an invalid postcode. Enter a full UK postcode, for example SW1A 2AA.",
+            row_index=13,
+        ),
+        TownsFundRoundFourValidationFailure(
+            sheet="Project Details",
+            section="Project Details",
+            column="Postcodes",
+            message="You entered an invalid postcode. Enter a full UK postcode, for example SW1A 2AA.",
+            row_index=14,
+        ),
     ]
 
 
@@ -859,7 +901,7 @@ def test_validate_postcodes_success():
 
     failures = validate_postcodes(workbook)
 
-    assert failures is None
+    assert failures == []
 
 
 def test_validate_funding_questions_success():
@@ -928,7 +970,7 @@ def test_validate_funding_questions_dropdown_failure():
     failures = validate_funding_questions(workbook)
     assert failures and len(failures) == 2
     assert [failure.message for failure in failures] == [msgs.DROPDOWN, msgs.DROPDOWN]  # assert both dropdown
-    assert [failure.row_indexes for failure in failures] == [[45], [67]]  # assert indexes are correct
+    assert [failure.row_index for failure in failures] == [45, 67]  # assert indexes are correct
     assert failures[0].column == "All Columns"  # assert that NA indicator causes "All Columns"
 
 
@@ -1066,21 +1108,21 @@ def test_validate_project_progress_current_project_delivery_status_and_upcoming_
             section="Projects Progress Summary",
             column="Current Project Delivery Stage",
             message="The cell is blank but is required for incomplete projects.",
-            row_indexes=[21],
+            row_index=21,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Project Progress",
             section="Projects Progress Summary",
             column="Most Important Upcoming Comms Milestone",
             message="The cell is blank but is required for incomplete projects.",
-            row_indexes=[21],
+            row_index=21,
         ),
         TownsFundRoundFourValidationFailure(
             sheet="Project Progress",
             section="Projects Progress Summary",
             column="Date of Most Important Upcoming Comms Milestone (" "e.g. Dec-22)",
             message="The cell is blank but is required for incomplete projects.",
-            row_indexes=[21],
+            row_index=21,
         ),
     ]
 
@@ -1116,6 +1158,6 @@ def test_validate_project_progress_leading_factor_of_delay_not_yet_started_failu
             section="Projects Progress Summary",
             column="Leading Factor of Delay",
             message=msgs.BLANK,
-            row_indexes=[0],
+            row_index=0,
         )
     ]

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -4,11 +4,10 @@ import pytest
 from core.const import TF_ROUND_4_TEMPLATE_VERSION
 from core.validation.exceptions import UnimplementedErrorMessageException
 from core.validation.failures import (
+    GenericFailure,
     InvalidEnumValueFailure,
-    InvalidOutcomeProjectFailure,
     NonNullableConstraintFailure,
     NonUniqueCompositeKeyFailure,
-    SignOffFailure,
     UnauthorisedSubmissionFailure,
     WrongInputFailure,
     WrongTypeFailure,
@@ -66,196 +65,163 @@ def test_invalid_enum_messages():
     InvalidEnumValueFailure(
         sheet="Project Details",
         column="Single or Multiple Locations",
-        row_indexes=[1],
+        row_index=1,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Project Delivery Status",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Delivery (RAG)",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Spend (RAG)",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Risk (RAG)",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Funding",
         column="Secured",
-        row_indexes=[50],
+        row_index=50,
         row_values=("TD-ABC-1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedImpact",
-        row_indexes=[23],
+        row_index=23,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Pre-mitigatedLikelihood",
-        row_indexes=[24],
+        row_index=24,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedImpact",
-        row_indexes=[25],
+        row_index=25,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="PostMitigatedLikelihood",
-        row_indexes=[23],
+        row_index=23,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="Proximity",
-        row_indexes=[24],
+        row_index=24,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Project Adjustment Request Status",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Current Project Delivery Stage",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="Project Progress",
         column="Leading Factor of Delay",
-        row_indexes=[2],
+        row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
     InvalidEnumValueFailure(
         sheet="RiskRegister",
         column="RiskCategory",
-        row_indexes=[25],
+        row_index=25,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
-        value="Value",
     ).to_message()
 
 
 def test_non_nullable_messages_project_details():
     failed_rows = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=22)
     NonNullableConstraintFailure(
-        sheet="Project Details", column="Locations", row_indexes=[15, 16], failed_row=None
+        sheet="Project Details", column="Locations", row_index=15, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_index=21, failed_row=None).to_message()
+    NonNullableConstraintFailure(
+        sheet="Project Progress", column="Start Date", row_index=1, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Details", column="Lat/Long", row_indexes=[21, 22], failed_row=None
+        sheet="Project Progress", column="Completion Date", row_index=4, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Start Date", row_indexes=[1, 2], failed_row=None
+        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_index=2, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Completion Date", row_indexes=[4], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_indexes=[2], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="Project Progress",
-        column="Most Important Upcoming Comms Milestone",
-        row_indexes=[7],
-        failed_row=None,
+        sheet="Project Progress", column="Most Important Upcoming Comms Milestone", row_index=7, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
-        row_indexes=[6],
+        row_index=6,
         failed_row=None,
     ).to_message()
+    NonNullableConstraintFailure(sheet="Programme Progress", column="Answer", row_index=4, failed_row=None).to_message()
     NonNullableConstraintFailure(
-        sheet="Programme Progress", column="Answer", row_indexes=[4], failed_row=None
+        sheet="Project Progress", column="Current Project Delivery Stage", row_index=3, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Current Project Delivery Stage", row_indexes=[3], failed_row=None
+        sheet="Outcome_Data", column="UnitofMeasurement", row_index=16, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="UnitofMeasurement",
-        row_indexes=[16, 21],
-        failed_row=failed_rows,
+        sheet="Outcome_Data", column="Amount", row_index=5, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="Amount",
-        row_indexes=[5],
-        failed_row=failed_rows,
+        sheet="Outcome_Data", column="GeographyIndicator", row_index=5, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data",
-        column="GeographyIndicator",
-        row_indexes=[5, 6],
-        failed_row=failed_rows,
+        sheet="Output_Data", column="Unit of Measurement", row_index=17, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_index=6, failed_row=None).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="Short Description", row_index=20, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Output_Data", column="Unit of Measurement", row_indexes=[17, 22], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_indexes=[6], failed_row=None).to_message()
-    NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Short Description", row_indexes=[20], failed_row=None
+        sheet="RiskRegister", column="Full Description", row_index=21, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Full Description", row_indexes=[21], failed_row=None
+        sheet="RiskRegister", column="Consequences", row_index=22, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Consequences", row_indexes=[22], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Mitigatons", row_indexes=[23], failed_row=None
+        sheet="RiskRegister", column="Mitigatons", row_index=23, failed_row=None
     ).to_message()  # typo throughout code
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="RiskOwnerRole", row_indexes=[24], failed_row=None
+        sheet="RiskRegister", column="RiskOwnerRole", row_index=24, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName", row_index=25, failed_row=None).to_message()
+    NonNullableConstraintFailure(
+        sheet="RiskRegister", column="RiskCategory", row_index=26, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="RiskName", row_indexes=[25], failed_row=None
+        sheet="Funding", column="Spend for Reporting Period", row_index=7, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="RiskCategory", row_indexes=[26], failed_row=None
+        sheet="Project Progress", column="Start Date", row_index=2, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Funding", column="Spend for Reporting Period", row_indexes=[7], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="Project Progress", column="Start Date", row_indexes=[2, 3], failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Short Description", row_indexes=[5, 6], failed_row=None
+        sheet="RiskRegister", column="Short Description", row_index=5, failed_row=None
     ).to_message()
 
 
@@ -266,7 +232,7 @@ def test_wrong_type_messages():
         column="Start Date",
         expected_type="datetime64[ns]",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -274,7 +240,7 @@ def test_wrong_type_messages():
         column="Completion Date",
         expected_type="datetime64[ns]",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -282,7 +248,7 @@ def test_wrong_type_messages():
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -290,7 +256,7 @@ def test_wrong_type_messages():
         column="Private Sector Funding Required",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -298,7 +264,7 @@ def test_wrong_type_messages():
         column="Private Sector Funding Secured",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -306,7 +272,7 @@ def test_wrong_type_messages():
         column="Spend for Reporting Period",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -314,7 +280,7 @@ def test_wrong_type_messages():
         column="Amount",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
@@ -322,7 +288,7 @@ def test_wrong_type_messages():
         column="Amount",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=failed_rows,
     ).to_message()
     WrongTypeFailure(
@@ -330,7 +296,7 @@ def test_wrong_type_messages():
         column="Amount",
         expected_type="float64",
         actual_type="object",
-        row_indexes=[22],
+        row_index=22,
         failed_row=failed_rows,
     ).to_message()
 
@@ -339,9 +305,8 @@ def test_enum_failure_with_footfall_geography_indicator_wrong():
     failure = InvalidEnumValueFailure(
         sheet="Outcome_Data",
         column="GeographyIndicator",
-        row_indexes=[60],
+        row_index=60,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4", "Year-on-year % change in monthly footfall"),
-        value="Value",
     )
 
     assert failure.to_message() == (
@@ -356,7 +321,7 @@ def test_enum_failure_with_footfall_geography_indicator_wrong():
 def test_non_unique_composite_key_messages():
     NonUniqueCompositeKeyFailure(
         sheet="Funding",
-        cols=("Project ID", "Funding Source Name", "Funding Source Type", "Secured", "Start_Date", "End_Date"),
+        column=["Project ID", "Funding Source Name", "Funding Source Type", "Secured", "Start_Date", "End_Date"],
         row=[
             "HS-GRA-02",
             "Norfolk County Council",
@@ -365,11 +330,11 @@ def test_non_unique_composite_key_messages():
             "2021-04-01 00:00:00",
             "2021-09-30 00:00:00",
         ],
-        row_indexes=[78],
+        row_index=78,
     ).to_message()
     NonUniqueCompositeKeyFailure(
         sheet="Output_Data",
-        cols=("Project ID", "Output", "Start_Date", "End_Date", "Unit of Measurement", "Actual/Forecast"),
+        column=["Project ID", "Output", "Start_Date", "End_Date", "Unit of Measurement", "Actual/Forecast"],
         row=[
             "HS-GRA-02",
             "Total length of new cycle ways",
@@ -378,68 +343,51 @@ def test_non_unique_composite_key_messages():
             "Km of cycle way",
             "Actual",
         ],
-        row_indexes=[82],
+        row_index=82,
     ).to_message()
     NonUniqueCompositeKeyFailure(
         sheet="Outcome_Data",
-        cols=("Project ID", "Outcome", "Start_Date", "End_Date", "GeographyIndicator"),
+        column=["Project ID", "Outcome", "Start_Date", "End_Date", "GeographyIndicator"],
         row=[
             "HS-GRA-03",
             "Road traffic flows in corridors of interest (for road schemes)",
             "2020-04-01 00:00:00",
             "Travel corridor",
         ],
-        row_indexes=[1],
+        row_index=1,
     ).to_message()
     NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
-        cols=("Programme ID", "Project ID", "RiskName"),
+        column=["Programme ID", "Project ID", "RiskName"],
         row=["HS-GRA", pd.NA, "Delivery Timeframe"],
-        row_indexes=[1],
+        row_index=1,
     ).to_message()
     NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
-        cols=("Programme ID", "Project ID", "RiskName"),
+        column=["Programme ID", "Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[23],
+        row_index=23,
     ).to_message()
 
     with pytest.raises(UnimplementedErrorMessageException):
         NonUniqueCompositeKeyFailure(
             sheet="Project Progress",
-            cols=("Programme ID", "Project ID", "RiskName"),
+            column=["Programme ID", "Project ID", "RiskName"],
             row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-            row_indexes=[7],
+            row_index=7,
         ).to_message()
-
-
-def test_invalid_project_outcome_failure():
-    InvalidOutcomeProjectFailure(
-        invalid_project="Invalid Project", section="Outcome Indicators (excluding footfall)", row_indexes=[5]
-    ).to_message()
-    InvalidOutcomeProjectFailure(
-        invalid_project="Invalid Project", section="Footfall Indicator", row_indexes=[65]
-    ).to_message()
 
 
 def test_authorised_submission():
     UnauthorisedSubmissionFailure(unauthorised_place_name="Newark", authorised_place_names=("Wigan",)).to_message()
 
 
-def test_sign_off_failure():
-    SignOffFailure(
-        tab="Review & Sign-Off",
-        section="Section 151 Officer / Chief Finance Officer",
-        missing_value="Name",
-        sign_off_officer="an S151 Officer or Chief Finance Officer",
-        cell="C9",
-    ).to_message()
-    SignOffFailure(
-        tab="Review & Sign-Off",
-        section="Town Board Chair",
-        missing_value="Date",
-        sign_off_officer="a programme SRO",
-        cell="C15",
+def test_generic_failure():
+    GenericFailure(
+        sheet="A Sheet",
+        section="A Section",
+        cell_index="C1",
+        message="A message",
     ).to_message()
 
 
@@ -447,32 +395,29 @@ def test_failures_to_messages():
     failure1 = InvalidEnumValueFailure(
         sheet="Project Details",
         column="Single or Multiple Locations",
-        row_indexes=[1],
+        row_index=1,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
-        value="Value",
     )
-    failure2 = NonNullableConstraintFailure(
-        sheet="Project Details", column="Lat/Long", row_indexes=[1], failed_row=None
-    )
+    failure2 = NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_index=1, failed_row=None)
     failure3 = WrongTypeFailure(
         sheet="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
-        row_indexes=[22],
+        row_index=22,
         failed_row=None,
     )
     failure4 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
-        cols=("Project ID", "RiskName"),
+        column=["Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[23],
+        row_index=23,
     )
     failure5 = NonUniqueCompositeKeyFailure(
         sheet="RiskRegister",
-        cols=("Project ID", "RiskName"),
+        column=["Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
-        row_indexes=[25],
+        row_index=25,
     )  # intentional duplicate message, should only show up as a single message in the assertion
 
     failures = [failure1, failure2, failure3, failure4, failure5]
@@ -515,49 +460,20 @@ def test_group_validation_messages():
     ]
 
 
-def test_construct_cell_index_single():
-    # single index
-    test_index1 = construct_cell_index("Place Details", "Question", [1])
-    assert test_index1 == "C1"
-
-    test_index2 = construct_cell_index("Project Details", "Locations", [2])
-    assert test_index2 == "H2 or K2"
-
-    test_index3 = construct_cell_index("Programme Progress", "Answer", [3])
-    assert test_index3 == "D3"
-
-    test_index4 = construct_cell_index("Project Progress", "Delivery (RAG)", [4])
-    assert test_index4 == "J4"
-
-    test_index5 = construct_cell_index("Funding Questions", "All Columns", [5])
-    assert test_index5 == "E5"
-
-    test_index6 = construct_cell_index("Funding Comments", "Comment", [6])
-    assert test_index6 == "C6 to E6"
-
-    test_index7 = construct_cell_index("Project Details", "Primary Intervention Theme", [27])
-    assert test_index7 == "F27"
-
-
-def test_construct_cell_index_multiple():
-    # multi-index
-    test_index1 = construct_cell_index("Funding", "Funding Source Type", [7, 8])
-    assert test_index1 == "D7, D8"
-
-    test_index2 = construct_cell_index("Private Investments", "Private Sector Funding Required", [9, 10])
-    assert test_index2 == "G9, G10"
-
-    test_index3 = construct_cell_index("Output_Data", "Amount", [11, 12, 13])
-    assert test_index3 == "E11 to W11, E12 to W12, E13 to W13"
-
-
-def test_construct_cell_index_remove_duplicates():
-    # should remove duplicates but retain order of row indexes - results in the same as test_index9
-    test_index1 = construct_cell_index("Output_Data", "Amount", [11, 11, 11, 12, 12, 13])
-    assert test_index1 == "E11 to W11, E12 to W12, E13 to W13"
-
-    test_index2 = construct_cell_index("Outcome_Data", "Higher Frequency", [8, 2, 11, 5, 9])
-    assert test_index2 == "P8, P2, P11, P5, P9"
+@pytest.mark.parametrize(
+    "index_input, expected",
+    [
+        (("Place Details", "Question", 1), "C1"),
+        (("Project Details", "Locations", 2), "H2 or K2"),
+        (("Programme Progress", "Answer", 3), "D3"),
+        (("Project Progress", "Delivery (RAG)", 4), "J4"),
+        (("Funding Questions", "All Columns", 5), "E5"),
+        (("Funding Comments", "Comment", 6), "C6 to E6"),
+        (("Project Details", "Primary Intervention Theme", 27), "F27"),
+    ],
+)
+def test_construct_cell_index(index_input, expected):
+    assert construct_cell_index(*index_input) == expected
 
 
 def test_remove_errors_already_caught_by_null_failure():
@@ -609,7 +525,7 @@ def test_failures_to_message_with_outcomes_column_amount():
     failure1 = NonNullableConstraintFailure(
         sheet="Outcome_Data",
         column="Amount",
-        row_indexes=[60],
+        row_index=60,
         failed_row=failed_rows1,
     )
     failure2 = WrongTypeFailure(
@@ -617,7 +533,7 @@ def test_failures_to_message_with_outcomes_column_amount():
         column="Amount",
         expected_type="float64",
         actual_type="string",
-        row_indexes=[23],
+        row_index=23,
         failed_row=failed_rows2,
     )
 
@@ -642,31 +558,31 @@ def test_failures_to_message_with_duplicated_errors():
         NonNullableConstraintFailure(
             sheet="Outcome_Data",
             column="Outcome",
-            row_indexes=[22],
+            row_index=22,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
             sheet="Outcome_Data",
             column="Outcome",
-            row_indexes=[22],
+            row_index=22,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
             sheet="Outcome_Data",
             column="Outcome",
-            row_indexes=[23],
+            row_index=23,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
             sheet="Outcome_Data",
             column="Amount",
-            row_indexes=[60],
+            row_index=60,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
             sheet="Outcome_Data",
             column="Amount",
-            row_indexes=[60],
+            row_index=60,
             failed_row=failed_row2,
         ),
     ]

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -3,7 +3,7 @@ import pytest
 
 from core.const import TF_ROUND_4_TEMPLATE_VERSION
 from core.validation.exceptions import UnimplementedErrorMessageException
-from core.validation.failures import (
+from core.validation.failures.user import (
     GenericFailure,
     InvalidEnumValueFailure,
     NonNullableConstraintFailure,

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import pytest
 
-import core.validation.failures as vf
+import core.validation.failures.user as uf
 import core.validation.messages as msgs
 from core.const import TF_PLACE_NAMES_TO_ORGANISATIONS
 from core.exceptions import ValidationError
-from core.validation.failures import WrongInputFailure
+from core.validation.failures.user import WrongInputFailure
 from core.validation.initial_check import (
     extract_submission_details,
     pre_transformation_check,
@@ -103,7 +103,7 @@ def test_pre_transformation_check_failures(valid_submission_details):
     failures = pre_transformation_check(valid_submission_details)
 
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
     valid_submission_details["Reporting Period"] = (
         "Invalid Reporting Period",
@@ -111,7 +111,7 @@ def test_pre_transformation_check_failures(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 2
-    assert isinstance(failures[1], vf.WrongInputFailure)
+    assert isinstance(failures[1], uf.WrongInputFailure)
 
     valid_submission_details["Fund Type"] = (
         "Invalid Fund Type",
@@ -119,7 +119,7 @@ def test_pre_transformation_check_failures(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 3
-    assert isinstance(failures[2], vf.WrongInputFailure)
+    assert isinstance(failures[2], uf.WrongInputFailure)
 
     valid_submission_details["Place Name"] = (
         "",
@@ -127,17 +127,17 @@ def test_pre_transformation_check_failures(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 4
-    assert isinstance(failures[3], vf.WrongInputFailure)
+    assert isinstance(failures[3], uf.WrongInputFailure)
 
     valid_submission_details["Invalid Sheets"] = ["1 - Start Here"]
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
     valid_submission_details["Missing Sheets"] = ["1 - Start Here"]
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
 
 def test_place_name_is_valid(valid_submission_details):
@@ -147,7 +147,7 @@ def test_place_name_is_valid(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
 
 def test_place_name_is_null(valid_submission_details):
@@ -157,7 +157,7 @@ def test_place_name_is_null(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
 
 def test_place_name_has_correct_fund_type(valid_submission_details):
@@ -167,7 +167,7 @@ def test_place_name_has_correct_fund_type(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
 
 
 def test_place_name_has_correct_fund_type_not_raised(valid_submission_details):
@@ -181,7 +181,7 @@ def test_place_name_has_correct_fund_type_not_raised(valid_submission_details):
     )
     failures = pre_transformation_check(valid_submission_details)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.WrongInputFailure)
+    assert isinstance(failures[0], uf.WrongInputFailure)
     assert failures[0].value_descriptor == "Place Name"
 
 
@@ -189,7 +189,7 @@ def test_unauthorised_submission():
     unauthorised_failure_dict = {"Unauthorised Place Name": ("Newark", ("Wigan",))}
     failures = pre_transformation_check(unauthorised_failure_dict)
     assert len(failures) == 1
-    assert isinstance(failures[0], vf.UnauthorisedSubmissionFailure)
+    assert isinstance(failures[0], uf.UnauthorisedSubmissionFailure)
 
 
 def test_validate_sign_off_success(valid_workbook_round_four):
@@ -202,9 +202,9 @@ def test_validate_sign_off_failure(invalid_workbook_round_four):
     failures = validate_sign_off(invalid_workbook_round_four)
 
     assert failures == [
-        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C16", message=msgs.BLANK),
-        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C18", message=msgs.BLANK),
-        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C8", message=msgs.BLANK),
+        uf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C16", message=msgs.BLANK),
+        uf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C18", message=msgs.BLANK),
+        uf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C8", message=msgs.BLANK),
     ]
 
 

--- a/tests/validation_tests/test_pre_checks.py
+++ b/tests/validation_tests/test_pre_checks.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import core.validation.failures as vf
+import core.validation.messages as msgs
 from core.const import TF_PLACE_NAMES_TO_ORGANISATIONS
 from core.exceptions import ValidationError
 from core.validation.failures import WrongInputFailure
@@ -201,27 +202,9 @@ def test_validate_sign_off_failure(invalid_workbook_round_four):
     failures = validate_sign_off(invalid_workbook_round_four)
 
     assert failures == [
-        vf.SignOffFailure(
-            tab="Review & Sign-Off",
-            section="Section 151 Officer / Chief Finance Officer",
-            missing_value="Name",
-            sign_off_officer="an S151 Officer or Chief Finance Officer",
-            cell="C8",
-        ),
-        vf.SignOffFailure(
-            tab="Review & Sign-Off",
-            section="Town Board Chair",
-            missing_value="Role",
-            sign_off_officer="a programme SRO",
-            cell="C16",
-        ),
-        vf.SignOffFailure(
-            tab="Review & Sign-Off",
-            section="Town Board Chair",
-            missing_value="Date",
-            sign_off_officer="a programme SRO",
-            cell="C18",
-        ),
+        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C16", message=msgs.BLANK),
+        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C18", message=msgs.BLANK),
+        vf.GenericFailure(sheet="Review & Sign-Off", section="-", cell_index="C8", message=msgs.BLANK),
     ]
 
 

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -5,20 +5,20 @@ import pandas as pd
 import pytest
 from pandas import Timestamp
 
-from core.validation.failures import (
-    InvalidEnumValueFailure,
-    NonNullableConstraintFailure,
-    NonUniqueCompositeKeyFailure,
-    UserFacingValidationFailure,
-    WrongTypeFailure,
-)
-from core.validation.historical import (
+from core.validation.failures.dev import (
+    DevValidationFailure,
     EmptySheetFailure,
     ExtraColumnFailure,
     MissingColumnFailure,
     NonUniqueFailure,
-    NonUserFacingValidationFailure,
     OrphanedRowFailure,
+)
+from core.validation.failures.user import (
+    InvalidEnumValueFailure,
+    NonNullableConstraintFailure,
+    NonUniqueCompositeKeyFailure,
+    UserValidationFailure,
+    WrongTypeFailure,
 )
 from core.validation.validate import (
     remove_undefined_sheets,
@@ -839,9 +839,7 @@ def test_validate_workbook_invalid(valid_workbook_and_schema, invalid_workbook):
     failures = validations(invalid_workbook, schema)
 
     assert failures
-    assert all(
-        isinstance(failure, (UserFacingValidationFailure, NonUserFacingValidationFailure)) for failure in failures
-    )
+    assert all(isinstance(failure, (UserValidationFailure, DevValidationFailure)) for failure in failures)
     assert len(failures) == 9
 
     ####################################

--- a/tests/validation_tests/test_validate.py
+++ b/tests/validation_tests/test_validate.py
@@ -6,16 +6,19 @@ import pytest
 from pandas import Timestamp
 
 from core.validation.failures import (
-    EmptySheetFailure,
-    ExtraColumnFailure,
     InvalidEnumValueFailure,
-    MissingColumnFailure,
     NonNullableConstraintFailure,
     NonUniqueCompositeKeyFailure,
-    NonUniqueFailure,
-    OrphanedRowFailure,
-    ValidationFailure,
+    UserFacingValidationFailure,
     WrongTypeFailure,
+)
+from core.validation.historical import (
+    EmptySheetFailure,
+    ExtraColumnFailure,
+    MissingColumnFailure,
+    NonUniqueFailure,
+    NonUserFacingValidationFailure,
+    OrphanedRowFailure,
 )
 from core.validation.validate import (
     remove_undefined_sheets,
@@ -198,7 +201,7 @@ def test_validate_types_invalid_exp_str_got_int(valid_workbook_and_schema):
     assert failures[0].column == "Project_ID"
     assert failures[0].expected_type == "string"
     assert failures[0].actual_type == "int64"
-    assert failures[0].row_indexes == [6]
+    assert failures[0].row_index == 6
     assert "Start_Date" not in failures[0].failed_row
 
 
@@ -219,7 +222,7 @@ def test_validate_types_invalid_exp_bool_got_str(valid_workbook_and_schema):
     assert failures[0].column == "Project Started"
     assert failures[0].expected_type == "bool"
     assert failures[0].actual_type == "string"
-    assert failures[0].row_indexes == [5]
+    assert failures[0].row_index == 5
     assert "Start_Date" not in failures[0].failed_row
 
 
@@ -240,7 +243,7 @@ def test_validate_types_invalid_exp_datetime_got_str(valid_workbook_and_schema):
     assert failures[0].column == "Date Started"
     assert failures[0].expected_type == "datetime64[ns]"
     assert failures[0].actual_type == "string"
-    assert failures[0].row_indexes == [7]
+    assert failures[0].row_index == 7
     assert "Start_Date" not in failures[0].failed_row
 
 
@@ -261,7 +264,7 @@ def test_validate_types_invalid_float_type(valid_workbook_and_schema):
     assert failures[0].column == "Funding Cost"
     assert failures[0].expected_type == "float64"
     assert failures[0].actual_type == "string"
-    assert failures[0].row_indexes == [5]
+    assert failures[0].row_index == 5
     assert "Start_Date" not in failures[0].failed_row
 
 
@@ -373,15 +376,15 @@ def test_validate_unique_composite_keys_invalid(valid_workbook_and_schema):
     assert failures == [
         NonUniqueCompositeKeyFailure(
             sheet="Project Sheet",
-            cols=("Project_ID", "Fund_ID", "Package_ID"),
+            column=["Project_ID", "Fund_ID", "Package_ID"],
             row=["PID001", "F001", "ABC001"],
-            row_indexes=[6],
+            row_index=6,
         ),
         NonUniqueCompositeKeyFailure(
             sheet="Project Sheet",
-            cols=("Project_ID", "Fund_ID", "Package_ID"),
+            column=["Project_ID", "Fund_ID", "Package_ID"],
             row=["PID001", "F001", "ABC001"],
-            row_indexes=[7],
+            row_index=7,
         ),
     ]
 
@@ -543,7 +546,7 @@ def test_validate_enums_valid_invalid_value(valid_workbook_and_schema):
         InvalidEnumValueFailure(
             sheet="Project Sheet",
             column="ColumnOfEnums",
-            row_indexes=[6],
+            row_index=6,
             row_values=(
                 False,
                 "ABC002",
@@ -556,7 +559,6 @@ def test_validate_enums_valid_invalid_value(valid_workbook_and_schema):
                 "Lookup2",
                 "InvalidEnumValue",
             ),
-            value="InvalidEnumValue",
         )
     ]
 
@@ -576,7 +578,7 @@ def test_validate_enums_valid_multiple_invalid_values(valid_workbook_and_schema)
         InvalidEnumValueFailure(
             sheet="Project Sheet",
             column="ColumnOfEnums",
-            row_indexes=[6],
+            row_index=6,
             row_values=(
                 False,
                 "ABC002",
@@ -589,12 +591,11 @@ def test_validate_enums_valid_multiple_invalid_values(valid_workbook_and_schema)
                 "Lookup2",
                 "InvalidEnumValueA",
             ),
-            value="InvalidEnumValueA",
         ),
         InvalidEnumValueFailure(
             sheet="Project Sheet",
             column="ColumnOfEnums",
-            row_indexes=[7],
+            row_index=7,
             row_values=(
                 True,
                 "ABC003",
@@ -607,7 +608,6 @@ def test_validate_enums_valid_multiple_invalid_values(valid_workbook_and_schema)
                 "",
                 "InvalidEnumValueB",
             ),
-            value="InvalidEnumValueB",
         ),
     ]
 
@@ -754,13 +754,13 @@ def test_validate_non_nullable_failure(valid_workbook_and_schema):
     assert isinstance(failures[0], NonNullableConstraintFailure)
     assert failures[0].sheet == "Project Sheet"
     assert failures[0].column == "Project_ID"
-    assert failures[0].row_indexes == [6]
+    assert failures[0].row_index == 6
     assert "Start_Date" not in failures[0].failed_row
 
     assert isinstance(failures[1], NonNullableConstraintFailure)
     assert failures[1].sheet == "Project Sheet"
     assert failures[1].column == "Project_ID"
-    assert failures[1].row_indexes == [7]
+    assert failures[1].row_index == 7
     assert "Start_Date" not in failures[1].failed_row
 
 
@@ -779,12 +779,12 @@ def test_validate_non_nullable_outcome_amount_melted_row(valid_workbook_and_sche
     assert isinstance(failures[0], NonNullableConstraintFailure)
     assert failures[0].sheet == "Outcome_Data"
     assert failures[0].column == "Amount"
-    assert failures[0].row_indexes == [5]
+    assert failures[0].row_index == 5
 
     assert isinstance(failures[1], NonNullableConstraintFailure)
     assert failures[1].sheet == "Outcome_Data"
     assert failures[1].column == "Amount"
-    assert failures[1].row_indexes == [5]
+    assert failures[1].row_index == 5
 
 
 def test_validate_non_nullable_captures_failed_row(valid_workbook_and_schema):
@@ -839,13 +839,14 @@ def test_validate_workbook_invalid(valid_workbook_and_schema, invalid_workbook):
     failures = validations(invalid_workbook, schema)
 
     assert failures
-    assert all(isinstance(failure, ValidationFailure) for failure in failures)
+    assert all(
+        isinstance(failure, (UserFacingValidationFailure, NonUserFacingValidationFailure)) for failure in failures
+    )
     assert len(failures) == 9
 
-
-####################################
-# Test remove_undefined_sheets
-####################################
+    ####################################
+    # Test remove_undefined_sheets
+    ####################################
 
 
 def test_remove_undefined_sheets_removes_extra_sheets(valid_workbook_and_schema):


### PR DESCRIPTION
_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
- all `Failure`s are per cell for consistency 
- `Failure`s raised during historical ingest are separated from `failures.py` into `historical.py`
- moves common `Failure` attributes to a parent class to enforce consistency across `Failures`

Next refactor is to go further by modifying `validate.py` so separate historical validation from other validation - i.e. foreign key validation should never occur for non-historical rounds so we don't need to do that check. The plan is to make it configurable - i.e. you can configure a set of checks per dataset.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
