### PR TITLE
[SMD-387] during extract do lookups with stripped and lowered values

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -133,7 +133,7 @@ def extract_project_lookup(df_lookup: pd.DataFrame, df_place: pd.DataFrame) -> d
     df_lookup.columns = ["Unique Project Identifier", "Town", "Project Name"]
 
     # filter on current place / programme and convert to dict
-    df_lookup = df_lookup.loc[df_lookup["Town"] == place_name]
+    df_lookup = df_lookup.loc[df_lookup["Town"].str.lower().str.strip() == str(place_name).lower().strip()]
     project_lookup = dict(zip(df_lookup["Project Name"], df_lookup["Unique Project Identifier"]))
 
     return project_lookup
@@ -164,8 +164,11 @@ def get_programme_id(df_lookup: pd.DataFrame, df_place: pd.DataFrame) -> str:
         "Town_Deal": FundTypeIdEnum.TOWN_DEAL.value,
         "Future_High_Street_Fund": FundTypeIdEnum.HIGH_STREET_FUND.value,
     }.get(fund_type, "")
+
     if prefix:
-        code = df_lookup.loc[df_lookup["place"] == place_name]["code"].values[0]
+        code = df_lookup.loc[df_lookup["place"].str.lower().str.strip() == str(place_name).lower().strip()][
+            "code"
+        ].values[0]
     else:
         code = ""
 

--- a/tests/extraction_tests/resources/mock_sheet_data/round_three/place_identifiers_mock.csv
+++ b/tests/extraction_tests/resources/mock_sheet_data/round_three/place_identifiers_mock.csv
@@ -1,4 +1,4 @@
 0,,,,,
 ,Town Deals,,,Future High Streets Fund,
-,Fake Town,FAK,,Fake Town,FAK
+, fake Town,FAK,,Fake Town,FAK
 ,Mock Town,MOC,,Test val,TES

--- a/tests/extraction_tests/resources/mock_sheet_data/round_three/project_identifiers_mock.csv
+++ b/tests/extraction_tests/resources/mock_sheet_data/round_three/project_identifiers_mock.csv
@@ -4,6 +4,6 @@
 ,TD-FAK-01,Fake Town,Test Project 1,Active,0,0,,HS-FAK-01,Fake Town,Test Project 1,0,0
 ,TD-FAK-02,Fake Town,Test Project 2,Active,0,0,,HS-FAK-02,Fake Town,Test Project 2,0,0
 ,TD-FAK-03,Fake Town,Test Project 3,Active,0,0,,HS-FAK-03,Fake Town,Test Project 3,0,0
-,TD-MOC-01,Mock Town,Mock Project 1,Active,0,0,,HS-TES-01,Test val,what proj1,0,0
-,TD-MOC-02,Mock Town,Mock Project 2,Active,0,0,,HS-TES-02,Test val,what proj1,0,0
-,TD-MOC-03,Mock Town,Mock Project 3,Active,0,0,,HS-TES-03,Test val,what proj1,0,0
+,TD-MOC-01,Mock Town ,Mock Project 1,Active,0,0,,HS-TES-01,Test val,what proj1,0,0
+,TD-MOC-02,Mock Town ,Mock Project 2,Active,0,0,,HS-TES-02,Test val,what proj1,0,0
+,TD-MOC-03,Mock Town ,Mock Project 3,Active,0,0,,HS-TES-03,Test val,what proj1,0,0


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?selectedIssue=SMD-387

### Change description
- use `strip` and `lower` when using lookups during extraction 

- [X] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
