### PR TITLE
[BAU] fix RAG type casting during transformation to retain pd.NA

### DIFF
--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -369,8 +369,11 @@ def extract_project_progress(df_data: pd.DataFrame, project_lookup: dict, round_
 
     # RAG ratings of user input '4' can be read into a DataFrame as '4.0'
     for col in whole_nums_to_integers_cols:
-        if col in df_data.columns:
-            df_data[col] = df_data[col].astype(str).str.rstrip(".0")
+        for idx, val in df_data[col].items():
+            if pd.isna(val):
+                continue  # skip NA values
+            else:
+                df_data[col][idx] = str(val).rstrip(".0")
 
     return df_data
 

--- a/tests/extraction_tests/test_round_four_extraction.py
+++ b/tests/extraction_tests/test_round_four_extraction.py
@@ -81,6 +81,7 @@ def test_extract_programme_progress(mock_progress_sheet, mock_programme_lookup):
     """Test programme progress rows extracted as expected."""
     extracted_programme_progress = extract_programme_progress(mock_progress_sheet, mock_programme_lookup)
     expected_programme_progress = pd.read_csv(resources_assertions / "programme_progress_expected.csv", index_col=0)
+
     assert_frame_equal(extracted_programme_progress, expected_programme_progress)
 
 
@@ -93,12 +94,13 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
     )
 
     # fix assertion data
-    expected_project_progress["Delivery (RAG)"] = expected_project_progress["Delivery (RAG)"].astype(str)
-    expected_project_progress["Spend (RAG)"] = expected_project_progress["Spend (RAG)"].astype(str)
-    expected_project_progress["Risk (RAG)"] = expected_project_progress["Risk (RAG)"].astype(str)
     expected_project_progress["Leading Factor of Delay"] = expected_project_progress["Leading Factor of Delay"].fillna(
         ""
     )
+
+    assert pd.isna(extracted_project_progress["Risk (RAG)"].iloc[0])  # empty cells should be extracted as pd.NA
+    assert isinstance(extracted_project_progress["Delivery (RAG)"].iloc[0], str)  # filled cells should be str
+    assert isinstance(extracted_project_progress["Spend (RAG)"].iloc[0], str)  # filled cells should be str
     assert_frame_equal(extracted_project_progress, expected_project_progress)
 
 

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -148,11 +148,9 @@ def test_extract_project_progress(mock_progress_sheet, mock_project_lookup):
         resources_assertions / "project_progress_expected.csv", index_col=0, dtype=str
     )
 
-    # fix assertion data
-    expected_project_progress["Delivery (RAG)"] = expected_project_progress["Delivery (RAG)"].astype(str)
-    expected_project_progress["Spend (RAG)"] = expected_project_progress["Spend (RAG)"].astype(str)
-    expected_project_progress["Risk (RAG)"] = expected_project_progress["Risk (RAG)"].astype(str)
-
+    assert pd.isna(extracted_project_progress["Risk (RAG)"].iloc[0])  # empty cells should be extracted as pd.NA
+    assert isinstance(extracted_project_progress["Delivery (RAG)"].iloc[0], str)  # filled cells should be str
+    assert isinstance(extracted_project_progress["Spend (RAG)"].iloc[0], str)  # filled cells should be str
     assert_frame_equal(extracted_project_progress, expected_project_progress)
 
 


### PR DESCRIPTION
### Change description
- fixes a bug found during re-ingest that caused returns with blank RAG cells to return enum validation errors due to `pd.NaN` being converted to `str` "nan"

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
