### PR TITLE
removing trailing whitespace on ipswich la

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -390,7 +390,7 @@ TF_PLACE_NAMES_TO_ORGANISATIONS = {
     "Hereford": "Herefordshire Council",
     "Buxton": "High Peak Borough Council",
     "St Neots": "Huntingdonshire District Council",
-    "Ipswich": "Ipswich Borough Council ",
+    "Ipswich": "Ipswich Borough Council",
     "Dewsbury": "Kirklees Council",
     "King's Lynn": "King's Lynn and West Norfolk",
     "Morley": "Leeds Council",


### PR DESCRIPTION
Remove trailing whitespace.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")