### PR TITLE
BAU: fix fixture score for AWS integration tests

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -11,4 +11,4 @@ class DevelopmentConfig(DefaultConfig):
     AWS_ACCESS_KEY_ID = getenv("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY = getenv("AWS_SECRET_ACCESS_KEY")
     AWS_ENDPOINT_OVERRIDE = getenv("AWS_ENDPOINT_OVERRIDE")
-    AWS_CONFIG = Config(retries={"max_attempts": 3, "mode": "standard"})
+    AWS_CONFIG = Config(retries={"max_attempts": 1, "mode": "standard"})

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -13,4 +13,4 @@ class UnitTestConfig(DefaultConfig):
     AWS_SECRET_ACCESS_KEY = "test"
     AWS_ENDPOINT_OVERRIDE = "http://127.0.0.1:4566/"
     AWS_S3_BUCKET_FAILED_FILES = "data-store-failed-files-unit-tests"
-    AWS_CONFIG = Config(retries={"max_attempts": 3, "mode": "standard"})
+    AWS_CONFIG = Config(retries={"max_attempts": 1, "mode": "standard"})

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+from config import Config
+from core.aws import _S3_CLIENT
+
+TEST_BUCKET = "test-bucket"
+
+
+def create_bucket(bucket: str):
+    """Helper function that creates a specified bucket if it doesn't already exist."""
+    if bucket not in {bucket_obj["Name"] for bucket_obj in _S3_CLIENT.list_buckets()["Buckets"]}:
+        _S3_CLIENT.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": "eu-central-1"})
+
+
+def delete_bucket(bucket: str):
+    """Helper function that deletes all objects in a specified bucket and then deletes the bucket."""
+    objects = _S3_CLIENT.list_objects_v2(Bucket=bucket)
+    if objects := objects.get("Contents"):
+        objects = list(map(lambda x: {"Key": x["Key"]}, objects))
+        _S3_CLIENT.delete_objects(Bucket=bucket, Delete={"Objects": objects})
+    _S3_CLIENT.delete_bucket(Bucket=bucket)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def test_buckets():
+    """Sets up and tears down buckets used by this module.
+
+    On set up:
+    - creates test-bucket
+    - creates data-store-failed-files-unit-tests
+
+    On tear down, deletes all objects stored in the buckets and then the buckets themselves.
+    """
+    create_bucket(TEST_BUCKET)
+    create_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
+    yield
+    delete_bucket(TEST_BUCKET)
+    delete_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)

--- a/tests/integration_tests/test_aws.py
+++ b/tests/integration_tests/test_aws.py
@@ -7,40 +7,7 @@ from botocore.exceptions import ClientError, EndpointConnectionError
 
 from config import Config
 from core.aws import _S3_CLIENT, get_failed_file, get_file, upload_file
-
-TEST_BUCKET = "test-bucket"
-
-
-def create_bucket(bucket: str):
-    """Helper function that creates a specified bucket if it doesn't already exist."""
-    if bucket not in {bucket_obj["Name"] for bucket_obj in _S3_CLIENT.list_buckets()["Buckets"]}:
-        _S3_CLIENT.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": "eu-central-1"})
-
-
-def delete_bucket(bucket: str):
-    """Helper function that deletes all objects in a specified bucket and then deletes the bucket."""
-    objects = _S3_CLIENT.list_objects_v2(Bucket=bucket)
-    if objects := objects.get("Contents"):
-        objects = list(map(lambda x: {"Key": x["Key"]}, objects))
-        _S3_CLIENT.delete_objects(Bucket=bucket, Delete={"Objects": objects})
-    _S3_CLIENT.delete_bucket(Bucket=bucket)
-
-
-@pytest.fixture(autouse=True, scope="module")
-def test_buckets():
-    """Sets up and tears down buckets used by this module.
-
-    On set up:
-    - creates test-bucket
-    - creates data-store-failed-files-unit-tests
-
-    On tear down, deletes all objects stored in the buckets and then the buckets themselves.
-    """
-    create_bucket(TEST_BUCKET)
-    create_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
-    yield
-    delete_bucket(TEST_BUCKET)
-    delete_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
+from tests.integration_tests.conftest import TEST_BUCKET
 
 
 @pytest.fixture()


### PR DESCRIPTION
Move out the fixture to create and delete the unit test buckets for to conftest file so that they can be shared by all integration tests


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
