### PR TITLE
[#FMD-255]: e2e integration test

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -671,21 +671,16 @@ EXPECTED_ROUND_THREE_SHEETS = [
 
 # Column sort orders for each dataframe prior to export to Excel
 TABLE_SORT_ORDERS = {
-    "PlaceDetails": ["SubmissionID", "Question", "Indicator"],
+    "PlaceDetails": ["SubmissionID", "Question"],
     "ProjectDetails": ["SubmissionID", "ProjectID"],
     "OrganisationRef": ["OrganisationName"],
     "ProgrammeRef": ["ProgrammeName", "FundTypeID"],
     "ProgrammeProgress": ["SubmissionID", "Question"],
     "ProjectProgress": ["SubmissionID", "ProjectID"],
-    "FundingQuestions": ["SubmissionID", "ProgrammeID", "Question", "Indicator"],
+    "FundingQuestions": ["SubmissionID", "ProgrammeID", "Question"],
     "Funding": [
         "SubmissionID",
         "ProjectID",
-        "FundingSourceName",
-        "FundingSourceType",
-        "Secured",
-        "StartDate",
-        "EndDate",
     ],
     "FundingComments": ["SubmissionID", "ProjectID"],
     "PrivateInvestments": ["SubmissionID", "ProjectID"],
@@ -695,12 +690,11 @@ TABLE_SORT_ORDERS = {
         "ProjectID",
         "Output",
         "FinancialPeriodStart",
-        "FinancialPeriodEnd",
-        "UnitofMeasurement",
     ],
     "OutcomeRef": ["OutcomeName"],
-    "OutcomeData": ["SubmissionID", "ProjectID", "Outcome", "StartDate", "EndDate", "GeographyIndicator"],
+    "OutcomeData": ["SubmissionID", "ProjectID", "Outcome", "StartDate"],
     "RiskRegister": ["SubmissionID", "ProgrammeID", "ProjectID", "RiskName"],
+    "ProjectFinanceChange": ["SubmissionID", "ProgrammeID"],
     "SubmissionRef": ["SubmissionID"],
 }
 

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -350,7 +350,13 @@ def output_dim_query(base_query: Query) -> Query:
     :return: updated query.
     """
     extended_query = (
-        base_query.join(ents.OutputData, ents.OutputData.project_id == ents.Project.id)
+        base_query.join(
+            ents.OutputData,
+            or_(
+                ents.Project.id == ents.OutputData.project_id,
+                ents.ProgrammeJunction.id == ents.OutputData.programme_junction_id,
+            ),
+        )
         .join(ents.OutputDim)
         .with_entities(
             ents.OutputDim.output_name,

--- a/tests/controller_tests/test_ingest_functions.py
+++ b/tests/controller_tests/test_ingest_functions.py
@@ -16,9 +16,7 @@ from core.controllers.ingest import clean_data, extract_data, get_metadata, pars
 from core.controllers.load_functions import next_submission_id
 
 # flake8: noqa
-from tests.integration_tests.test_ingest_component_towns_fund import (
-    towns_fund_round_3_file_success,
-)
+from tests.integration_tests.conftest import towns_fund_round_3_file_success
 
 
 def test_get_metadata():

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import BinaryIO
+
 import pytest
 
 from config import Config
@@ -33,3 +36,24 @@ def test_buckets():
     yield
     delete_bucket(Config.AWS_S3_BUCKET_FAILED_FILES)
     delete_bucket(Config.AWS_S3_BUCKET_SUCCESSFUL_FILES)
+
+
+@pytest.fixture()
+def pathfinders_round_1_file_success() -> BinaryIO:
+    """An example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation errors."""
+    with open(Path(__file__).parent / "mock_pf_returns" / "PF_Round_1_Success.xlsx", "rb") as file:
+        yield file
+
+
+@pytest.fixture(scope="function")
+def towns_fund_round_3_file_success() -> BinaryIO:
+    """An example spreadsheet for reporting round 3 of Towns Fund that should ingest without validation errors."""
+    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_3_Success.xlsx", "rb") as file:
+        yield file
+
+
+@pytest.fixture(scope="function")
+def towns_fund_round_4_file_success() -> BinaryIO:
+    """An example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation errors."""
+    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Success.xlsx", "rb") as file:
+        yield file

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -1,0 +1,142 @@
+import io
+import json
+from datetime import datetime
+
+import pandas as pd
+from pandas._testing import assert_frame_equal, assert_series_equal
+
+from core.db import db
+from core.db import entities as ents
+
+
+def test_multiple_rounds_multiple_funds_end_to_end(
+    test_client_reset,
+    towns_fund_round_3_file_success,
+    towns_fund_round_4_file_success,
+    pathfinders_round_1_file_success,
+    test_buckets,
+):
+    """Tests that the ingestion of multiple rounds and funds will be loaded into the database
+    and serialised out in an Excel file correctly."""
+
+    endpoint = "/ingest"
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": towns_fund_round_3_file_success,
+            "fund_name": "Towns Fund",
+            "reporting_round": 3,
+            "do_load": True,
+        },
+    )
+
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": towns_fund_round_4_file_success,
+            "fund_name": "Towns Fund",
+            "reporting_round": 4,
+            "auth": json.dumps(
+                {
+                    "Place Names": ["Blackfriars - Northern City Centre"],
+                    "Fund Types": ["Town_Deal", "Future_High_Street_Fund"],
+                }
+            ),
+            "do_load": True,
+        },
+    )
+
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": pathfinders_round_1_file_success,
+            "fund_name": "Pathfinders",
+            "reporting_round": 1,
+            "auth": json.dumps(
+                {
+                    "Programme": [
+                        "Bolton Metropolitan Borough Council",
+                    ],
+                    "Fund Types": [
+                        "Pathfinders",
+                    ],
+                }
+            ),
+            "do_load": True,
+        },
+    )
+
+    db.session.commit()
+
+    download = test_client_reset.get("/download?file_format=xlsx")
+
+    excel_file = io.BytesIO(download.data)
+
+    df_dict = pd.read_excel(excel_file, sheet_name=None)
+
+    assert len(df_dict["PlaceDetails"]) == len(ents.PlaceDetail.query.all())
+    assert len(df_dict["ProjectDetails"]) == len(ents.Project.query.all())
+    assert len(df_dict["OrganisationRef"]) == len(ents.Organisation.query.all())
+    assert len(df_dict["ProgrammeRef"]) == len(ents.Programme.query.all())
+    assert len(df_dict["ProgrammeProgress"]) == len(ents.ProgrammeProgress.query.all())
+    assert len(df_dict["ProjectProgress"]) == len(ents.ProjectProgress.query.all())
+    assert len(df_dict["FundingQuestions"]) == len(ents.FundingQuestion.query.all())
+    assert len(df_dict["Funding"]) == len(ents.Funding.query.all())
+    assert len(df_dict["FundingComments"]) == len(ents.FundingComment.query.all())
+    assert len(df_dict["PrivateInvestments"]) == len(ents.PrivateInvestment.query.all())
+    assert len(df_dict["OutputRef"]) == len(ents.OutputDim.query.all())
+    assert len(df_dict["OutputData"]) == len(ents.OutputData.query.all())
+    assert len(df_dict["OutcomeRef"]) == len(ents.OutcomeDim.query.all())
+    assert len(df_dict["OutcomeData"]) == len(ents.OutcomeData.query.all())
+    assert len(df_dict["RiskRegister"]) == len(ents.RiskRegister.query.all())
+    assert len(df_dict["ProjectFinanceChange"]) == len(ents.ProjectFinanceChange.query.all())
+    assert len(df_dict["SubmissionRef"]) == len(ents.Submission.query.all())
+
+    expected_programme_ref = pd.DataFrame(
+        {
+            "ProgrammeID": ["HS-WRC", "PF-BOL", "HS-SWI"],
+            "ProgrammeName": ["Blackfriars - Northern City Centre", "Bolton Metropolitan Borough Council", "Swindon"],
+            "FundTypeID": ["HS", "PF", "HS"],
+            "OrganisationName": [
+                "Worcester City Council",
+                "Bolton Metropolitan Borough Council",
+                "Swindon Borough Council",
+            ],
+        }
+    )
+
+    assert_frame_equal(expected_programme_ref, df_dict["ProgrammeRef"])
+
+    expected_submission_ref = pd.DataFrame(
+        {
+            "SubmissionID": ["S-PF-R01-1", "S-R03-1", "S-R04-1"],
+            "ProgrammeID": ["PF-BOL", "HS-SWI", "HS-WRC"],
+            "ReportingPeriodStart": [
+                datetime(2024, 4, 1),
+                datetime(2022, 10, 1),
+                datetime(2023, 4, 1),
+            ],
+            "ReportingPeriodEnd": [
+                datetime(2024, 6, 30),
+                datetime(2023, 3, 31),
+                datetime(2023, 9, 30),
+            ],
+            "ReportingRound": [1, 3, 4],
+        }
+    )
+
+    assert_frame_equal(expected_submission_ref, df_dict["SubmissionRef"])
+
+    place_detail_expected_first_row = pd.Series(
+        {
+            "OrganisationName": "Bolton Metropolitan Borough Council",
+            "SubmissionID": "S-PF-R01-1",
+            "ProgrammeID": "PF-BOL",
+            "Question": "Contact email address",
+            "Indicator": None,
+            "Answer": "test@testing.gov.uk",
+            "Place": "Bolton Metropolitan Borough Council",
+        },
+        name=0,
+    )
+    assert_series_equal(place_detail_expected_first_row, df_dict["PlaceDetails"].iloc[0])

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -8,13 +8,6 @@ from core.db.entities import Programme, Submission
 
 
 @pytest.fixture()
-def pathfinders_round_1_file_success() -> BinaryIO:
-    """An example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation errors."""
-    with open(Path(__file__).parent / "mock_pf_returns" / "PF_Round_1_Success.xlsx", "rb") as file:
-        yield file
-
-
-@pytest.fixture()
 def pathfinders_round_1_file_initial_validation_failure() -> BinaryIO:
     """An example spreadsheet for reporting round 1 of Pathfinders that should ingest without validation errors."""
     with open(Path(__file__).parent / "mock_pf_returns" / "PF_Round_1_Initial_Validation_Failure.xlsx", "rb") as file:

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -10,13 +10,6 @@ from core.db.entities import ProgrammeJunction, Project, ProjectProgress, Submis
 
 
 @pytest.fixture(scope="function")
-def towns_fund_round_4_file_success() -> BinaryIO:
-    """An example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation errors."""
-    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Success.xlsx", "rb") as file:
-        yield file
-
-
-@pytest.fixture(scope="function")
 def towns_fund_round_4_file_success_duplicate() -> BinaryIO:
     """Duplicate of an example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation
     errors."""
@@ -82,13 +75,6 @@ def towns_fund_round_4_file_hs_funding_failure() -> BinaryIO:
 def towns_fund_round_4_round_agnostic_failures() -> BinaryIO:
     """An example spreadsheet for reporting round 4 of Towns Fund that should raise TF round agnostic failures"""
     with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Round_Agnostic_Failures.xlsx", "rb") as file:
-        yield file
-
-
-@pytest.fixture(scope="function")
-def towns_fund_round_3_file_success() -> BinaryIO:
-    """An example spreadsheet for reporting round 3 of Towns Fund that should ingest without validation errors."""
-    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_3_Success.xlsx", "rb") as file:
         yield file
 
 
@@ -217,6 +203,13 @@ def test_ingest_with_r4_file_success_with_load_re_ingest(
         },
     )
 
+    programme_junction_rows_first_ingest = ProgrammeJunction.query.all()
+    programme_id_first_ingest = programme_junction_rows_first_ingest[0].programme_id
+    submission_id_first_ingest = programme_junction_rows_first_ingest[0].submission_id
+    project_detail_rows_first_ingest = Project.query.all()
+
+    db.session.commit()
+
     response = test_client_reset.post(
         endpoint,
         data={
@@ -246,6 +239,18 @@ def test_ingest_with_r4_file_success_with_load_re_ingest(
         "status": 200,
         "title": "success",
     }
+
+    programme_junction_rows_second_ingest = ProgrammeJunction.query.all()
+    programme_id_second_ingest = programme_junction_rows_second_ingest[0].programme_id
+    submission_id_second_ingest = programme_junction_rows_second_ingest[0].submission_id
+    project_detail_rows_second_ingest = Project.query.all()
+
+    # the number of Programmes, Submissions, and their children should be the same after re-ingest
+    assert len(programme_junction_rows_first_ingest) == len(programme_junction_rows_second_ingest)
+    assert len(project_detail_rows_first_ingest) == len(project_detail_rows_second_ingest)
+    # the Programme ID should remain the same, but the Submission ID should be different
+    assert programme_id_first_ingest == programme_id_second_ingest
+    assert submission_id_first_ingest != submission_id_second_ingest
 
 
 def test_ingest_with_r4_corrupt_submission(test_client, towns_fund_round_4_file_corrupt, test_buckets):


### PR DESCRIPTION
- Fixes a bug which tries to sort the column output of the extract on columns that don't exist for Pathfinders.
- Fixes a bug which caused a ```OutcomeRef``` data to only join at the project and not the programme level during serialisation.
- Updates the re-ingest integration test to make it more meaningful.
- Adds an end-to-end integration test.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
