### PR TITLE
BAU: fix td and hs submission id bug

### DIFF
--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -683,24 +683,28 @@ def get_latest_submission_by_round_and_fund(reporting_round: int, fund_id: str) 
 
     Different fund ids have differing lengths, and so require a different substring to order by.
 
+    HS and TD belong to TF submissions, and so require retrieval of the same incremention of submission ids.
+
     :param reporting_round: integer representing the reporting round.
     :param fund_id: the two-letter code representing the fund.
     :return: a Submission object.
     """
 
-    fund_id_number = {
+    # TODO: https://dluhcdigital.atlassian.net/jira/software/c/projects/FMD/boards/139/backlog?selectedIssue=FMD-258
+    id_character_offset = {
         "TD": 7,
         "HS": 7,
         "PF": 10,
     }
 
+    fund_types = ["TD", "HS"] if fund_id in ["TD", "HS"] else [fund_id]
+
     latest_submission_id = (
         ents.Submission.query.join(ents.ProgrammeJunction)
         .join(ents.Programme)
         .filter(ents.Submission.reporting_round == reporting_round)
-        .filter(ents.Programme.fund_type_id == fund_id)
-        .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, fund_id_number[fund_id]), Integer)))
+        .filter(ents.Programme.fund_type_id.in_(fund_types))
+        .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, id_character_offset[fund_id]), Integer)))
         .first()
     )
-
     return latest_submission_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -470,3 +470,35 @@ def pathfinders_round_1_submission_data():
     )
     db.session.add(programme_junction)
     db.session.commit()
+
+
+@pytest.fixture(scope="module")
+def towns_fund_td_round_3_submission_data():
+    """Pre-populates Submission table with an already existing TD submission."""
+    submission = Submission(
+        submission_id="S-R03-1",
+        reporting_round=3,
+        reporting_period_start=datetime(2019, 10, 10),
+        reporting_period_end=datetime(2021, 10, 10),
+    )
+
+    organisation = Organisation(organisation_name="Romulus")
+    db.session.add_all((submission, organisation))
+    db.session.flush()
+
+    programme = Programme(
+        programme_id="TD-ROM",
+        programme_name="Romulan Star Empire",
+        fund_type_id="TD",
+        organisation_id=organisation.id,
+    )
+
+    db.session.add(programme)
+    db.session.flush()
+
+    programme_junction = ProgrammeJunction(
+        submission_id=submission.id,
+        programme_id=programme.id,
+    )
+    db.session.add(programme_junction)
+    db.session.commit()

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -950,3 +950,23 @@ def test_ingest_same_programme_different_rounds(
         "leading_factor_of_delay": "Property Development/ Planning Permission",
         "adjustment_request_status": "PAR submitted - approved",
     }
+
+
+def test_ingest_with_r3_hs_file_success_with_td_data_already_in(
+    test_client_reset, towns_fund_round_3_file_success, towns_fund_td_round_3_submission_data, test_buckets
+):
+    """Tests that ingesting a HS file with one TD submission already in for the same round increment the submission id
+    correctly."""
+    endpoint = "/ingest"
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": towns_fund_round_3_file_success,
+            "fund_name": "Towns Fund",
+            "reporting_round": 3,
+            "do_load": True,
+        },
+    )
+
+    assert len(Submission.query.all()) == 2
+    assert Submission.query.filter(Submission.submission_id == "S-R03-2").first()


### PR DESCRIPTION
Fixes a bug wherein ```get_latest_submission_by_round_and_fund``` does a look-up based on ```fund_type_id```, which discerns TD and HS as different funds when they belong to the same round of submissions.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")