### PR TITLE
SMD-667 - Fix cell reference string in case of ignored non-header rows

### DIFF
--- a/tables/process.py
+++ b/tables/process.py
@@ -135,6 +135,7 @@ class TableProcessor:
         if rows := [idx for idx in self.ignored_non_header_rows if idx not in table.df.index]:
             raise TableProcessingError(f"Ignored non-header rows {rows} are out-of-bounds.")
         table.df = table.df.drop(self.ignored_non_header_rows)
+        table.row_idx_map = dict(zip(range(len(table.df)), table.df.index))
 
     def _replace_dropdown_placeholder(self, table: Table) -> None:
         table.df = table.df.replace(self.dropdown_placeholder, np.nan)

--- a/tables/process.py
+++ b/tables/process.py
@@ -91,8 +91,6 @@ class TableProcessor:
         header = self._concatenate_headers(header, headers_to_ffill=self.merged_header_rows)
         table.df.columns = header
         table.df = table.df.iloc[self.num_header_rows :]
-        table.df = table.df.reset_index(drop=True)
-        table.first_row_idx += self.num_header_rows
 
     @staticmethod
     def _remove_merged_headers(table: Table) -> None:
@@ -132,10 +130,9 @@ class TableProcessor:
             del table.col_idx_map[col]
 
     def _remove_ignored_non_header_rows(self, table: Table) -> None:
-        if rows := [idx for idx in self.ignored_non_header_rows if idx not in table.df.index]:
-            raise TableProcessingError(f"Ignored non-header rows {rows} are out-of-bounds.")
-        table.df = table.df.drop(self.ignored_non_header_rows)
-        table.row_idx_map = dict(zip(range(len(table.df)), table.df.index))
+        if any(idx not in range(len(table.df)) for idx in self.ignored_non_header_rows):
+            raise TableProcessingError(f"Ignored non-header rows {self.ignored_non_header_rows} are out-of-bounds.")
+        table.df = table.df.drop(table.df.index[self.ignored_non_header_rows])
 
     def _replace_dropdown_placeholder(self, table: Table) -> None:
         table.df = table.df.replace(self.dropdown_placeholder, np.nan)
@@ -147,4 +144,3 @@ class TableProcessor:
     @staticmethod
     def _drop_empty_rows(table: Table) -> None:
         table.df = table.df.dropna(how="all")
-        table.df = table.df.reset_index(drop=True)

--- a/tables/table.py
+++ b/tables/table.py
@@ -69,9 +69,10 @@ class Table:
 
     def get_cell(self, row_idx: int, col_name: str) -> Cell:
         """
-        Get the original cell from the table-scope cell.
+        Creates a Cell object based on the given row index and column name, using the table's column index map to
+        determine the true column index in the global scope, or the Excel file.
 
-        :param row_idx: The row index of the cell in the table scope.
+        :param row_idx: The row index of the cell in the global scope.
         :param col_name: The column name of the cell in the table scope.
         """
         col_idx = self.col_idx_map[col_name]

--- a/tables/table.py
+++ b/tables/table.py
@@ -58,17 +58,14 @@ class Table:
     df: pd.DataFrame
     id_tag: str
     first_col_idx: int
-    first_row_idx: int
     col_idx_map: dict[str, int]
 
     def __init__(self, df: pd.DataFrame, start_tag: Cell, id_tag: str):
         self.df = df
         self.start_tag = start_tag
         self.id_tag = id_tag
-        self.first_row_idx = start_tag.row + 1
         self.first_col_idx = start_tag.column
         self.col_idx_map = dict(zip(df.columns, range(len(df.columns))))
-        self.row_idx_map = dict(zip(range(len(df)), range(len(df))))
 
     def get_cell(self, row_idx: int, col_name: str) -> Cell:
         """
@@ -78,5 +75,4 @@ class Table:
         :param col_name: The column name of the cell in the table scope.
         """
         col_idx = self.col_idx_map[col_name]
-        orig_row_idx = self.row_idx_map[row_idx]  # Use the row_idx_map to get the original row index
-        return Cell(row=self.first_row_idx + orig_row_idx, column=self.first_col_idx + col_idx)
+        return Cell(row=row_idx, column=self.first_col_idx + col_idx)

--- a/tables/table.py
+++ b/tables/table.py
@@ -61,23 +61,22 @@ class Table:
     first_row_idx: int
     col_idx_map: dict[str, int]
 
-    def __init__(self, df: pd.DataFrame, id_tag: str, start_tag: Cell, col_idx_map: dict[str, int] = None):
-        if col_idx_map is None:
-            # column names may need to be lifted from designated header rows first
-            col_idx_map = {}
+    def __init__(self, df: pd.DataFrame, start_tag: Cell, id_tag: str):
         self.df = df
+        self.start_tag = start_tag
         self.id_tag = id_tag
-        self.first_col_idx = start_tag.column
         self.first_row_idx = start_tag.row + 1
-        self.col_idx_map = col_idx_map
+        self.first_col_idx = start_tag.column
+        self.col_idx_map = dict(zip(df.columns, range(len(df.columns))))
+        self.row_idx_map = dict(zip(range(len(df)), range(len(df))))
 
-    def get_cell(self, row: int, column: str) -> Cell:
-        """Get the original cell from the table-scope cell.
-
-        :param row: Table cell row
-        :param column: Table cell column
-        :return: original cell
+    def get_cell(self, row_idx: int, col_name: str) -> Cell:
         """
-        col = self.first_col_idx + self.col_idx_map[column]
-        row = self.first_row_idx + row
-        return Cell(row, col)
+        Get the original cell from the table-scope cell.
+
+        :param row_idx: The row index of the cell in the table scope.
+        :param col_name: The column name of the cell in the table scope.
+        """
+        col_idx = self.col_idx_map[col_name]
+        orig_row_idx = self.row_idx_map[row_idx]  # Use the row_idx_map to get the original row index
+        return Cell(row=self.first_row_idx + orig_row_idx, column=self.first_col_idx + col_idx)

--- a/tables/tests/test_extract.py
+++ b/tables/tests/test_extract.py
@@ -150,9 +150,9 @@ def test_basic_table_extract_process(table_extractor, basic_table_config):
             "DropdownColumn": ["Yes", "No", "Yes"],
             "UniqueColumn": ["Unique1", "Unique2", "Unique3"],
         },
+        index=[2, 3, 4],
     )
     assert_frame_equal(table.df, expected_table)
-    assert table.first_row_idx == 2
     assert table.first_col_idx == 0
     assert table.col_idx_map == {"DropdownColumn": 2, "IntColumn": 1, "StringColumn": 0, "UniqueColumn": 3}
 
@@ -187,10 +187,9 @@ def test_table_extract_and_process_with_ignored_non_header_rows(table_extractor,
             "DropdownColumn": ["No", "Yes"],
             "UniqueColumn": ["Unique2", "Unique3"],
         },
-        index=[1, 2],
+        index=[3, 4],
     )
     assert_frame_equal(table.df, expected_table)
-    assert table.first_row_idx == 2
 
 
 def test_table_extract_and_process_with_ignored_non_header_rows_non_zero(table_extractor, basic_table_config):
@@ -210,10 +209,9 @@ def test_table_extract_and_process_with_ignored_non_header_rows_non_zero(table_e
             "DropdownColumn": ["Yes", "Yes"],
             "UniqueColumn": ["Unique1", "Unique3"],
         },
-        index=[0, 2],
+        index=[2, 4],
     )
     assert_frame_equal(table.df, expected_table)
-    assert table.first_row_idx == 2
 
 
 @pytest.mark.parametrize("row_idx", [4, -1])
@@ -257,6 +255,7 @@ def test_table_extract_and_process_with_stacked_headers(table_extractor, stacked
             ("Column1, StackedHeader"): ["A", "b"],
             ("Column2, StackedHeader"): ["1", "2"],
         },
+        index=[14, 15],
     )
     assert_frame_equal(table.df, expected_table)
 
@@ -317,6 +316,7 @@ def test_table_extract_and_process_does_not_drop_empty_rows_by_default(table_ext
                 np.NaN,
             ],
         },
+        index=[29, 30, 31, 32, 33, 34],
         dtype=object,
     )
     assert_frame_equal(table.df, expected_table)
@@ -346,9 +346,10 @@ def test_table_extract_and_process_removes_select_as_default_dropdown_placeholde
 ):
     tables = extract_process(table_extractor, table_with_dropdown_placeholder_config)
     table = tables[0]
-
-    expected_table = pd.DataFrame(data={"DropdownColumn": [np.NaN, "Select from dropdown", np.NaN]})
-
+    expected_table = pd.DataFrame(
+        data={"DropdownColumn": [np.NaN, "Select from dropdown", np.NaN]},
+        index=[42, 43, 44],
+    )
     assert_frame_equal(table.df, expected_table)
 
 
@@ -358,14 +359,20 @@ def test_table_extract_and_process_removes_custom_dropdown_placeholder(
     table_with_dropdown_placeholder_config["process"]["dropdown_placeholder"] = "Select from dropdown"
     tables = extract_process(table_extractor, table_with_dropdown_placeholder_config)
     table = tables[0]
-    expected_table = pd.DataFrame(data={"DropdownColumn": ["< Select >", np.NaN, "< Select >"]})
+    expected_table = pd.DataFrame(
+        data={"DropdownColumn": ["< Select >", np.NaN, "< Select >"]},
+        index=[42, 43, 44],
+    )
     assert_frame_equal(table.df, expected_table)
 
 
 def test_table_extract_and_process_strips_white_space_by_default(table_extractor, table_with_white_space_config):
     tables = extract_process(table_extractor, table_with_white_space_config)
     table = tables[0]
-    expected_table = pd.DataFrame(data={"Whitespace": ["leadingspace", "trailingspace", np.NaN]})
+    expected_table = pd.DataFrame(
+        data={"Whitespace": ["leadingspace", "trailingspace", np.NaN]},
+        index=[52, 53, 54],
+    )
     assert_frame_equal(table.df, expected_table)
 
 
@@ -375,7 +382,10 @@ def test_table_extract_and_process_strips_white_space_and_drops_resulting_na_row
     table_with_white_space_config["process"]["drop_empty_rows"] = True
     tables = extract_process(table_extractor, table_with_white_space_config)
     table = tables[0]
-    expected_table = pd.DataFrame(data={"Whitespace": ["leadingspace", "trailingspace"]})
+    expected_table = pd.DataFrame(
+        data={"Whitespace": ["leadingspace", "trailingspace"]},
+        index=[52, 53],
+    )
     assert_frame_equal(table.df, expected_table)
 
 
@@ -386,21 +396,23 @@ def test_table_extract_and_process_returns_multiple_table_instances(table_extrac
             "ColumnA": ["5", "6", "7", np.NaN, np.NaN, np.NaN],
             "ColumnB": ["01/01/2001", "02/01/2001", "03/01/2001", np.NaN, np.NaN, np.NaN],
         },
+        index=[59, 60, 61, 62, 63, 64],
     )
     expected_table_1 = pd.DataFrame(
         data={"ColumnA": ["1", "2", "3"], "ColumnB": ["10/10/2010", "11/10/2010", "12/10/2010"]},
+        index=[61, 62, 63],
     )
     expected_table_2 = pd.DataFrame(
         data={"ColumnA": ["1", "2"], "ColumnB": ["10/10/2010", "11/10/2010"]},
+        index=[61, 62],
     )
     expected_table_3 = pd.DataFrame(
         data={"ColumnA": ["1", "2"], "ColumnB": ["10/10/2010", "11/10/2010"]},
+        index=[67, 68],
     )
     expected_table_4 = pd.DataFrame(
-        data={
-            "ColumnA": [None, None],
-            "ColumnB": [None, None],
-        },
+        data={"ColumnA": [None, None], "ColumnB": [None, None]},
+        index=[68, 69],
     )
     assert_frame_equal(tables[0].df, expected_table_0)
     assert_frame_equal(tables[1].df, expected_table_1)
@@ -417,6 +429,7 @@ def test_table_extract_and_process_removes_column_not_in_schema(table_extractor,
             "ColumnInSchema1": ["A", "B", "C"],
             "ColumnInSchema2": ["G", "H", "I"],
         },
+        index=[75, 76, 77],
     )
     assert table.col_idx_map == {"ColumnInSchema1": 0, "ColumnInSchema2": 2}
     assert_frame_equal(table.df, expected_table)
@@ -441,6 +454,7 @@ def test_table_extract_and_process_of_table_with_merged_double_stacked_header_ce
             "TopHeader, BottomHeader2": ["B"],
             "TopHeader, BottomHeader3": ["C"],
         },
+        index=[84],
     )
     assert_frame_equal(table.df, expected_table)
 
@@ -456,6 +470,7 @@ def test_table_extract_and_process_of_table_with_merged_triple_stacked_header_ce
             "TopHeader, MiddleHeader2, BottomHeader2": ["B"],
             "TopHeader, MiddleHeader2, BottomHeader3": ["C"],
         },
+        index=[91],
     )
     assert table.col_idx_map == {
         "TopHeader, MiddleHeader1, BottomHeader1": 0,
@@ -488,6 +503,7 @@ def test_table_extract_and_process_of_table_with_merged_cells(table_extractor, t
             "Column1": ["A"],
             "Column2": ["B"],
         },
+        index=[106],
     )
     assert table.col_idx_map == {
         "Column1": 0,

--- a/tables/tests/test_validate.py
+++ b/tables/tests/test_validate.py
@@ -93,8 +93,7 @@ def table_level_check_schema():
 
 def build_mock_extracted_table(data: dict[str, list[Any]]) -> Table:
     data = pd.DataFrame(data=data, index=range(len(list(data.values())[0])))
-    col_idx_map = {column: i for i, column in enumerate(data.keys())}
-    return Table(data, start_tag=Cell(row=0, column=0), col_idx_map=col_idx_map, id_tag="example-tag")
+    return Table(data, start_tag=Cell(row=0, column=0), id_tag="example-tag")
 
 
 def test_table_successful_validation(basic_table_schema):
@@ -127,7 +126,7 @@ def test_table_validation_throws_exception_table_contains_additional_columns(sin
 
 
 def test_table_validation_throws_exception_table_missing_columns(single_int_schema):
-    table = Table(df=pd.DataFrame(), start_tag=Cell(0, 0), col_idx_map={}, id_tag="example-tag")
+    table = Table(df=pd.DataFrame(), start_tag=Cell(0, 0), id_tag="example-tag")
     with pytest.raises(ValueError, match="Schema columns {'Column'} are not in the table."):
         TableValidator(single_int_schema).validate(table)
 

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -174,8 +174,7 @@ def test_ingest_pf_r1_general_validation_errors(test_client, pathfinders_round_1
             "sheet": "Finances",
         },
         {
-            "cell_index": "F8",  # TODO: This is the wrong cell index, should be "F9", fix ticket here:
-            # https://dluhcdigital.atlassian.net/browse/SMD-667
+            "cell_index": "F9",
             "description": "You’ve entered your own content, instead of selecting from the dropdown list provided. "
             "Select an option from the dropdown list.",
             "error_type": None,


### PR DESCRIPTION
### Ticket
[Fix cell reference string in case of ignored non-header rows](https://dluhcdigital.atlassian.net/browse/SMD-667)

### Change summary
By removing all index resetting during table processing, all table DataFrames contain the original indices from the spreadsheet, removing the need for additional logic to map back from table-scope row indices to original indices even in the case of arbitrary removal of rows. This allows us to dispense with the `first_row_idx` attribute of the `Table` class.

Because DataFrames now contain original indices and not reset ones...
- The `_remove_ignored_non_header_rows` method of `TableProcessor` had to be adjusted to remove rows based on `ignored_non_header_rows` indices matching the actual _position_ of rows in the DataFrame (the index values you'd get if you ran a `reset_index`), rather than the index (as those two things had diverged).
- The indices of expected DataFrames in the extraction tests had to be updated