### PR TITLE
[BAU] skip funding validation if data is non-numeric

### DIFF
--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -351,8 +351,14 @@ def validate_funding_spent(workbook: dict[str, pd.DataFrame]) -> list["TownsFund
     project_ids = workbook["Project Details"]["Project ID"].tolist()
     funding_df = workbook["Funding"]
 
+    try:
+        funding_spent = [spend_per_project(funding_df, project) for project in project_ids]
+    except TypeError:
+        # data contains non-numeric values so cannot validate funding
+        return
+
     # pull funding spent for individual projects into a DataFrame
-    funding_spent = pd.DataFrame([spend_per_project(funding_df, project) for project in project_ids]).set_index("index")
+    funding_spent = pd.DataFrame(funding_spent).set_index("index")
 
     # TODO: create a single Failure instance for a single overspend error with a set of "locations" rather
     #   than a Failure for each cell
@@ -414,6 +420,7 @@ def spend_per_project(funding_df: pd.DataFrame, project_id: str) -> dict[str:int
         ),
         "Total": (funding_df["Spend for Reporting Period"].sum()),
     }
+
     # Business logic here is taken from spreadsheet 4a - Funding Profile Z45 for grand total expenditure
     return funding_spent
 

--- a/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/round_four_specific_validations/test_tf_r4_specific_validations.py
@@ -780,6 +780,41 @@ def test_validate_funding_spent_no_errors(mocker, allocated_funding):
     assert not failures
 
 
+def test_validate_funding_spent_skipped_if_non_numeric_data(mocker, allocated_funding):
+    mocker.patch(
+        "core.validation.specific_validations.towns_fund_round_four.DefaultConfig.TF_FUNDING_ALLOCATED",
+        allocated_funding,
+    )
+    funding_df = pd.DataFrame(
+        data=[
+            # Overspent at the programme level sum of all three project spend
+            # Project 1
+            {
+                "Project ID": "HS-FAK-01",
+                "Funding Source Type": "Towns Fund",
+                "Funding Source Name": "funding CDEL",
+                "Spend for Reporting Period": 1,
+            },
+            {
+                "Project ID": "HS-FAK-01",
+                "Funding Source Type": "Towns Fund",
+                "Funding Source Name": "funding CDEL",
+                "Spend for Reporting Period": "Non-numeric value",  # non numeric
+            },
+        ]
+    )
+
+    workbook = {
+        "Programme_Ref": pd.DataFrame([{"Programme ID": "HS-FAK", "FundType_ID": "HS"}]),
+        "Project Details": pd.DataFrame([{"Project ID": "HS-FAK-01"}]),
+        "Funding": funding_df,
+    }
+
+    failures = validate_funding_spent(workbook)
+
+    assert failures is None
+
+
 def test_validate_funding_profiles_funding_secured_not_null():
     funding_df = pd.DataFrame(
         index=[47, 48, 49, 49],


### PR DESCRIPTION

### Change description
Fixes an issue found on the test environment where if a user entered non numerical funding data, the application would crash on trying to sum the funding data. Now we just skip the funding validation if this happens and rely on the type validation to flag the non-numerical data.

 https://funding-service-design-team-dl.sentry.io/issues/4650934446/events/1ab5e3376f7541aa87504a05a4aab322/

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
