### PR TITLE
[BAU] add robustness to dropping of null and merged columns in fundin…

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -390,7 +390,9 @@ def extract_funding_questions(df_input: pd.DataFrame, programme_id: str) -> pd.D
         # return empty dataframe if fund_type is Future High Street Fund
         return pd.DataFrame(columns=["Question", "Guidance Notes", "Indicator", "Response", "Programme ID"])
 
-    df_input = df_input.iloc[12:19, 2:13].dropna(axis=1, how="all")
+    df_input = df_input.iloc[12:19, 2:13]
+    first_row = df_input.iloc[0]
+    df_input = df_input.dropna(axis=1, how="all", subset=[first_row.name])
 
     # Use the first row as the column headers
     fund_questions_df = df_input.rename(columns=df_input.iloc[0]).iloc[1:]


### PR DESCRIPTION
…g questions extraction

Background:

The "Yes" dropdown value spread across the 8 columns in the picture below (some of which are merged) only appears in the pandas DataFrame in the first column of every merged set of cells in all of our test data and dummy data.

However, when a particular production submission is ingested, it puts the "Yes" value across ALL merged cells. This then changed the output of a subsequent dropna .

We've made the code robust to this in this one case now but we couldn't decipher what causes this as we can't reproduce it in a new spreadsheet (even with the same data from prod etc)..

![image](https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/22678716/004d4f17-3163-4eba-8a74-d667653e24db)

### Change description
- makes the extraction code for funding question robust against the issue above by dropping Excel cell-merged columns based on the columns lack of header value rather than requiring the whole column to be null to be dropped

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Difficult to test as we can't reproduce it outside of some production data that caused this in the first instance. That submission now returns a valid response when passed to ingest.

### Screenshots of UI changes (if applicable)
