### PR TITLE
Adding pre-commit to dev requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -9,3 +9,8 @@ pydot==1.4.2  # ERD diagram
 pytest
 pytest-env
 pytest-mock
+
+#-----------------------------------
+#   Code Quality
+#-----------------------------------
+pre-commit


### PR DESCRIPTION
### Change description
Adding [pre-commit](https://[pre-commit](https://pre-commit.com/).com/) to the dev requirements to avoid the need to manually run `pip install pre-commit` after running `pip-sync requirements-dev.txt` after checking out a different branch in this repo.