### PR TITLE
BAU: fix subsequent submissions for pf

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -535,7 +535,7 @@ class Submission(BaseModel):
 
         :return: submission number
         """
-        return int(self.submission_id.split("-")[2])
+        return int(self.submission_id.split("-")[-1])
 
 
 class GeospatialDim(BaseModel):

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -681,17 +681,25 @@ def get_organisation_exists(organisation_name: str) -> ents.Organisation | None:
 def get_latest_submission_by_round_and_fund(reporting_round: int, fund_id: str) -> ents.Submission:
     """Get the latest submission id for a given reporting round and fund.
 
+    Different fund ids have differing lengths, and so require a different substring to order by.
+
     :param reporting_round: integer representing the reporting round.
     :param fund_id: the two-letter code representing the fund.
     :return: a Submission object.
     """
+
+    fund_id_number = {
+        "TD": 7,
+        "HS": 7,
+        "PF": 10,
+    }
 
     latest_submission_id = (
         ents.Submission.query.join(ents.ProgrammeJunction)
         .join(ents.Programme)
         .filter(ents.Submission.reporting_round == reporting_round)
         .filter(ents.Programme.fund_type_id == fund_id)
-        .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, 7), Integer)))
+        .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, fund_id_number[fund_id]), Integer)))
         .first()
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,3 +438,35 @@ def towns_fund_bolton_round_1_test_data():
     )
     db.session.add(programme_junction)
     db.session.commit()
+
+
+@pytest.fixture(scope="module")
+def pathfinders_round_1_submission_data():
+    """Pre-populates Submission table with an already existing PF submission."""
+    submission = Submission(
+        submission_id="S-PF-R01-1",
+        reporting_round=1,
+        reporting_period_start=datetime(2019, 10, 10),
+        reporting_period_end=datetime(2021, 10, 10),
+    )
+
+    organisation = Organisation(organisation_name="Romulus")
+    db.session.add_all((submission, organisation))
+    db.session.flush()
+
+    programme = Programme(
+        programme_id="PF-ROM",
+        programme_name="Romulan Star Empire",
+        fund_type_id="PF",
+        organisation_id=organisation.id,
+    )
+
+    db.session.add(programme)
+    db.session.flush()
+
+    programme_junction = ProgrammeJunction(
+        submission_id=submission.id,
+        programme_id=programme.id,
+    )
+    db.session.add(programme_junction)
+    db.session.commit()


### PR DESCRIPTION
Fixes a bug wherein subsequent submission ids for PF were not incrementing correctly, and adds a test to ensure that subsequent submissions for the same round for different programmes for PF do not have any errors on load.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

