### PR TITLE
FMD-156: Add default filename for retrieved db submissions and update unit test s3 bucket setup

### DIFF
--- a/core/controllers/retrieve_submission_file_db.py
+++ b/core/controllers/retrieve_submission_file_db.py
@@ -32,4 +32,7 @@ def retrieve_submission_file_db(submission_id):
     except NoResultFound:
         return abort(404, "Could not find a file that matches this submission_id")
 
+    if not file_name:
+        file_name = f"{submission_id}-submission-file.xlsx"
+
     return flask.send_file(BytesIO(file_bytes), mimetype=EXCEL_MIMETYPE, download_name=file_name, as_attachment=True)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -3,8 +3,6 @@ import pytest
 from config import Config
 from core.aws import _S3_CLIENT
 
-TEST_BUCKET = "test-bucket"
-
 
 def create_bucket(bucket: str):
     """Helper function that creates a specified bucket if it doesn't already exist."""
@@ -21,20 +19,17 @@ def delete_bucket(bucket: str):
     _S3_CLIENT.delete_bucket(Bucket=bucket)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def test_buckets():
     """Sets up and tears down buckets used by this module.
     On set up:
-    - creates test-bucket
     - creates data-store-failed-files-unit-tests
     - creates data-store-successful-files-unit-tests
 
     On tear down, deletes all objects stored in the buckets and then the buckets themselves.
     """
-    create_bucket(TEST_BUCKET)
     create_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
     create_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)
     yield
-    delete_bucket(TEST_BUCKET)
     delete_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
     delete_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,4 +1,9 @@
+import pytest
+
+from config import Config
 from core.aws import _S3_CLIENT
+
+TEST_BUCKET = "test-bucket"
 
 
 def create_bucket(bucket: str):
@@ -14,3 +19,22 @@ def delete_bucket(bucket: str):
         objects = list(map(lambda x: {"Key": x["Key"]}, objects))
         _S3_CLIENT.delete_objects(Bucket=bucket, Delete={"Objects": objects})
     _S3_CLIENT.delete_bucket(Bucket=bucket)
+
+
+@pytest.fixture()
+def test_buckets():
+    """Sets up and tears down buckets used by this module.
+    On set up:
+    - creates test-bucket
+    - creates data-store-failed-files-unit-tests
+    - creates data-store-successful-files-unit-tests
+
+    On tear down, deletes all objects stored in the buckets and then the buckets themselves.
+    """
+    create_bucket(TEST_BUCKET)
+    create_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
+    create_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)
+    yield
+    delete_bucket(TEST_BUCKET)
+    delete_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
+    delete_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)

--- a/tests/integration_tests/test_retrieve_submission_file.py
+++ b/tests/integration_tests/test_retrieve_submission_file.py
@@ -6,24 +6,10 @@ from config import Config
 from core.aws import _S3_CLIENT
 from core.const import EXCEL_MIMETYPE
 from core.db.entities import Submission
-from tests.integration_tests.conftest import create_bucket, delete_bucket
-
-
-@pytest.fixture(autouse=True, scope="module")
-def test_buckets():
-    """Sets up and tears down buckets used by this module.
-    On set up:
-    - creates data-store-successful-files-unit-tests
-    On tear down, deletes all objects stored in the buckets and then the buckets themselves.
-    """
-
-    create_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)
-    yield
-    delete_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)
 
 
 @pytest.fixture()
-def uploaded_mock_file(seeded_test_client):
+def uploaded_mock_file(seeded_test_client, test_buckets):
     """Uploads a mock generic file and deletes it on tear down."""
     fake_file = io.BytesIO(b"0x01010101")
     uuid = str(


### PR DESCRIPTION
### Change description

- Unify test_bucket setup to create & teardown all s3 buckets
- Move test_bucket fixture to conftest and remove duplicates from modules
- Update test_ingest_endpoint_s3_upload_failure_db_rollback test to make use of mocking to test behaviour with different raised exceptions
- Add default filename for submission files retrieved from database if no filename present in db

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
