### PR TITLE
[FMD-106] Write dates as Excel 'dates' not strings

### DIFF
--- a/core/controllers/download.py
+++ b/core/controllers/download.py
@@ -4,7 +4,7 @@ and Excel. It retrieves data from the database and returns the data in the reque
 """
 import io
 import json
-from datetime import datetime
+from datetime import date, datetime
 from typing import Generator
 
 import pandas as pd
@@ -13,6 +13,20 @@ from flask import abort, make_response, request
 from core.const import DATETIME_ISO_8601, EXCEL_MIMETYPE, TABLE_SORT_ORDERS
 from core.db.queries import download_data_base_query, query_extend_with_outcome_filter
 from core.serialisation.data_serialiser import serialise_download_data
+
+
+def date_to_string(obj) -> str:
+    """Converts a datetime object suitable for JSON serialisation.
+
+    :param obj: A datetime object (or date) that want to serialise into a string.
+    :return: If obj is a datetime object, then a string representation of that timestamp.
+
+    :raises ValueError: For when a type other than date or datetime is supplied
+    """
+    if isinstance(obj, datetime) or isinstance(obj, date):
+        return obj.isoformat()
+
+    raise ValueError(f"Cannot serialise {str(type(obj))}")
 
 
 def download():
@@ -51,7 +65,7 @@ def download():
     match file_format:
         case "json":
             serialised_data = {sheet: data for sheet, data in data_generator}
-            file_content = json.dumps(serialised_data)
+            file_content = json.dumps(serialised_data, default=date_to_string)
             content_type = "application/json"
             file_extension = "json"
         case "xlsx":
@@ -79,7 +93,7 @@ def data_to_excel(data_generator: Generator[tuple[str, list[dict]], None, None])
     :return: The content of the Excel file as bytes.
     """
     buffer = io.BytesIO()
-    writer = pd.ExcelWriter(buffer, engine="xlsxwriter")
+    writer = pd.ExcelWriter(buffer, engine="xlsxwriter", datetime_format="MM/DD/YYYY")
     for sheet_name, sheet_data in data_generator:
         df = pd.DataFrame.from_records(sheet_data)
         if len(df.index) > 0:

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -1,6 +1,7 @@
 """Mappings to define serialiser outputs for DB models."""
 from typing import Generator
 
+from marshmallow import fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 from sqlalchemy.orm import Query
 from sqlalchemy.sql import text
@@ -141,8 +142,8 @@ class FundingSchema(SQLAlchemySchema):
     funding_source_name = auto_field(data_key="FundingSourceName")
     funding_source_type = auto_field(data_key="FundingSourceType")
     secured = auto_field(data_key="Secured")
-    start_date = auto_field(data_key="StartDate")
-    end_date = auto_field(data_key="EndDate")
+    start_date = fields.Raw(data_key="StartDate")
+    end_date = fields.Raw(data_key="EndDate")
     spend_for_reporting_period = auto_field(data_key="SpendforReportingPeriod")
     status = auto_field(data_key="ActualOrForecast")
     project_name = auto_field(model=Project, data_key="ProjectName")
@@ -170,8 +171,8 @@ class OutcomeDataSchema(SQLAlchemySchema):
     submission_id = auto_field(model=Submission, data_key="SubmissionID")
     programme_id = auto_field(model=Programme, data_key="ProgrammeID")
     project_id = auto_field(model=Project, data_key="ProjectID")
-    start_date = auto_field(data_key="StartDate")
-    end_date = auto_field(data_key="EndDate")
+    start_date = fields.Raw(data_key="StartDate")
+    end_date = fields.Raw(data_key="EndDate")
     outcome_name = auto_field(model=OutcomeDim, data_key="Outcome")
     unit_of_measurement = auto_field(data_key="UnitofMeasurement")
     geography_indicator = auto_field(data_key="GeographyIndicator")
@@ -202,8 +203,8 @@ class OutputDataSchema(SQLAlchemySchema):
 
     submission_id = auto_field(model=Submission, data_key="SubmissionID")
     project_id = auto_field(model=Project, data_key="ProjectID")
-    start_date = auto_field(data_key="FinancialPeriodStart")
-    end_date = auto_field(data_key="FinancialPeriodEnd")
+    start_date = fields.Raw(data_key="FinancialPeriodStart")
+    end_date = fields.Raw(data_key="FinancialPeriodEnd")
     output_name = auto_field(model=OutputDim, data_key="Output")
     unit_of_measurement = auto_field(data_key="UnitofMeasurement")
     state = auto_field(data_key="ActualOrForecast")
@@ -311,8 +312,8 @@ class ProjectProgressSchema(SQLAlchemySchema):
 
     submission_id = auto_field(model=Submission, data_key="SubmissionID")
     project_id = auto_field(model=Project, data_key="ProjectID")
-    start_date = auto_field(data_key="StartDate")
-    end_date = auto_field(data_key="CompletionDate")
+    start_date = fields.Raw(data_key="StartDate")
+    end_date = fields.Raw(data_key="CompletionDate")
     adjustment_request_status = auto_field(data_key="ProjectAdjustmentRequestStatus")
     delivery_status = auto_field(data_key="ProjectDeliveryStatus")
     leading_factor_of_delay = auto_field(data_key="LeadingFactorOfDelay")
@@ -322,7 +323,7 @@ class ProjectProgressSchema(SQLAlchemySchema):
     risk_rag = auto_field(data_key="Risk(RAG)")
     commentary = auto_field(data_key="CommentaryonStatusandRAGRatings")
     important_milestone = auto_field(data_key="MostImportantUpcomingCommsMilestone")
-    date_of_important_milestone = auto_field(data_key="DateofMostImportantUpcomingCommsMilestone")
+    date_of_important_milestone = fields.Raw(data_key="DateofMostImportantUpcomingCommsMilestone")
     project_name = auto_field(model=Project, data_key="ProjectName")
     programme_name = auto_field(model=Programme, data_key="Place")
     organisation_name = auto_field(model=Organisation, data_key="OrganisationName")

--- a/tests/controller_tests/test_download.py
+++ b/tests/controller_tests/test_download.py
@@ -1,9 +1,22 @@
 from copy import deepcopy
+from datetime import date, datetime
 
 import pandas as pd
+import pytest
 
 from core.const import EXCEL_MIMETYPE
-from core.controllers.download import sort_output_dataframes
+from core.controllers.download import date_to_string, sort_output_dataframes
+
+
+def test_date_json_serialisation_helper(test_client):
+    assert date_to_string(datetime(2023, 11, 14, 15, 15, 15)) == "2023-11-14T15:15:15"
+    assert date_to_string(date(2023, 11, 14)) == "2023-11-14"
+
+    class UnknownType:
+        pass
+
+    with pytest.raises(ValueError):
+        date_to_string(UnknownType())
 
 
 def test_invalid_file_format(test_client):

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -23,6 +23,18 @@ def test_serialise_download_data_specific_tab(seeded_test_client, additional_tes
     assert test_serialised_data.keys() == {"ProgrammeRef"}
 
 
+def test_serialise_datetimes(seeded_test_client, additional_test_data):
+    """Check that dates are exported as datetime/date objects instead of plain strings"""
+    base_query = download_data_base_query()
+    test_generator = serialise_download_data(base_query, outcome_categories=None, sheets_required=["Funding"])
+    serialised_data = {sheet: data for sheet, data in test_generator}
+
+    df_output_data = pd.DataFrame.from_records(serialised_data["Funding"])
+
+    assert isinstance(df_output_data["StartDate"].dropna().unique()[0], np.datetime64)
+    assert isinstance(df_output_data["EndDate"].dropna().unique()[0], np.datetime64)
+
+
 def test_serialise_download_data_no_filters(seeded_test_client, additional_test_data):
     base_query = download_data_base_query()
     test_serialised_data = {


### PR DESCRIPTION
### Change description
Extract date fields (e.g. StartDate, EndDate on Funding) to be Excel dates not strings

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
