### PR TITLE
BAU: validation docstring tidy up

### DIFF
--- a/core/validation/__init__.py
+++ b/core/validation/__init__.py
@@ -8,7 +8,7 @@ from core.validation_schema import get_schema
 
 
 def validate(workbook: dict[str, pd.DataFrame], original_workbook: dict[str, pd.DataFrame], reporting_round: int):
-    """Validate a workbook against it's round specific schema.
+    """Validate a workbook against its round specific schema.
 
     :param workbook: a set of data in a dataframe that fits the data model
     :param original_workbook: the workbook before being transformed

--- a/core/validation/failures/internal.py
+++ b/core/validation/failures/internal.py
@@ -1,3 +1,10 @@
+"""This module defines a set of classes representing different types of validation
+failures that can occur while validating a Workbook, but that will not occur for user submissions.
+
+These classes can be useful for developers to debug a data pipeline by providing more
+detailed and granular failures that may occur when developing a new pipeline or adjusting an historical one.
+"""
+
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any

--- a/core/validation/messages.py
+++ b/core/validation/messages.py
@@ -1,3 +1,5 @@
+"""Validation failure messages to be returned to the user."""
+
 from core.const import TF_ROUND_4_TEMPLATE_VERSION
 
 # BLANK MESSAGES

--- a/core/validation/pre_transformation_validation_schema.py
+++ b/core/validation/pre_transformation_validation_schema.py
@@ -1,3 +1,9 @@
+"""Validation schemas for pre-transformation validation failures.
+
+Each round for each fund has a distinct schema based on the types of checks to be performed and where the data
+is to be extracted from to be performed against.
+"""
+
 from collections import namedtuple
 
 from core.const import PLACE_TO_FUND_TYPE, TF_PLACE_NAMES_TO_ORGANISATIONS

--- a/core/validation/specific_validations/towns_fund_round_four.py
+++ b/core/validation/specific_validations/towns_fund_round_four.py
@@ -1,3 +1,5 @@
+"""Module for functions relating to data validation specific to Town's Fund Round 4."""
+
 import re
 from dataclasses import dataclass
 

--- a/core/validation/utils.py
+++ b/core/validation/utils.py
@@ -26,6 +26,7 @@ def remove_duplicate_indexes(df: pd.DataFrame):
 
 def numeric_eval(value: Any) -> int | float | Any:
     """Evaluate value as an int or float. If impossible, return the original value.
+
     :param value: any value
     :return: the value as an int or a float
     :raises ValueError: if value cannot be evaluated as an int or a float
@@ -38,6 +39,7 @@ def numeric_eval(value: Any) -> int | float | Any:
 
 def is_numeric(value: Any) -> bool:
     """Returns True if the value is numerical, otherwise False.
+
     :param value: value to check is numerical
     :return: True if numerical, else False
     """

--- a/core/validation/validate.py
+++ b/core/validation/validate.py
@@ -1,6 +1,6 @@
 """Excel Data Validation
 
-Provides functionality for validating a data against a schema. Any schema offense
+Provides functionality for validating data against a schema. Any schema offenses
 cause the validation to fail. Details of these failures are captured and returned.
 """
 import numbers
@@ -62,7 +62,7 @@ def validations(
 ) -> list[user.SchemaUserValidationFailure | internal.InternalValidationFailure]:
     """
     Validate the given data against a provided schema by checking each table's
-    columns, data types, unique values, and foreign keys.
+    columns, data types, unique values, composite keys, and foreign keys.
 
     :param data_dict: A dictionary where keys are table names and values are pandas
                      DataFrames.
@@ -130,6 +130,8 @@ def validate_types(data_dict: dict[str, pd.DataFrame], table: str, column_to_typ
     Validate that the data types of columns in a given table align with the
     provided schema by comparing the actual types to the expected types.
 
+    Type validation is not performed for data that is null.
+
     :param data_dict: A dictionary where keys are table names and values are pandas
                      DataFrames.
     :param table: The name of the table to validate.
@@ -142,7 +144,7 @@ def validate_types(data_dict: dict[str, pd.DataFrame], table: str, column_to_typ
         for column, exp_type in column_to_type.items():
             got_value = row.get(column)
 
-            if not isinstance(got_value, list) and (got_value is None or pd.isna(got_value)):
+            if got_value is None or pd.isna(got_value):
                 continue
             got_type = _PY_TO_NUMPY_TYPES.get(type(got_value).__name__, "object")
 
@@ -190,7 +192,12 @@ def validate_unique_composite_key(
     data_dict: dict[str, pd.DataFrame], table: str, composite_key: tuple
 ) -> list[user.NonUniqueCompositeKeyFailure]:
     """
-    Validates the uniqueness of specified composite key for given table in data.
+    Validates the uniqueness of a specified composite key for each row of data in a table.
+
+    This function filters the DataFrame by the columns specified in the composite key, and finds the duplicated rows,
+    including NaN/Empty.
+    It ensures there is only one composite key error per index in order to prevent rows that were melted during
+    transformation leading to duplicate error messages on the same index by dropping duplicated indexes.
 
     :param data_dict: A dictionary containing table names as keys and corresponding pandas DataFrames as values.
     :param table: The name of the table to be validated.
@@ -203,11 +210,9 @@ def validate_unique_composite_key(
     non_unique_composite_key_failures = []
     composite_key = list(composite_key)
 
-    # filter dataframe by these columns and find duplicated rows including NaN/Empty
     mask = data_df[composite_key].duplicated(keep="first")
     duplicated_rows = data_df[mask][composite_key]
 
-    # handle melted rows
     duplicated_rows = remove_duplicate_indexes(duplicated_rows)
 
     if mask.any():


### PR DESCRIPTION
Tidies docstrings inside the ```validation``` directory. 

Also removes a redundant piece of code that checked if a value was a list or not in ```validate_types```.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
