### PR TITLE
BAU: improve serialisation programmer/config error

### DIFF
--- a/core/controllers/download.py
+++ b/core/controllers/download.py
@@ -106,9 +106,14 @@ def sort_output_dataframes(df: pd.DataFrame, sheet: str) -> pd.DataFrame:
     :param df: The DataFrame to be sorted.
     :param sheet: The name of the Excel output sheet.
     :return: Sorted dataframe.
+    :raise: ValueError: if "sheet" is not present in TABLE_SORT_ORDERS configuration
     """
-
-    df.sort_values(TABLE_SORT_ORDERS.get(sheet), inplace=True)
+    if sort_order := TABLE_SORT_ORDERS.get(sheet):
+        df.sort_values(sort_order, inplace=True)
+    else:  # Programmer error
+        raise ValueError(
+            f"No table sort order defined for table extract: {sheet}. Please add sheet to TABLE_SORT_ORDERS"
+        )
     df.reset_index(drop=True, inplace=True)
 
     return df

--- a/tests/controller_tests/test_download.py
+++ b/tests/controller_tests/test_download.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import pandas as pd
+import pytest
 
 from core.const import EXCEL_MIMETYPE
 from core.controllers.download import sort_output_dataframes
@@ -79,3 +80,17 @@ def test_sort_columns_function(test_session):
         "Grant Recipient's Single Point of Contact",
     ]
     assert list(sorted_place_df.OrganisationName) == ["Org 3", "Org 2", "Org X", "Org 1"]
+
+
+def test_sort_columns_exception(test_session):
+    """Test that error raised when no sort order provided for a download "tab" (ie configuration error)"""
+    test_data = {
+        "TestCol": ["Val_1", "Val-2"],
+    }
+    unsorted_place_df = pd.DataFrame(test_data)
+
+    with pytest.raises(ValueError) as e:
+        sort_output_dataframes(unsorted_place_df, "UnspecifiedSheet")
+    assert str(e.value) == (
+        "No table sort order defined for table extract: UnspecifiedSheet. Please add " "sheet to TABLE_SORT_ORDERS"
+    )


### PR DESCRIPTION

### Change description
Minor improvement to help programmers when configuring serialisation tables. If tables added via query/serialisation, it also needs to be specified in the sort-orders const.

- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
