### PR TITLE
FMD-225: Add submission_filename cleanup script

### DIFF
--- a/core/controllers/retrieve_submission_file.py
+++ b/core/controllers/retrieve_submission_file.py
@@ -47,4 +47,9 @@ def retrieve_submission_file(submission_id):
             )
         raise error
 
-    return flask.send_file(file, mimetype=content_type, download_name=meta_data["filename"], as_attachment=True)
+    filename = meta_data["filename"]
+    # Check against Round 4 submission files which were all saved with 'ingest_spreadsheet' as the submission_filename
+    if filename == "ingest_spreadsheet":
+        filename = f'{meta_data["programme_name"]} - {meta_data["submission_id"]}.xlsx'
+
+    return flask.send_file(file, mimetype=content_type, download_name=filename, as_attachment=True)

--- a/scripts/db_filename_clean.py
+++ b/scripts/db_filename_clean.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Select
+
+from app import app
+from core.db import db
+from core.db.entities import Submission
+
+
+def db_filename_clean():
+    """
+    We found some submissions where the submission_filename was erroneously saved with URL encoded characters.
+
+    This script will tidy up any submissions where the submission_filename starts and/or ends with '%22',
+    which would affect the user experience when downloading the file.
+
+    To run the script from CLI, run the following (if running locally you'll need to add FLASK_ENV=development):
+    python -m scripts.db_filename_clean
+    """
+
+    query = (
+        Select(Submission.id, Submission.submission_filename)
+        .where(Submission.submission_file != None)  # noqa
+        .filter(Submission.submission_filename.contains("%22", autoescape=True))
+    )
+    submissions = db.session.execute(query).all()
+    print(str(query))
+    print(submissions)
+
+    for id, submission_filename in submissions:
+        clean_filename = submission_filename.lstrip("%2").rstrip("%2")
+        print(f"Updating submission {id} with filename {submission_filename} to {clean_filename}")
+        db.session.query(Submission).filter(Submission.id == id).update({"submission_filename": clean_filename})
+    db.session.commit()
+    print("Update complete")
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        db_filename_clean()

--- a/tests/integration_tests/test_retrieve_submission_file.py
+++ b/tests/integration_tests/test_retrieve_submission_file.py
@@ -27,6 +27,29 @@ def uploaded_mock_file(seeded_test_client, test_buckets):
     _S3_CLIENT.delete_object(Bucket=Config.AWS_S3_BUCKET_SUCCESSFUL_FILES, Key=key)
 
 
+@pytest.fixture()
+def uploaded_mock_file_ingest_spreadsheet_name(seeded_test_client, test_buckets):
+    """Uploads a mock generic file and deletes it on tear down."""
+    fake_file = io.BytesIO(b"0x01010101")
+    uuid = str(
+        Submission.query.filter(Submission.submission_id == "S-R03-1").with_entities(Submission.id).distinct().one()[0]
+    )
+    key = f"HS/{uuid}"
+    metadata = {
+        "filename": "ingest_spreadsheet",
+        "submission_id": "S-R03-1",
+        "programme_name": "Leaky Cauldron regeneration",
+    }
+    _S3_CLIENT.upload_fileobj(
+        fake_file,
+        Config.AWS_S3_BUCKET_SUCCESSFUL_FILES,
+        key,
+        ExtraArgs={"Metadata": metadata, "ContentType": EXCEL_MIMETYPE},
+    )
+    yield
+    _S3_CLIENT.delete_object(Bucket=Config.AWS_S3_BUCKET_SUCCESSFUL_FILES, Key=key)
+
+
 def test_retrieve_submission_file_invalid_id(seeded_test_client):
     invalid_id = "S-R10-10"
     response = seeded_test_client.get(f"/retrieve_submission_file?submission_id={invalid_id}")
@@ -38,6 +61,21 @@ def test_retrieve_submission_file(seeded_test_client, uploaded_mock_file):
     response = seeded_test_client.get(f"/retrieve_submission_file?submission_id={submission_id}")
     assert response.status_code == 200
     assert response.headers.get("Content-Disposition") == "attachment; filename=fake_file.xlsx"
+    assert response.data == b"0x01010101"
+    assert response.headers["content-type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert response.content_type == EXCEL_MIMETYPE
+
+
+def test_retrieve_submission_file_ingest_spreadsheet_name(
+    seeded_test_client, uploaded_mock_file_ingest_spreadsheet_name
+):
+    submission_id = "S-R03-1"
+    response = seeded_test_client.get(f"/retrieve_submission_file?submission_id={submission_id}")
+    assert response.status_code == 200
+    assert (
+        response.headers.get("Content-Disposition")
+        == 'attachment; filename="Leaky Cauldron regeneration - S-R03-1.xlsx"'
+    )
     assert response.data == b"0x01010101"
     assert response.headers["content-type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     assert response.content_type == EXCEL_MIMETYPE


### PR DESCRIPTION
### Change description
- New script to cleanup `submission_filename` in Submission table and remove erroneous `%22` from start and end of filenames
- Add check against incorrect Round 4 filename of `ingest_spreadsheet` and replace with user-friendly and helpful filename on download

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
