### PR TITLE
SMD-710 - Pathfinders - validate postcodes

### DIFF
--- a/core/table_configs/pathfinders/round_1.py
+++ b/core/table_configs/pathfinders/round_1.py
@@ -89,6 +89,7 @@ class PFErrors:
     AMOUNT_MOVED_GT_ZERO = "Amount moved must be greater than £0."
     AMOUNT_MOVED_LT_5M = "Amount moved must be less than £5m."
     FUTURE_DATE = "You must not enter a date in the future."
+    INVALID_POSTCODE_LIST = "Please enter a valid postcode or list of postcodes separated by commas."
 
 
 PF_TABLE_CONFIG = {
@@ -244,7 +245,10 @@ PF_TABLE_CONFIG = {
         "validate": {
             "columns": {
                 "Project name": pa.Column(str),
-                'Project full postcode/postcodes (e.g., "AB1D 2EF")': pa.Column(str),
+                'Project full postcode/postcodes (e.g., "AB1D 2EF")': pa.Column(
+                    str,
+                    pa.Check.postcode_list(error=PFErrors.INVALID_POSTCODE_LIST),
+                ),
             },
         },
     },

--- a/tables/checks.py
+++ b/tables/checks.py
@@ -17,6 +17,7 @@ However, there are two main disadvantages of schemas with inline custom checks:
     2. you can’t use them to synthesize data because the checks are not associated with a hypothesis strategy.
 """
 
+import re
 from datetime import datetime
 
 import pandas as pd
@@ -67,3 +68,21 @@ def max_word_count(element, *, max_words):
     if not isinstance(element, str):
         raise TypeError("Value must be a string")
     return len(element.split()) <= max_words
+
+
+@pa.extensions.register_check_method(check_type="element_wise")
+def postcode_list(element):
+    """Checks that a string can be split on commas and each element matches a basic UK postcode regex.
+
+    :param element: an element to check
+    :return: True if passes the check, else False
+    """
+    if not isinstance(element, str):
+        raise TypeError("Value must be a string")
+    postcode_regex = r"^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$"
+    postcodes = element.split(",")
+    for postcode in postcodes:
+        postcode = postcode.strip()
+        if not re.match(postcode_regex, postcode):
+            return False
+    return True

--- a/tables/checks.py
+++ b/tables/checks.py
@@ -23,6 +23,8 @@ from datetime import datetime
 import pandas as pd
 import pandera as pa
 
+from core.transformation.utils import POSTCODE_REGEX
+
 
 @pa.extensions.register_check_method(check_type="element_wise")
 def is_datetime(element):
@@ -79,10 +81,9 @@ def postcode_list(element):
     """
     if not isinstance(element, str):
         raise TypeError("Value must be a string")
-    postcode_regex = r"^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$"
     postcodes = element.split(",")
     for postcode in postcodes:
         postcode = postcode.strip()
-        if not re.match(postcode_regex, postcode):
+        if not re.match(POSTCODE_REGEX, postcode):
             return False
     return True

--- a/tables/tests/test_checks.py
+++ b/tables/tests/test_checks.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tables.checks import postcode_list
+
+
+def test_postcode_list_valid_postcodes():
+    valid_postcodes = [
+        "SW1A1AA",
+        "SW1A 1AA",
+        "M11AE",
+        "M1 1AE",
+        "CR26XH",
+        "CR2 6XH",
+        "DN551PT",
+        "DN55 1PT",
+        "W1A1HQ",
+        "W1A 1HQ",
+        "EC1A1BB",
+        "EC1A 1BB",
+    ]
+    for postcode in valid_postcodes:
+        assert postcode_list(postcode)
+    assert postcode_list("SW1A1AA, EC1A 1BB, M1 1AE")
+
+
+def test_postcode_list_invalid_postcodes():
+    invalid_postcodes = [
+        "SW1A 1AA1",
+        "SW1A 1",
+        "sw1a 1aa",
+        "SW!A 1AA",
+        "InvalidPostcode",
+    ]
+    for postcode in invalid_postcodes:
+        assert not postcode_list(postcode)
+    assert not postcode_list("SW1A1AA, InvalidPostcode, M1 1AE")
+
+
+def test_postcode_list_empty_input():
+    assert not postcode_list("")
+
+
+def test_postcode_list_non_string_input():
+    with pytest.raises(TypeError):
+        postcode_list(123)
+
+    with pytest.raises(TypeError):
+        postcode_list(["SW1A1AA", "EC1A 1BB"])

--- a/tables/tests/test_checks.py
+++ b/tables/tests/test_checks.py
@@ -28,7 +28,7 @@ def test_postcode_list_valid_postcode_list():
     assert postcode_list("SW1A1AA, EC1A 1BB, M1 1AE")
 
 
-@pytest.mark.parametrize("postcode", ["SW1A 1AA1", "SW1A 1", "sw1a 1aa", "SW!A 1AA", "InvalidPostcode"])
+@pytest.mark.parametrize("postcode", ["SW1A 1", "sw1a 1aa", "SW!A 1AA", "InvalidPostcode"])
 def test_postcode_list_invalid_postcodes(postcode):
     assert not postcode_list(postcode)
 

--- a/tables/tests/test_checks.py
+++ b/tables/tests/test_checks.py
@@ -3,8 +3,9 @@ import pytest
 from tables.checks import postcode_list
 
 
-def test_postcode_list_valid_postcodes():
-    valid_postcodes = [
+@pytest.mark.parametrize(
+    "postcode",
+    [
         "SW1A1AA",
         "SW1A 1AA",
         "M11AE",
@@ -17,22 +18,22 @@ def test_postcode_list_valid_postcodes():
         "W1A 1HQ",
         "EC1A1BB",
         "EC1A 1BB",
-    ]
-    for postcode in valid_postcodes:
-        assert postcode_list(postcode)
+    ],
+)
+def test_postcode_list_valid_postcodes(postcode):
+    assert postcode_list(postcode)
+
+
+def test_postcode_list_valid_postcode_list():
     assert postcode_list("SW1A1AA, EC1A 1BB, M1 1AE")
 
 
-def test_postcode_list_invalid_postcodes():
-    invalid_postcodes = [
-        "SW1A 1AA1",
-        "SW1A 1",
-        "sw1a 1aa",
-        "SW!A 1AA",
-        "InvalidPostcode",
-    ]
-    for postcode in invalid_postcodes:
-        assert not postcode_list(postcode)
+@pytest.mark.parametrize("postcode", ["SW1A 1AA1", "SW1A 1", "sw1a 1aa", "SW!A 1AA", "InvalidPostcode"])
+def test_postcode_list_invalid_postcodes(postcode):
+    assert not postcode_list(postcode)
+
+
+def test_postcode_list_invalid_postcode_list():
     assert not postcode_list("SW1A1AA, InvalidPostcode, M1 1AE")
 
 
@@ -40,9 +41,8 @@ def test_postcode_list_empty_input():
     assert not postcode_list("")
 
 
-def test_postcode_list_non_string_input():
-    with pytest.raises(TypeError):
-        postcode_list(123)
-
-    with pytest.raises(TypeError):
-        postcode_list(["SW1A1AA", "EC1A 1BB"])
+@pytest.mark.parametrize("invalid_input", [123, ["SW1A1AA", "EC1A 1BB"]])
+def test_postcode_list_non_string_input(invalid_input):
+    with pytest.raises(TypeError) as excinfo:
+        postcode_list(invalid_input)
+    assert str(excinfo.value) == "Value must be a string"


### PR DESCRIPTION
### Ticket

[SMD-710 - Pathfinders - validate postcodes](https://dluhcdigital.atlassian.net/browse/SMD-710)

### Change summary
Add validation to check for postcode or comma-separated list of postcodes in postcodes field in "Project location" table from new Pathfinder Reporting Template.