### PR TITLE
SMD-670 - Adding table name to error message for Pathfinders

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -154,7 +154,7 @@ def extract_process_validate_tables(
                 error_messages.append(
                     Message(
                         sheet=worksheet_name,
-                        section=None,
+                        section=table_name,
                         cell_index=error.cell.str_ref if error.cell else None,
                         description=error.message,
                         error_type=None,

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -216,7 +216,7 @@ def test_ingest_pf_r1_general_validation_errors(test_client, pathfinders_round_1
             "cell_index": "B24",
             "description": "Please enter a valid email address.",
             "error_type": None,
-            "section": None,
+            "section": "Contact email address",
             "sheet": "Admin",
         },
         {
@@ -224,14 +224,14 @@ def test_ingest_pf_r1_general_validation_errors(test_client, pathfinders_round_1
             "description": "You entered text instead of a number. Remove any units of measurement and only use numbers,"
             " for example, 9.",
             "error_type": None,
-            "section": None,
+            "section": "Outputs",
             "sheet": "Outputs",
         },
         {
             "cell_index": "J42",
             "description": "Amount must be positive.",
             "error_type": None,
-            "section": None,
+            "section": "Forecast and actual spend",
             "sheet": "Finances",
         },
         {
@@ -239,7 +239,7 @@ def test_ingest_pf_r1_general_validation_errors(test_client, pathfinders_round_1
             "description": "You’ve entered your own content, instead of selecting from the dropdown list provided. "
             "Select an option from the dropdown list.",
             "error_type": None,
-            "section": None,
+            "section": "Risks",
             "sheet": "Risks",
         },
     ]


### PR DESCRIPTION
### Ticket
[SMD-670 - Pathfinders - align extraction and validation config table names with spreadsheet for directed error messaging](https://dluhcdigital.atlassian.net/browse/SMD-670)

### Change summary
- Simply adding table name to error message. We use existing "section" field to align with TF / frontend
- Changes not in this PR include broader changes to extract config to support alignment with spreadsheet, which were subsumed into separate PR [SMD-666 - SMD-666 - Align table extraction with finalised spreadsheet](https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/492) for simplicity, as per comment on SMD-670 ticket