### PR TITLE
BAU: General clean up of ingest user failures and unused TODO's

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -49,9 +49,8 @@ def ingest(body: dict, excel_file: FileStorage) -> tuple[dict, int]:
     """Ingests a spreadsheet submission and stores its contents in a database.
 
     This function takes in an Excel file object and extracts data from the file, transforms it to fit the data model,
-    casts it to the specified schema, and validates it.
-    If reporting round is specified, the spreadsheet will be transformed using round specific implementations, prior to
-     validation.
+    casts it to the specified schema, and validates it. reporting round and fund are extracted from the request body
+    and used to construct the dependencies to be injected for transformation and validation.
 
     If the data fails validation, a `ValidationError` is raised, which will result in a 400 error containing a set of
     validation messages that identify where in the spreadsheet is causing the validation failure.
@@ -108,11 +107,12 @@ def process_validation_failures(
     """Processes a set of validation failures into the appropriate validation messages and constructs the response.
 
     This function takes in a list of validation failure objects, if any internal failures are present it returns a
-    500 response. Otherwise, it then constructs the relevant error messages using a fund specific messenger class
-    instantiated from the messaging class factory. and constructs the appropriate response containing these messages.
+    500 response. Otherwise, it then constructs the relevant error messages using the fund specific messenger class
+    passed to this function. and constructs the appropriate response containing these messages.
 
     :param validation_failures: a list of validation failure objects generated during validation
     :param messenger: converts failures to user messages
+    :return: A JSON Response
     """
     internal_failures = [failure for failure in validation_failures if isinstance(failure, InternalValidationFailure)]
     user_failures = [failure for failure in validation_failures if isinstance(failure, UserValidationFailure)]

--- a/core/extraction/towns_fund_round_three.py
+++ b/core/extraction/towns_fund_round_three.py
@@ -543,7 +543,6 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict, round_fou
     # drop always unused cells for funding secured before 2020 and beyond 2026
     unused_mask = df_funding.loc[
         (
-            # TODO: refactor Funding Source Type == Towns Fund outside of masks to avoid repeated logic
             (df_funding["Funding Source Type"] == "Towns Fund")
             & (df_funding["Start_Date"].isna() | (df_funding["End_Date"].isna()))
         )
@@ -983,8 +982,8 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
             ]
         )
 
-    # TODO: These cells not "locked" in Excel sheet. Assuming (from context of spreadsheet) they should be.
-    # TODO: Hard-coding here as a precaution (to prevent un-mappable data ingest)
+    # These cells not "locked" in Excel sheet. Assuming (from context of spreadsheet) they should be.
+    # Hard-coding here as a precaution (to prevent un-mappable data ingest)
     footfall_df["Indicator Name"] = "Year on Year monthly % change in footfall"
     footfall_df["Unit of Measurement"] = "Year-on-year % change in monthly footfall"
 

--- a/core/validation/failures/user.py
+++ b/core/validation/failures/user.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import pandas as pd
 
-from core.util import join_as_string
 from core.validation.failures import ValidationFailureBase
 
 
@@ -51,25 +50,12 @@ class GenericFailure(UserValidationFailure):
             raise ValueError("GenericFailure must be instantiated with either cell_index or column and row_index")
             # row_index not included in the check because in some cases this can be instantiated with only column
 
-    def __str__(self):
-        pass
-
 
 @dataclass
 class NonUniqueCompositeKeyFailure(SchemaUserValidationFailure):
     """Class representing a non-unique-composite_key failure that is raised due to duplicate data."""
 
     row: list
-
-    def __str__(self):
-        """Method to get the string representation of the non-unique-composite_key failure."""
-        cols_str = join_as_string(self.column)
-        row_str = list(self.row)
-        return (
-            f'Non Unique Row Failure: Table "{self.table}"; '
-            f'Columns "{cols_str}" contains contains a duplicate row consisting of the values: '
-            f'"{row_str}"'
-        )
 
 
 @dataclass
@@ -79,13 +65,6 @@ class WrongTypeFailure(SchemaUserValidationFailure):
     expected_type: str | float | int | datetime | object | bool | list
     actual_type: str
     failed_row: pd.Series | None
-
-    def __str__(self):
-        """Method to get the string representation of the wrong type failure."""
-        return (
-            f'Wrong Type Failure: Table "{self.table}" column "{self.column}" expected '
-            f'type "{self.expected_type}", got type "{self.actual_type}"'
-        )
 
 
 @dataclass

--- a/core/validation/schema_validation/schemas.py
+++ b/core/validation/schema_validation/schemas.py
@@ -43,7 +43,6 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
             "foreign_keys": {
                 "Programme ID": {"parent_table": "Programme_Ref", "parent_pk": "Programme ID"},
             },
-            # TODO: Round 4 Answer added because this all programme progress are required
             "non-nullable": ["Programme ID", "Question", "Answer"],
         },
         "Place Details": {
@@ -61,7 +60,6 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
                 "Question",
                 "Indicator",
             ),
-            # TODO: Round 4 Answer added because place details data is required
             "non-nullable": ["Programme ID", "Question", "Indicator", "Answer"],
         },
         "Funding Questions": {
@@ -324,7 +322,6 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
             },
             "non-nullable": [
                 "RiskName",
-                "RiskName",
                 "RiskCategory",
                 "Short Description",
                 "Full Description",
@@ -336,7 +333,6 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
                 "PostMitigatedLikelihood",
                 "Proximity",
                 "RiskOwnerRole",
-                # TODO: Added all fields for Round 4
             ],
         },
     }
@@ -468,7 +464,7 @@ TF_ROUND_3_VAL_SCHEMA = parse_schema(
             "columns": {
                 "Project ID": str,
                 "Funding Source Name": str,
-                "Funding Source Type": str,  # TODO: could maybe be an enum but ok for now
+                "Funding Source Type": str,
                 "Secured": str,
                 "Start_Date": datetime,
                 "End_Date": datetime,
@@ -740,7 +736,7 @@ TF_ROUND_2_VAL_SCHEMA = parse_schema(
                 "Submission ID": str,
                 "Project ID": str,
                 "Funding Source Name": str,
-                "Funding Source Type": str,  # TODO: could maybe be an enum but ok for now
+                "Funding Source Type": str,
                 "Secured": str,
                 "Start_Date": datetime,
                 "End_Date": datetime,
@@ -989,7 +985,7 @@ TF_ROUND_1_VAL_SCHEMA = parse_schema(
                 "Submission ID": str,
                 "Project ID": str,
                 "Funding Source Name": str,
-                "Funding Source Type": str,  # TODO: could maybe be an enum but ok for now
+                "Funding Source Type": str,
                 "Secured": str,
                 "Start_Date": datetime,
                 "End_Date": datetime,

--- a/core/validation/specific_validation/towns_fund_round_four/validate.py
+++ b/core/validation/specific_validation/towns_fund_round_four/validate.py
@@ -58,7 +58,6 @@ def validate(
         validate_programme_risks,
         validate_funding_profiles_funding_source_enum,
         validate_funding_profiles_at_least_one_other_funding_source_fhsf,
-        validate_funding_profiles_funding_secured_not_null,
         validate_psi_funding_gap,
         validate_locations,
         validate_funding_spent,
@@ -354,7 +353,7 @@ def validate_psi_funding_gap(workbook: dict[str, pd.DataFrame]) -> list["Generic
 
 def validate_funding_spent(workbook: dict[str, pd.DataFrame]) -> list["GenericFailure"] | None:
     """Validates that total reported funding spent on the sheet is less than the amount specified as allocated in a
-    separate sheet stored on S3.
+    separate sheet stored in this repo (data-store).
 
     For Town deal funds this is done on a per-project basis whereas for future High Street Funds this is done
     per-programme leading to slightly different logics for both.

--- a/tests/extraction_tests/test_round_three_extraction.py
+++ b/tests/extraction_tests/test_round_three_extraction.py
@@ -457,9 +457,10 @@ def test_ingest_towns_fund_template():
 # Test intended only as a local debug tool
 @pytest.mark.skip(reason="currently this is just a pytest/pycharm debug entrypoint for ingest work")
 def test_ingest_round_two_historical():
-    # TODO: currently testing with small subset of data (to allow reasonable debugging speed)
     round_two_data = pd.read_excel(
+        # test with small subset of data (to allow reasonable debugging speed)
         "Round 2 Reporting - Consolidation (MASTER).xlsx",
+        # uncomment bellow to test with complete data set
         # "Round 2 Reporting - Consolidation.xlsx",
         sheet_name=None,  # extract from all sheets
     )


### PR DESCRIPTION
I have updated some of the ingest docstrings to reflect the current behaviour.

Removed __str__ methods from user failures. These failures are dataclasses so they already have __repr__ methods that will return very similar strings if called and these __str__ methods are no longer called in the application.

I have searched for TODO's and removed those that are no longer relevant and downgraded to comments those that don't state a specific action to be done.

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
