### PR TITLE
BAU: fix output query

### DIFF
--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -321,6 +321,7 @@ def output_data_query(base_query: Query) -> Query:
                 ents.ProgrammeJunction.id == ents.OutputData.programme_junction_id,
             ),
         )
+        .join(ents.OutputDim)
         .with_entities(
             ents.Submission.submission_id,
             conditional_expression_programme_id.label("programme_id"),

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -78,6 +78,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Answer",
         "Place",
     ]
+    assert len(test_serialised_data["PlaceDetails"]) == 16
     assert list(test_serialised_data["ProjectDetails"][0].keys()) == [
         "SubmissionID",
         "ProjectID",
@@ -91,6 +92,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["ProjectDetails"]) == 12
     assert list(test_serialised_data["OrganisationRef"][0].keys()) == ["OrganisationName", "Geography"]
     assert list(test_serialised_data["ProgrammeRef"][0].keys()) == [
         "ProgrammeID",
@@ -106,6 +108,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["ProgrammeProgress"]) == 8
     assert list(test_serialised_data["ProjectProgress"][0].keys()) == [
         "SubmissionID",
         "ProjectID",
@@ -125,6 +128,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["ProjectProgress"]) == 3
     assert list(test_serialised_data["FundingQuestions"][0].keys()) == [
         "SubmissionID",
         "ProgrammeID",
@@ -135,6 +139,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["FundingQuestions"]) == 17
     assert list(test_serialised_data["Funding"][0].keys()) == [
         "SubmissionID",
         "ProgrammeID",
@@ -150,6 +155,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["Funding"]) == 14
     assert list(test_serialised_data["FundingComments"][0].keys()) == [
         "SubmissionID",
         "ProjectID",
@@ -158,6 +164,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["FundingComments"]) == 8
     assert list(test_serialised_data["PrivateInvestments"][0].keys()) == [
         "SubmissionID",
         "ProjectID",
@@ -170,6 +177,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["PrivateInvestments"]) == 8
     assert list(test_serialised_data["OutputRef"][0].keys()) == ["OutputName", "OutputCategory"]
     assert list(test_serialised_data["OutputData"][0].keys()) == [
         "SubmissionID",
@@ -186,6 +194,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["OutputData"]) == 44
     assert list(test_serialised_data["OutcomeRef"][0].keys()) == ["OutcomeName", "OutcomeCategory"]
     assert list(test_serialised_data["OutcomeData"][0].keys()) == [
         "SubmissionID",
@@ -203,6 +212,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["OutcomeData"]) == 30
     assert list(test_serialised_data["RiskRegister"][0].keys()) == [
         "SubmissionID",
         "ProgrammeID",
@@ -223,6 +233,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["RiskRegister"]) == 28
     assert list(test_serialised_data["ProjectFinanceChange"][0].keys()) == [
         "SubmissionID",
         "ProgrammeID",
@@ -239,6 +250,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
+    assert len(test_serialised_data["ProjectFinanceChange"]) == 1
 
     # check a couple of tables that all results are returned
     assert len(test_serialised_data["RiskRegister"]) == len(RiskRegister.query.all()) == 28


### PR DESCRIPTION
Fixes an issue whereby the query for OutputData was leading to a cartesian join.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
