### PR TITLE
[SMD-403] rename spreadsheet language

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -707,7 +707,7 @@ TABLE_SORT_ORDERS = {
 }
 
 # Internal table names to Round 3 & 4 TF tab names mapping
-INTERNAL_TABLE_TO_FORM_TAB = {
+INTERNAL_TABLE_TO_FORM_SHEET = {
     "Project Details": "Project Admin",
     "Project Progress": "Programme Progress",
     "Programme Progress": "Programme Progress",

--- a/core/extraction/towns_fund_round_one.py
+++ b/core/extraction/towns_fund_round_one.py
@@ -1214,7 +1214,7 @@ def extract_data_model_fields() -> pd.DataFrame:
 
     :return: DataFrame mapping data model table names to their respective column names.
     """
-    column_mapping = {mapping.worksheet_name: list(mapping.column_mapping.keys()) for mapping in INGEST_MAPPINGS}
+    column_mapping = {mapping.table: list(mapping.column_mapping.keys()) for mapping in INGEST_MAPPINGS}
 
     dataframe_mapping = {table_name: pd.DataFrame(columns=columns) for table_name, columns in column_mapping.items()}
 

--- a/core/util.py
+++ b/core/util.py
@@ -59,14 +59,14 @@ def group_by_first_element(tuples: list[tuple]) -> dict[str, list[tuple | Any]]:
     return nested
 
 
-def get_project_number_by_position(row_index: int, sheet: str):
+def get_project_number_by_position(row_index: int, table: str):
     """Extracts the project number from the row index and table name of a row by mapping it's on page position
 
     :param row_index: row number on Excel sheet that row has come from
-    :param sheet: name of the database table the row has come from
+    :param table: name of the table the row has come from
     :return: project number
     """
-    match sheet:
+    match table:
         case "Funding" | "Funding Comments":
             project_number = math.ceil((row_index - 32) / 28)
         case "Output_Data":

--- a/core/validation/__init__.py
+++ b/core/validation/__init__.py
@@ -4,7 +4,7 @@ import core.validation.specific_validations.towns_fund_round_four as tf_round_4
 from core.exceptions import ValidationError
 from core.validation.casting import cast_to_schema
 from core.validation.initial_check import validate_sign_off
-from core.validation.validate import validate_workbook
+from core.validation.validate import validate_data
 from core.validation_schema import get_schema
 
 
@@ -19,7 +19,7 @@ def validate(workbook: dict[str, pd.DataFrame], original_workbook: dict[str, pd.
     """
     validation_schema = get_schema(reporting_round)
     cast_to_schema(workbook, validation_schema)
-    validation_failures = validate_workbook(workbook, validation_schema)
+    validation_failures = validate_data(workbook, validation_schema)
 
     if reporting_round == 4:
         round_4_failures = tf_round_4.validate(workbook)

--- a/core/validation/casting.py
+++ b/core/validation/casting.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def cast_to_schema(workbook: dict[str, pd.DataFrame], schema: dict) -> None:
+def cast_to_schema(data: dict[str, pd.DataFrame], schema: dict) -> None:
     """
     Cast the columns in a workbook to the data types specified in the schema. This
     process modifies workbook in-place.
@@ -9,28 +9,28 @@ def cast_to_schema(workbook: dict[str, pd.DataFrame], schema: dict) -> None:
     This step is needed because data extracted from spreadsheets are often parsed as
     strings by default.
 
-    :param workbook: A dictionary mapping sheet names to data frames.
-    :param schema: A dictionary specifying the data types for each column in each sheet.
+    :param data: A dictionary mapping table_data names to data frames.
+    :param schema: A dictionary specifying the data types for each column in each table_data.
     :return: None
     """
-    for sheet_name, sheet in workbook.items():
-        if sheet_name not in schema:
-            continue  # skip casting if schema doesn't exist for that sheet - this will be caught during validation
+    for table, table_data in data.items():
+        if table not in schema:
+            continue  # skip casting if schema doesn't exist for that table_data - this will be caught during validation
 
-        column_to_type = schema[sheet_name]["columns"]
-        sheet_types = sheet.dtypes
+        column_to_type = schema[table]["columns"]
+        table_types = table_data.dtypes
 
-        sheet_retyped = False
+        table_retyped = False
         for column, target_type in column_to_type.items():
-            if column in sheet_types:
-                original_type = sheet_types[column]
+            if column in table_types:
+                original_type = table_types[column]
 
                 if original_type != target_type:
                     try:
-                        sheet[column] = sheet[column].astype(target_type)
-                        sheet_retyped = True
+                        table_data[column] = table_data[column].astype(target_type)
+                        table_retyped = True
                     except ValueError:
                         continue  # this will be caught during validation
 
-        if sheet_retyped:
-            workbook[sheet_name] = sheet
+        if table_retyped:
+            data[table] = table_data

--- a/core/validation/failures/internal.py
+++ b/core/validation/failures/internal.py
@@ -17,57 +17,56 @@ class InternalValidationFailure(ValidationFailureBase):
 
 
 @dataclass
-class ExtraSheetFailure(InternalValidationFailure):
-    """Class representing an extra sheet failure."""
+class ExtraTableFailure(InternalValidationFailure):
+    """Class representing an extra table failure."""
 
-    extra_sheet: str
+    extra_table: str
 
     def __str__(self):
         """
-        Method to get the string representation of the extra sheet failure.
+        Method to get the string representation of the extra table failure.
         """
         return (
-            "Extra Sheets Failure: The workbook included a sheet named"
-            f'"{self.extra_sheet}" but it is not in the schema.'
+            "Extra Table Failure: The data included a table named" f'"{self.extra_table}" but it is not in the schema.'
         )
 
 
 @dataclass
-class EmptySheetFailure(InternalValidationFailure):
-    """Class representing an empty sheet failure."""
+class EmptyTableFailure(InternalValidationFailure):
+    """Class representing an empty table failure."""
 
-    empty_sheet: str
+    empty_table: str
 
     def __str__(self):
-        """Method to get the string representation of the empty sheet failure."""
-        return f'Empty Sheets Failure: The sheet named "{self.empty_sheet}" contains no ' "data."
+        """Method to get the string representation of the empty table failure."""
+        return f'Empty Table Failure: The table named "{self.empty_table}" contains no data.'
 
 
 @dataclass
 class ExtraColumnFailure(InternalValidationFailure):
     """Class representing an extra column failure."""
 
-    sheet: str
+    table: str
     extra_column: str
 
     def __str__(self):
         """
         Method to get the string representation of the extra column failure.
         """
-        return f'Extra Column Failure: Sheet "{self.sheet}" Column' f' "{self.extra_column}" is not in the schema.'
+        return f'Extra Column Failure: Table "{self.table}" Column' f' "{self.extra_column}" is not in the schema.'
 
 
 @dataclass
 class MissingColumnFailure(InternalValidationFailure):
     """Class representing a missing column failure."""
 
-    sheet: str
+    table: str
     missing_column: str
 
     def __str__(self):
         """Method to get the string representation of the missing column failure."""
         return (
-            f'Missing Column Failure: Sheet "{self.sheet}" Column'
+            f'Missing Column Failure: Table "{self.table}" Column'
             f' "{self.missing_column}" is missing from the schema.'
         )
 
@@ -76,19 +75,19 @@ class MissingColumnFailure(InternalValidationFailure):
 class NonUniqueFailure(InternalValidationFailure):
     """Class representing a non-unique value failure."""
 
-    sheet: str
+    table: str
     column: str
 
     def __str__(self):
         """Method to get the string representation of the non-unique value failure."""
-        return f'Non Unique Failure: Sheet "{self.sheet}" column "{self.column}" should ' f"contain only unique values."
+        return f'Non Unique Failure: Table "{self.table}" column "{self.column}" should ' f"contain only unique values."
 
 
 @dataclass
 class OrphanedRowFailure(InternalValidationFailure):
     """Class representing an orphaned row failure."""
 
-    sheet: str
+    table: str
     row: int
     foreign_key: str
     fk_value: Any
@@ -98,7 +97,7 @@ class OrphanedRowFailure(InternalValidationFailure):
     def __str__(self):
         """Method to get the string representation of the orphaned row failure."""
         return (
-            f'Orphaned Row Failure: Sheet "{self.sheet}" Column "{self.foreign_key}" '
+            f'Orphaned Row Failure: Table "{self.table}" Column "{self.foreign_key}" '
             f"Row {self.row} "
             f'Value "{self.fk_value}" not in parent table '
             f'"{self.parent_table}" where PK "{self.parent_pk}"'
@@ -106,14 +105,11 @@ class OrphanedRowFailure(InternalValidationFailure):
 
 
 @dataclass
-class InvalidSheetFailure(InternalValidationFailure):
-    """Class representing an invalid sheet failure."""
+class InvalidTableFailure(InternalValidationFailure):
+    """Class representing an invalid table failure."""
 
-    invalid_sheet: str
+    invalid_table: str
 
     def __str__(self):
-        """Method to get the string representation of the empty sheet failure."""
-        return (
-            f"Invalid Sheets Failure: The sheet named {self.invalid_sheet} is invalid "
-            f"as it is missing expected values"
-        )
+        """Method to get the string representation of the empty table failure."""
+        return f'Invalid Table Failure: Table "{self.invalid_table}" is invalid as it is missing expected values'

--- a/core/validation/schema.py
+++ b/core/validation/schema.py
@@ -13,53 +13,53 @@ def parse_schema(schema: dict) -> Optional[dict]:
     :return: Returns the parsed schema or None if invalid.
     """
     try:
-        for sheet_name, sheet_schema in schema.items():
+        for table, table_schema in schema.items():
             # Check all defined types are valid and transform to numpy dtypes
-            for column, dtype in sheet_schema["columns"].items():
-                assert dtype in _PY_TO_NUMPY_TYPES, f"Invalid type for column {column} in sheet {sheet_name}: {dtype}"
-                sheet_schema["columns"][column] = _PY_TO_NUMPY_TYPES[dtype]
+            for column, dtype in table_schema["columns"].items():
+                assert dtype in _PY_TO_NUMPY_TYPES, f"Invalid type for column {column} in table {table}: {dtype}"
+                table_schema["columns"][column] = _PY_TO_NUMPY_TYPES[dtype]
 
             # unpack enum classes to sets their sets of values
-            enums = sheet_schema.get("enums", {})
+            enums = table_schema.get("enums", {})
             for column, enum in enums.items():
                 assert isinstance(enum, EnumType), f"{enum} is not an EnumType"
-                sheet_schema["enums"][column] = {str(e) for e in enum}
+                table_schema["enums"][column] = {str(e) for e in enum}
 
             # Check all unique columns exist in columns
-            columns = set(sheet_schema["columns"].keys())
-            uniques = sheet_schema.get("uniques", [])
+            columns = set(table_schema["columns"].keys())
+            uniques = table_schema.get("uniques", [])
             undefined_uniques = {unique for unique in uniques if unique not in columns}
-            assert isinstance(uniques, list), f'Uniques are not a list in sheet "{sheet_name}"'
+            assert isinstance(uniques, list), f'Uniques are not a list in table "{table}"'
             assert not undefined_uniques, (
-                f'The following columns in sheet "{sheet_name}" are undefined but in ' f"uniques: {undefined_uniques}"
+                f'The following columns in table "{table}" are undefined but in ' f"uniques: {undefined_uniques}"
             )
 
             # Check foreign key definitions are valid
-            foreign_keys = sheet_schema.get("foreign_keys", {})
+            foreign_keys = table_schema.get("foreign_keys", {})
             for column, lookup in foreign_keys.items():
-                assert column in sheet_schema["columns"].keys()  # check FK exists
+                assert column in table_schema["columns"].keys()  # check FK exists
                 assert lookup["parent_table"] in schema.keys()  # check parent table exists
                 assert lookup["parent_pk"] in schema[lookup["parent_table"]]["columns"].keys()  # check parent pk exists
                 assert (
                     lookup["parent_pk"] in schema[lookup["parent_table"]]["uniques"]
                 )  # check parent pk has unique constraint
-                assert lookup["parent_table"] != sheet_name  # check fk definition is not self referencing
+                assert lookup["parent_table"] != table  # check fk definition is not self referencing
 
             # Check enum definitions are valid
-            enums = sheet_schema.get("enums", {})
+            enums = table_schema.get("enums", {})
             for column, enum_values in enums.items():
                 assert column in columns
                 assert isinstance(enum_values, (list, set))
                 assert all(isinstance(value, str) for value in enum_values)
-                sheet_schema["enums"][column] = set(enum_values)  # cast to a set
+                table_schema["enums"][column] = set(enum_values)  # cast to a set
 
             # TODO: add tests for this
-            non_nullable = sheet_schema.get("non-nullable", [])
+            non_nullable = table_schema.get("non-nullable", [])
             for column in non_nullable:
                 assert column in columns, f"{column} - not in columns - {columns}"
 
             # TODO: add tests for this
-            table_nullable = sheet_schema.get("table_nullable", False)
+            table_nullable = table_schema.get("table_nullable", False)
             assert isinstance(table_nullable, bool), f"table_nullable should be bool but is {type(table_nullable)}"
 
     except (KeyError, AttributeError, AssertionError) as schema_err:

--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -6,7 +6,7 @@ import pandas as pd
 import core.validation.messages as msgs
 from config.envs.default import DefaultConfig
 from core.const import (
-    INTERNAL_TABLE_TO_FORM_TAB,
+    INTERNAL_TABLE_TO_FORM_SHEET,
     PRE_DEFINED_FUNDING_SOURCES,
     FundingSourceCategoryEnum,
     FundingUses,
@@ -639,5 +639,5 @@ class TownsFundRoundFourValidationFailure(UserValidationFailure):
 
     def to_message(self) -> tuple[str | None, str | None, str | None, str]:
         cell_index = construct_cell_index(self.sheet, self.column, self.row_index)
-        sheet = INTERNAL_TABLE_TO_FORM_TAB[self.sheet]
+        sheet = INTERNAL_TABLE_TO_FORM_SHEET[self.sheet]
         return sheet, self.section, cell_index, self.message

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -1,6 +1,6 @@
-"""Excel Workbook Validation
+"""Excel Data Validation
 
-Provides functionality for validating a workbook against a schema. Any schema offense
+Provides functionality for validating a data against a schema. Any schema offense
 cause the validation to fail. Details of these failures are captured and returned.
 """
 import numbers
@@ -13,61 +13,61 @@ from core.validation.schema import _PY_TO_NUMPY_TYPES
 from core.validation.utils import is_blank, remove_duplicate_indexes
 
 
-def validate_workbook(
-    workbook: dict[str, pd.DataFrame], schema: dict
+def validate_data(
+    data_dict: dict[str, pd.DataFrame], schema: dict
 ) -> list[user.SchemaUserValidationFailure | internal.InternalValidationFailure]:
-    """Validate a workbook against a schema.
+    """Validate a set of data against a schema.
 
     This is the top-level validate function. It:
     - casts all column types to those defined in the schema.
-    - removes any sheets that aren't in the schema.
+    - removes any tables that aren't in the schema.
     - validates remaining data against constraints defined in the schema.
     - captures and returns any causes of validation failure.
 
-    :param workbook: A dictionary where keys are sheet names and values are pandas
+    :param data_dict: A dictionary where keys are table names and values are pandas
                      DataFrames.
-    :param schema: A dictionary defining the schema of the workbook, with sheet names as
+    :param schema: A dictionary defining the schema of the data, with table names as
                    keys and values that are dictionaries mapping column names to
                    expected data types and any additional validation criteria.
     :return: A list of ValidationFailure objects representing any validation errors
              found.
     """
-    extra_sheets = remove_undefined_sheets(workbook, schema)
-    validation_failures = validations(workbook, schema)
-    return [*extra_sheets, *validation_failures]
+    extra_tables = remove_undefined_tables(data_dict, schema)
+    validation_failures = validations(data_dict, schema)
+    return [*extra_tables, *validation_failures]
 
 
-def remove_undefined_sheets(workbook: dict[str, pd.DataFrame], schema: dict) -> list[internal.ExtraSheetFailure]:
-    """Remove any sheets undefined in the schema.
+def remove_undefined_tables(data_dict: dict[str, pd.DataFrame], schema: dict) -> list[internal.ExtraTableFailure]:
+    """Remove any tables undefined in the schema.
 
-    If any sheets are undefined then fail validation and capture.
+    If any tables are undefined then fail validation and capture.
 
-    :param workbook: a dictionary of pd.DataFrames (worksheets)
-    :param schema: schema containing the expected sheet names
-    :return: any captured ExtraSheetFailures
+    :param data_dict: a dictionary of pd.DataFrames (tables)
+    :param schema: schema containing the expected table names
+    :return: any captured ExtraTableFailures
     """
-    sheet_names_in_data = set(workbook.keys())
-    sheet_names_in_schema = set(schema.keys())
-    extra_sheets = sheet_names_in_data - sheet_names_in_schema
+    data_tables = set(data_dict.keys())
+    schema_tables = set(schema.keys())
+    extra_tables = data_tables - schema_tables
 
-    for invalid_sheet in extra_sheets:
-        del workbook[invalid_sheet]  # discard undefined sheets
+    for invalid_table in extra_tables:
+        del data_dict[invalid_table]  # discard undefined tables
 
-    extra_sheet_failures = [internal.ExtraSheetFailure(extra_sheet=extra_sheet) for extra_sheet in extra_sheets]
-    return extra_sheet_failures
+    extra_table_failures = [internal.ExtraTableFailure(extra_table=extra_table) for extra_table in extra_tables]
+    return extra_table_failures
 
 
 def validations(
-    workbook: dict[str, pd.DataFrame], schema: dict
+    data_dict: dict[str, pd.DataFrame], schema: dict
 ) -> list[user.SchemaUserValidationFailure | internal.InternalValidationFailure]:
     """
-    Validate the given workbook against a provided schema by checking each sheet's
+    Validate the given data against a provided schema by checking each table's
     columns, data types, unique values, and foreign keys.
 
-    :param workbook: A dictionary where keys are sheet names and values are pandas
+    :param data_dict: A dictionary where keys are table names and values are pandas
                      DataFrames.
-    :param schema: A dictionary containing the validation schema for each sheet of the
-                   workbook.
+    :param schema: A dictionary containing the validation schema for each table of the
+                   data.
     :return: A list of validation failures encountered during validation, if any.
     """
     constraints = (
@@ -81,67 +81,64 @@ def validations(
     )
 
     validation_failures = []
-    for sheet_name in workbook.keys():
-        # if the table is empty and not defined as nullable, then raise an Empty Sheet Failure
-        if workbook[sheet_name].empty and not schema[sheet_name].get("table_nullable"):
-            validation_failures.append(internal.EmptySheetFailure(sheet_name))
+    for table in data_dict.keys():
+        # if the table is empty and not defined as nullable, then raise an Empty Table Failure
+        if data_dict[table].empty and not schema[table].get("table_nullable"):
+            validation_failures.append(internal.EmptyTableFailure(table))
             continue
 
-        sheet_schema = schema[sheet_name]
+        table_schema = schema[table]
 
         for validation_func, schema_section in constraints:
-            if schema_section in sheet_schema:
-                validation_failures.extend(validation_func(workbook, sheet_name, sheet_schema[schema_section]))
+            if schema_section in table_schema:
+                validation_failures.extend(validation_func(data_dict, table, table_schema[schema_section]))
 
     return validation_failures
 
 
 def validate_columns(
-    workbook: dict[str, pd.DataFrame], sheet_name: str, column_to_type: dict
+    data_dict: dict[str, pd.DataFrame], table: str, column_to_type: dict
 ) -> list[internal.ExtraColumnFailure | internal.MissingColumnFailure]:
     """
-    Validate that the columns in a given worksheet align with the schema by
+    Validate that the columns in a given table align with the schema by
     comparing the column names to the provided schema.
 
-    :param workbook: A dictionary where keys are sheet names and values are
+    :param data_dict: A dictionary where keys are table names and values are
                      pandas DataFrames.
-    :param sheet_name: The name of the worksheet to validate.
+    :param table: The name of the table to validate.
     :param column_to_type: A dictionary where keys are column names and values
                            are expected data types.
     :return: A list of extra and missing column failures, if any.
     """
-    columns = workbook[sheet_name].columns
+    columns = data_dict[table].columns
     data_columns = set(columns)
     schema_columns = set(column_to_type.keys())
     extra_columns = data_columns - schema_columns
     missing_columns = schema_columns - data_columns
 
     extra_column_failures = [
-        internal.ExtraColumnFailure(sheet=sheet_name, extra_column=extra_column) for extra_column in extra_columns
+        internal.ExtraColumnFailure(table=table, extra_column=extra_column) for extra_column in extra_columns
     ]
     missing_column_failures = [
-        internal.MissingColumnFailure(sheet=sheet_name, missing_column=missing_column)
-        for missing_column in missing_columns
+        internal.MissingColumnFailure(table=table, missing_column=missing_column) for missing_column in missing_columns
     ]
     return [*extra_column_failures, *missing_column_failures]
 
 
-def validate_types(
-    workbook: dict[str, pd.DataFrame], sheet_name: str, column_to_type: dict
-) -> list[user.WrongTypeFailure]:
+def validate_types(data_dict: dict[str, pd.DataFrame], table: str, column_to_type: dict) -> list[user.WrongTypeFailure]:
     """
-    Validate that the data types of columns in a given worksheet align with the
+    Validate that the data types of columns in a given table align with the
     provided schema by comparing the actual types to the expected types.
 
-    :param workbook: A dictionary where keys are sheet names and values are pandas
+    :param data_dict: A dictionary where keys are table names and values are pandas
                      DataFrames.
-    :param sheet_name: The name of the worksheet to validate.
+    :param table: The name of the table to validate.
     :param column_to_type: A dictionary where keys are column names and values are
                            expected data types.
     :return: A list of wrong type failures, if any.
     """
     wrong_type_failures = []
-    for index, row in workbook[sheet_name].iterrows():
+    for index, row in data_dict[table].iterrows():
         for column, exp_type in column_to_type.items():
             got_value = row.get(column)
             if got_value is None or pd.isna(got_value):
@@ -155,7 +152,7 @@ def validate_types(
             if got_type != exp_type:
                 wrong_type_failures.append(
                     user.WrongTypeFailure(
-                        sheet=sheet_name,
+                        table=table,
                         column=column,
                         expected_type=exp_type,
                         actual_type=got_type,
@@ -168,46 +165,46 @@ def validate_types(
 
 
 def validate_uniques(
-    workbook: dict[str, pd.DataFrame], sheet_name: str, unique_columns: list
+    data_dict: dict[str, pd.DataFrame], table: str, unique_columns: list
 ) -> list[internal.NonUniqueFailure]:
     """Validate that unique columns have all unique values.
 
-    :param workbook: A dictionary where keys are sheet names and values are
+    :param data_dict: A dictionary where keys are table names and values are
                      pandas DataFrames.
-    :param sheet_name: The name of the worksheet to validate.
+    :param table: The name of the table to validate.
     :param unique_columns: A list of columns that should contain only unique values.
     :return: A list of non-unique failures, if any.
     """
-    sheet = workbook[sheet_name]
+    data_df = data_dict[table]
     non_unique_failures = [
-        internal.NonUniqueFailure(sheet=sheet_name, column=column)
+        internal.NonUniqueFailure(table=table, column=column)
         for column in unique_columns
-        if not sheet[column].is_unique
+        if not data_df[column].is_unique
     ]
 
     return non_unique_failures
 
 
 def validate_unique_composite_key(
-    workbook: dict[str, pd.DataFrame], sheet_name: str, composite_key: tuple
+    data_dict: dict[str, pd.DataFrame], table: str, composite_key: tuple
 ) -> list[user.NonUniqueCompositeKeyFailure]:
     """
-    Validates the uniqueness of specified composite key for given sheet in workbook.
+    Validates the uniqueness of specified composite key for given table in data.
 
-    :param workbook: A dictionary containing sheet names as keys and corresponding pandas DataFrames as values.
-    :param sheet_name: The name of the worksheet to be validated.
+    :param data_dict: A dictionary containing table names as keys and corresponding pandas DataFrames as values.
+    :param table: The name of the table to be validated.
     :param composite_key: A list of tuples, where each tuple contains the column names
                            that should have combined uniqueness.
     :return: A list of non-unique composite key failures, if any exist.
     """
 
-    sheet = workbook[sheet_name]
+    data_df = data_dict[table]
     non_unique_composite_key_failures = []
     composite_key = list(composite_key)
 
     # filter dataframe by these columns and find duplicated rows including NaN/Empty
-    mask = sheet[composite_key].duplicated(keep="first")
-    duplicated_rows = sheet[mask][composite_key]
+    mask = data_df[composite_key].duplicated(keep="first")
+    duplicated_rows = data_df[mask][composite_key]
 
     # handle melted rows
     duplicated_rows = remove_duplicate_indexes(duplicated_rows)
@@ -217,7 +214,7 @@ def validate_unique_composite_key(
         #   than a Failure for each cell
         failures = [
             user.NonUniqueCompositeKeyFailure(
-                sheet=sheet_name, column=composite_key, row=duplicate.values.tolist(), row_index=idx
+                table=table, column=composite_key, row=duplicate.values.tolist(), row_index=idx
             )
             for idx, duplicate in duplicated_rows.iterrows()
         ]
@@ -227,36 +224,36 @@ def validate_unique_composite_key(
 
 
 def validate_foreign_keys(
-    workbook: dict[str, pd.DataFrame],
-    sheet_name: str,
+    data_dict: dict[str, pd.DataFrame],
+    table: str,
     foreign_keys: dict[str, dict[str, str]],
 ) -> list[internal.OrphanedRowFailure]:
     """
-    Validate that foreign key values in a given worksheet reference existing
+    Validate that foreign key values in a given table reference existing
     rows in their respective parent tables. For each foreign key in the schema,
     this function checks that the values in the column are present in the parent
     table's corresponding primary key column.
 
-    :param workbook: A dictionary where keys are sheet names and values are
+    :param data_dict: A dictionary where keys are table names and values are
                      pandas DataFrames.
-    :param sheet_name: The name of the worksheet to validate.
+    :param table: The name of the table to validate.
     :param foreign_keys: A dictionary where keys are column names containing
                          foreign keys and values are themselves dictionaries
                          containing the parent table name and parent primary
                          key column name.
     :return: A list of orphaned row failures, if any.
     """
-    sheet = workbook[sheet_name]
+    data_df = data_dict[table]
     orphaned_rows = []
 
     for foreign_key, parent in foreign_keys.items():
-        fk_values: NDArray = sheet[foreign_key].values
+        fk_values: NDArray = data_df[foreign_key].values
         # TODO: Handle situation when the parent table and or parent_pk doesn't exist in the data
-        lookup_values = set(workbook[parent["parent_table"]][parent["parent_pk"]].values)
+        lookup_values = set(data_dict[parent["parent_table"]][parent["parent_pk"]].values)
         nullable = parent.get("nullable", False)
         orphaned_rows.extend(
             internal.OrphanedRowFailure(
-                sheet=sheet_name,
+                table=table,
                 row=row_idx,
                 foreign_key=foreign_key,
                 fk_value=fk_val,
@@ -281,28 +278,28 @@ def _is_allowed_na_value(nullable_flag, value):
 
 
 def validate_enums(
-    workbook: dict[str, pd.DataFrame],
-    sheet_name: str,
+    data_dict: dict[str, pd.DataFrame],
+    table: str,
     enums: dict[str, set[str]],
 ) -> list[user.InvalidEnumValueFailure]:
     """
     Validate that all values in specified columns belong to a given set of valid values.
 
-    :param workbook: A dictionary of pandas DataFrames, where the keys are the sheet
+    :param data_dict: A dictionary of pandas DataFrames, where the keys are the table
                      names.
-    :param sheet_name: The name of the sheet to validate.
+    :param table: The name of the table to validate.
     :param enums: A dictionary where the keys are column names, and the values are sets
                   of valid values for that column.
     :return: A list of InvalidEnumValueFailure objects for any rows with values outside
              the set of valid enum values.
     """
-    sheet = workbook[sheet_name]
+    data_df = data_dict[table]
     invalid_enum_values = []
 
     for column, valid_enum_values in enums.items():
         valid_enum_values.add("")  # allow empty string here, picked up later
-        row_is_valid = sheet[column].isin(valid_enum_values)
-        invalid_rows = sheet[~row_is_valid]
+        row_is_valid = data_df[column].isin(valid_enum_values)
+        invalid_rows = data_df[~row_is_valid]
 
         # handle melted rows
         invalid_rows = remove_duplicate_indexes(invalid_rows)
@@ -313,7 +310,7 @@ def validate_enums(
                 continue  # allow na values here
             invalid_enum_values.append(
                 user.InvalidEnumValueFailure(
-                    sheet=sheet_name,
+                    table=table,
                     column=column,
                     row_index=row.name,
                     row_values=tuple(row),
@@ -324,33 +321,33 @@ def validate_enums(
 
 
 def validate_nullable(
-    workbook: dict[str, pd.DataFrame],
-    sheet_name: str,
+    data_dict: dict[str, pd.DataFrame],
+    table: str,
     non_nullable: list[str],
 ) -> list[user.NonNullableConstraintFailure]:
     """Validate that specified columns do not contain null or empty values.
 
     This function checks for null (NaN) values and empty string values in the specified
-    columns of the given sheet in the workbook. If any null or empty values are found,
+    columns of the given table in the data. If any null or empty values are found,
     NonNullableConstraintFailure objects are created and returned in a list.
 
-    :param workbook: A dictionary of pandas DataFrames, where the keys are the sheet names.
-    :param sheet_name: The name of the sheet to validate.
+    :param data_dict: A dictionary of pandas DataFrames, where the keys are the table names.
+    :param table: The name of the table to validate.
     :param non_nullable: A list of column names that should not contain null or empty values.
     :return: A list of NonNullableConstraintFailure objects for any rows violating the non-nullable constraint.
     """
     if not non_nullable:
         return []
 
-    sheet = workbook[sheet_name]
+    data_df = data_dict[table]
     non_nullable_constraint_failure = []
 
-    for idx, row in sheet.iterrows():
+    for idx, row in data_df.iterrows():
         for column in non_nullable:
             if is_blank(row[column]):
                 non_nullable_constraint_failure.append(
                     user.NonNullableConstraintFailure(
-                        sheet=sheet_name,
+                        table=table,
                         column=column,
                         row_index=idx,
                         failed_row=row,

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from core.validation.casting import cast_to_schema
 from core.validation.schema import parse_schema
-from core.validation.validate import validate_workbook
+from core.validation.validate import validate_data
 
 
 def load_schema(file_path, variable):
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         exit()
 
     cast_to_schema(workbook, schema)
-    errors = validate_workbook(workbook=workbook, schema=schema)
+    errors = validate_data(data_dict=workbook, schema=schema)
 
     if errors:
         for error in errors:

--- a/tests/controller_tests/test_ingest.py
+++ b/tests/controller_tests/test_ingest.py
@@ -414,7 +414,7 @@ def test_ingest_endpoint_returns_validation_errors(test_client, example_data_mod
         side_effect=ValidationError(
             validation_failures=[
                 NonNullableConstraintFailure(
-                    sheet="Project Progress", column="Start Date", row_index=5, failed_row=None
+                    table="Project Progress", column="Start Date", row_index=5, failed_row=None
                 )
             ]
         ),

--- a/tests/controller_tests/test_mappings.py
+++ b/tests/controller_tests/test_mappings.py
@@ -44,7 +44,7 @@ def test_data_mapping(mocked_get_row_id):
     )
     mapping.fk_relations.append(fk_mapping)
 
-    models = mapping.map_worksheet_to_models(worksheet)
+    models = mapping.map_data_to_models(worksheet)
 
     # mapping returns the correct number of results
     assert len(models) == 2
@@ -77,7 +77,7 @@ def test_data_mapping_project_id_fk(mocked_get_row_id):
     )
     mapping.fk_relations.append(fk_mapping)
 
-    models = mapping.map_worksheet_to_models(worksheet)
+    models = mapping.map_data_to_models(worksheet)
 
     assert len(models) == 1
     assert models[0].project_id == "123"  # mocked_get_row_id return value
@@ -108,7 +108,7 @@ def test_data_mapping_child_fk_attribute_matches_lookup_attribute(mocked_get_row
     )
     mapping.fk_relations.append(fk_mapping)
 
-    models = mapping.map_worksheet_to_models(worksheet)
+    models = mapping.map_data_to_models(worksheet)
 
     assert len(models) == 1
     assert models[0].child_fk_and_lookup == "123"  # mocked_get_row_id return value

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -174,7 +174,7 @@ def test_full_ingest_columns(mock_ingest_full_extract):
     it's corresponding DataMapping sub-tuple of INGEST_MAPPINGS (which contains expected column names for each).
     """
     for mapping in INGEST_MAPPINGS:
-        extract_columns = set(mock_ingest_full_extract[mapping.worksheet_name].columns)
+        extract_columns = set(mock_ingest_full_extract[mapping.table].columns)
         mapping_columns = set(mapping.column_mapping.keys())
 
         # Submission ID discarded from expected results, as this added later.

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -426,11 +426,11 @@ def test_full_ingest_columns(mock_ingest_full_extract):
     it's corresponding DataMapping sub-tuple of INGEST_MAPPINGS (which contains expected column names for each).
     """
     for mapping in INGEST_MAPPINGS:
-        extract_columns = set(mock_ingest_full_extract[mapping.worksheet_name].columns)
+        extract_columns = set(mock_ingest_full_extract[mapping.table].columns)
         mapping_columns = set(mapping.column_mapping.keys())
 
         # remove round 4 specific columns
-        if mapping.worksheet_name == "Project Progress":
+        if mapping.table == "Project Progress":
             mapping_columns.discard("Leading Factor of Delay")
             mapping_columns.discard("Current Project Delivery Stage")
 

--- a/tests/integration_tests/test_ingest_component.py
+++ b/tests/integration_tests/test_ingest_component.py
@@ -139,7 +139,6 @@ def test_ingest_with_r4_corrupt_submission(test_client_function, towns_fund_roun
             "excel_file": towns_fund_round_4_file_corrupt,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -164,7 +163,6 @@ def test_ingest_with_r4_file_pre_transformation_failure(
             "excel_file": towns_fund_round_4_file_pre_transformation_failure,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -196,7 +194,6 @@ def test_ingest_with_r4_file_authorisation_failure(test_client_function, towns_f
             "excel_file": towns_fund_round_4_file_success,
             "reporting_round": 4,
             "place_names": ["Buxton"],
-            "do_load": False,
         },
     )
 
@@ -224,7 +221,6 @@ def test_ingest_with_r4_file_project_outcome_failure(
             "excel_file": towns_fund_round_4_file_project_outcome_failure,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -268,7 +264,6 @@ def test_ingest_with_r4_file_psi_risk_register_failure(
             "excel_file": towns_fund_round_4_file_psi_risk_register_failure,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -337,7 +332,6 @@ def test_ingest_with_r4_file_project_admin_project_progress_failure(
             "excel_file": towns_fund_round_4_file_project_admin_project_progress_failure,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -389,7 +383,6 @@ def test_ingest_with_r4_file_td_funding_failure(test_client_function, towns_fund
             "excel_file": towns_fund_round_4_file_td_funding_failure,
             "reporting_round": 4,
             "place_names": ["Worcester"],
-            "do_load": False,
         },
     )
 
@@ -467,7 +460,6 @@ def test_ingest_with_r4_file_hs_file_failure(test_client_function, towns_fund_ro
             "excel_file": towns_fund_round_4_file_hs_funding_failure,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 
@@ -506,7 +498,6 @@ def test_ingest_with_r4_round_agnostic_failures(test_client_function, towns_fund
             "excel_file": towns_fund_round_4_round_agnostic_failures,
             "reporting_round": 4,
             "place_names": ["Blackfriars - Northern City Centre"],
-            "do_load": False,
         },
     )
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -16,7 +16,7 @@ from core.validation.failures import internal, user
 def test_handle_validation_error_internal(test_client, mocker, caplog):
     mock_save_failed_submission = mocker.patch("core.handlers.save_failed_submission", return_value="AN ID")
 
-    failures = [internal.ExtraSheetFailure(extra_sheet="Test Table")]
+    failures = [internal.ExtraTableFailure(extra_table="Test Table")]
     with caplog.at_level(logging.ERROR) and test_client.application.test_request_context():
         file = BytesIO(b"mock file")
         g.excel_file = file

--- a/tests/validation_tests/test_failures.py
+++ b/tests/validation_tests/test_failures.py
@@ -63,91 +63,91 @@ def test_failures_to_messages_pre_transformation_failures():
 
 def test_invalid_enum_messages():
     InvalidEnumValueFailure(
-        sheet="Project Details",
+        table="Project Details",
         column="Single or Multiple Locations",
         row_index=1,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Project Delivery Status",
         row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Delivery (RAG)",
         row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Spend (RAG)",
         row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Risk (RAG)",
         row_index=2,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Funding",
+        table="Funding",
         column="Secured",
         row_index=50,
         row_values=("TD-ABC-1", "Value 2", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="Pre-mitigatedImpact",
         row_index=23,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="Pre-mitigatedLikelihood",
         row_index=24,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="PostMitigatedImpact",
         row_index=25,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="PostMitigatedLikelihood",
         row_index=23,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="Proximity",
         row_index=24,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Project Adjustment Request Status",
         row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Current Project Delivery Stage",
         row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Leading Factor of Delay",
         row_index=2,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
     ).to_message()
     InvalidEnumValueFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column="RiskCategory",
         row_index=25,
         row_values=("Value 1", "TD-ABC-01", "Value 3", "Value 4"),
@@ -157,78 +157,78 @@ def test_invalid_enum_messages():
 def test_non_nullable_messages_project_details():
     failed_rows = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=22)
     NonNullableConstraintFailure(
-        sheet="Project Details", column="Locations", row_index=15, failed_row=None
+        table="Project Details", column="Locations", row_index=15, failed_row=None
     ).to_message()
-    NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_index=21, failed_row=None).to_message()
+    NonNullableConstraintFailure(table="Project Details", column="Lat/Long", row_index=21, failed_row=None).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Start Date", row_index=1, failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="Project Progress", column="Completion Date", row_index=4, failed_row=None
+        table="Project Progress", column="Start Date", row_index=1, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Commentary on Status and RAG Ratings", row_index=2, failed_row=None
+        table="Project Progress", column="Completion Date", row_index=4, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Most Important Upcoming Comms Milestone", row_index=7, failed_row=None
+        table="Project Progress", column="Commentary on Status and RAG Ratings", row_index=2, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress",
+        table="Project Progress", column="Most Important Upcoming Comms Milestone", row_index=7, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        table="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         row_index=6,
         failed_row=None,
     ).to_message()
-    NonNullableConstraintFailure(sheet="Programme Progress", column="Answer", row_index=4, failed_row=None).to_message()
+    NonNullableConstraintFailure(table="Programme Progress", column="Answer", row_index=4, failed_row=None).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Current Project Delivery Stage", row_index=3, failed_row=None
+        table="Project Progress", column="Current Project Delivery Stage", row_index=3, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data", column="UnitofMeasurement", row_index=16, failed_row=failed_rows
+        table="Outcome_Data", column="UnitofMeasurement", row_index=16, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data", column="Amount", row_index=5, failed_row=failed_rows
+        table="Outcome_Data", column="Amount", row_index=5, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Outcome_Data", column="GeographyIndicator", row_index=5, failed_row=failed_rows
+        table="Outcome_Data", column="GeographyIndicator", row_index=5, failed_row=failed_rows
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Output_Data", column="Unit of Measurement", row_index=17, failed_row=None
+        table="Output_Data", column="Unit of Measurement", row_index=17, failed_row=None
     ).to_message()
-    NonNullableConstraintFailure(sheet="Output_Data", column="Amount", row_index=6, failed_row=None).to_message()
+    NonNullableConstraintFailure(table="Output_Data", column="Amount", row_index=6, failed_row=None).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Short Description", row_index=20, failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Full Description", row_index=21, failed_row=None
+        table="RiskRegister", column="Short Description", row_index=20, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Consequences", row_index=22, failed_row=None
+        table="RiskRegister", column="Full Description", row_index=21, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Mitigatons", row_index=23, failed_row=None
+        table="RiskRegister", column="Consequences", row_index=22, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        table="RiskRegister", column="Mitigatons", row_index=23, failed_row=None
     ).to_message()  # typo throughout code
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="RiskOwnerRole", row_index=24, failed_row=None
+        table="RiskRegister", column="RiskOwnerRole", row_index=24, failed_row=None
     ).to_message()
-    NonNullableConstraintFailure(sheet="RiskRegister", column="RiskName", row_index=25, failed_row=None).to_message()
+    NonNullableConstraintFailure(table="RiskRegister", column="RiskName", row_index=25, failed_row=None).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="RiskCategory", row_index=26, failed_row=None
-    ).to_message()
-    NonNullableConstraintFailure(
-        sheet="Funding", column="Spend for Reporting Period", row_index=7, failed_row=None
+        table="RiskRegister", column="RiskCategory", row_index=26, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="Project Progress", column="Start Date", row_index=2, failed_row=None
+        table="Funding", column="Spend for Reporting Period", row_index=7, failed_row=None
     ).to_message()
     NonNullableConstraintFailure(
-        sheet="RiskRegister", column="Short Description", row_index=5, failed_row=None
+        table="Project Progress", column="Start Date", row_index=2, failed_row=None
+    ).to_message()
+    NonNullableConstraintFailure(
+        table="RiskRegister", column="Short Description", row_index=5, failed_row=None
     ).to_message()
 
 
 def test_wrong_type_messages():
     failed_rows = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=22)
     WrongTypeFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Start Date",
         expected_type="datetime64[ns]",
         actual_type="string",
@@ -236,7 +236,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Completion Date",
         expected_type="datetime64[ns]",
         actual_type="string",
@@ -244,7 +244,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
@@ -252,7 +252,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Private Investments",
+        table="Private Investments",
         column="Private Sector Funding Required",
         expected_type="float64",
         actual_type="string",
@@ -260,7 +260,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Private Investments",
+        table="Private Investments",
         column="Private Sector Funding Secured",
         expected_type="float64",
         actual_type="string",
@@ -268,7 +268,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Funding",
+        table="Funding",
         column="Spend for Reporting Period",
         expected_type="float64",
         actual_type="string",
@@ -276,7 +276,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Output_Data",
+        table="Output_Data",
         column="Amount",
         expected_type="float64",
         actual_type="string",
@@ -284,7 +284,7 @@ def test_wrong_type_messages():
         failed_row=None,
     ).to_message()
     WrongTypeFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column="Amount",
         expected_type="float64",
         actual_type="string",
@@ -292,7 +292,7 @@ def test_wrong_type_messages():
         failed_row=failed_rows,
     ).to_message()
     WrongTypeFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column="Amount",
         expected_type="float64",
         actual_type="object",
@@ -303,7 +303,7 @@ def test_wrong_type_messages():
 
 def test_enum_failure_with_footfall_geography_indicator_wrong():
     failure = InvalidEnumValueFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column="GeographyIndicator",
         row_index=60,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4", "Year-on-year % change in monthly footfall"),
@@ -320,7 +320,7 @@ def test_enum_failure_with_footfall_geography_indicator_wrong():
 
 def test_non_unique_composite_key_messages():
     NonUniqueCompositeKeyFailure(
-        sheet="Funding",
+        table="Funding",
         column=["Project ID", "Funding Source Name", "Funding Source Type", "Secured", "Start_Date", "End_Date"],
         row=[
             "HS-GRA-02",
@@ -333,7 +333,7 @@ def test_non_unique_composite_key_messages():
         row_index=78,
     ).to_message()
     NonUniqueCompositeKeyFailure(
-        sheet="Output_Data",
+        table="Output_Data",
         column=["Project ID", "Output", "Start_Date", "End_Date", "Unit of Measurement", "Actual/Forecast"],
         row=[
             "HS-GRA-02",
@@ -346,7 +346,7 @@ def test_non_unique_composite_key_messages():
         row_index=82,
     ).to_message()
     NonUniqueCompositeKeyFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column=["Project ID", "Outcome", "Start_Date", "End_Date", "GeographyIndicator"],
         row=[
             "HS-GRA-03",
@@ -357,13 +357,13 @@ def test_non_unique_composite_key_messages():
         row_index=1,
     ).to_message()
     NonUniqueCompositeKeyFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column=["Programme ID", "Project ID", "RiskName"],
         row=["HS-GRA", pd.NA, "Delivery Timeframe"],
         row_index=1,
     ).to_message()
     NonUniqueCompositeKeyFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column=["Programme ID", "Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
         row_index=23,
@@ -371,7 +371,7 @@ def test_non_unique_composite_key_messages():
 
     with pytest.raises(UnimplementedErrorMessageException):
         NonUniqueCompositeKeyFailure(
-            sheet="Project Progress",
+            table="Project Progress",
             column=["Programme ID", "Project ID", "RiskName"],
             row=[pd.NA, "HS-GRA-01", "Project Delivery"],
             row_index=7,
@@ -393,14 +393,14 @@ def test_generic_failure():
 
 def test_failures_to_messages():
     failure1 = InvalidEnumValueFailure(
-        sheet="Project Details",
+        table="Project Details",
         column="Single or Multiple Locations",
         row_index=1,
         row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
     )
-    failure2 = NonNullableConstraintFailure(sheet="Project Details", column="Lat/Long", row_index=1, failed_row=None)
+    failure2 = NonNullableConstraintFailure(table="Project Details", column="Lat/Long", row_index=1, failed_row=None)
     failure3 = WrongTypeFailure(
-        sheet="Project Progress",
+        table="Project Progress",
         column="Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
         expected_type="datetime64[ns]",
         actual_type="string",
@@ -408,13 +408,13 @@ def test_failures_to_messages():
         failed_row=None,
     )
     failure4 = NonUniqueCompositeKeyFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column=["Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
         row_index=23,
     )
     failure5 = NonUniqueCompositeKeyFailure(
-        sheet="RiskRegister",
+        table="RiskRegister",
         column=["Project ID", "RiskName"],
         row=[pd.NA, "HS-GRA-01", "Project Delivery"],
         row_index=25,
@@ -559,13 +559,13 @@ def test_failures_to_message_with_outcomes_column_amount():
     failed_rows1 = pd.Series({"Start_Date": pd.to_datetime("2023-05-01 12:00:00")}, name=60)
     failed_rows2 = pd.Series({"Start_Date": pd.to_datetime("2023-06-01 12:00:00")}, name=23)
     failure1 = NonNullableConstraintFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column="Amount",
         row_index=60,
         failed_row=failed_rows1,
     )
     failure2 = WrongTypeFailure(
-        sheet="Outcome_Data",
+        table="Outcome_Data",
         column="Amount",
         expected_type="float64",
         actual_type="string",
@@ -592,31 +592,31 @@ def test_failures_to_message_with_duplicated_errors():
     failed_row2 = pd.Series({"Start_Date": pd.to_datetime("2023-06-01 12:00:00")}, name=60)
     errors = [
         NonNullableConstraintFailure(
-            sheet="Outcome_Data",
+            table="Outcome_Data",
             column="Outcome",
             row_index=22,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
-            sheet="Outcome_Data",
+            table="Outcome_Data",
             column="Outcome",
             row_index=22,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
-            sheet="Outcome_Data",
+            table="Outcome_Data",
             column="Outcome",
             row_index=23,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
-            sheet="Outcome_Data",
+            table="Outcome_Data",
             column="Amount",
             row_index=60,
             failed_row=failed_row1,
         ),
         NonNullableConstraintFailure(
-            sheet="Outcome_Data",
+            table="Outcome_Data",
             column="Amount",
             row_index=60,
             failed_row=failed_row2,


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-403


### Change description
Renames "spreadsheet" language to more generic language. The background to this is that when the validation was first developed, we built it expecting one table per sheet. This means that the use sheet/worksheet in place of "table" is very misleading now that we ingest data with multiple tables per sheet.

- renames all reference to workbook ---> data
- renames all reference to worksheet/sheet ---> table

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
