### PR TITLE
FMD-219: build and use paketo image instead of local dockerfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,13 +16,34 @@ on:
           - production
 
 jobs:
+  tag_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version_to_tag: ${{ steps.tagging.outputs.tag_value }}
+    steps:
+      - id: tagging
+        run: |
+          echo "tag_value=$(echo '${{ github.ref }}' | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_OUTPUT
+  paketo_build:
+    permissions:
+      packages: write
+    needs: [ tag_version ]
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
+    with:
+      assets_required: false
+      version_to_build: ${{ needs.tag_version.outputs.version_to_tag }}
+      owner: ${{ github.repository_owner }}
+      application: ${{ github.event.repository.name }}
   deployment:
     concurrency: deploy-${{ inputs.environment || 'test' }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
+    needs: [ tag_version, paketo_build ]
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'test' }}
+    env:
+      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name == 'main' && 'latest' || needs.tag_version.outputs.version_to_tag }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
@@ -45,10 +66,10 @@ jobs:
       - name: Inject env specific values into manifest
         run: |
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/data-store/manifest.yml
-          yq -i '.variables.FLASK_ENV = "${{ inputs.environment || 'test' }}"' copilot/data-store/manifest.yml
+          yq -i '.image.location = "${{ env.IMAGE_LOCATION }}"' copilot/data-store/manifest.yml
 
       - name: Run database migrations
-        run: scripts/migration-task-script.py ${{ vars.COPILOT_ENV || 'test' }}
+        run: scripts/migration-task-script.py ${{ inputs.environment || 'test' }} ${{ env.IMAGE_LOCATION }}
 
       - name: Copilot deploy
         run: |

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn wsgi:app -c run/gunicorn/run.py --workers=3

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ docker run -p 8080:8080 communitiesuk/funding-service-design-post-award-data-sto
 App should be available at `http://localhost:8080`
 
 ## Deployment
-`main` branch is continuously deployed to AWS, see [.github/workflows/deploy.yml](.github/workflows/deploy.yml)
+`main` branch is continuously deployed to the AWS Test environment, deployments to the Dev and Production environments are triggered by a [manual Github Actions workflow](https://github.com/communitiesuk/funding-service-design-post-award-data-store/actions/workflows/deploy.yml).
+
+On the deployed environments we use [Paketo buildpacks](https://paketo.io) rather than the local Dockerfile.
 
 ## Accessing on AWS
 As it is deployed as a Backend Service on AWS the service is not publicly accessible.

--- a/copilot/data-store/manifest.yml
+++ b/copilot/data-store/manifest.yml
@@ -16,8 +16,6 @@ http:
 
 # Configuration for your containers and service.
 image:
-  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
-  build: Dockerfile
   # Port exposed through your container to route traffic to it.
   port: 8080
 

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,6 @@
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name = "BP_CPYTHON_VERSION"
+  value = "3.11.*" # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable


### PR DESCRIPTION
### Change description
Sister PR to: https://github.com/communitiesuk/funding-service-design-post-award-submit/pull/81

This changes the build process to produce a [Paketo](https://paketo.io/docs/howto/python/) image rather than using the local dockerfile, this means the underlying image is managed for us which improves security. 

This also includes the associated refactors to the DB migration script to use the Paketo image

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have tested on dev environment: https://github.com/communitiesuk/funding-service-design-post-award-data-store/actions/runs/7972571461


### Screenshots of UI changes (if applicable)
