### PR TITLE
SMD-731: make comms milestone and comms milestone date optional

### DIFF
--- a/core/validation/specific_validation/towns_fund_round_four/validate.py
+++ b/core/validation/specific_validation/towns_fund_round_four/validate.py
@@ -593,8 +593,6 @@ def validate_project_progress(workbook: dict[str, pd.DataFrame]) -> list["Generi
     - For projects with a delivery status other than '4. Completed':
         - Validates the following columns for null values:
             - 'Current Project Delivery Stage'
-            - 'Most Important Upcoming Comms Milestone'
-            - 'Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)'
 
     :param workbook: A dictionary containing sheet names as keys and pandas DataFrames
                      representing each sheet in the Round 4 submission.
@@ -614,12 +612,6 @@ def validate_project_progress(workbook: dict[str, pd.DataFrame]) -> list["Generi
     columns_to_check = [
         ("Leading Factor of Delay", project_delayed_rows, msgs.BLANK),
         ("Current Project Delivery Stage", project_incomplete_rows, msgs.BLANK_IF_PROJECT_INCOMPLETE),
-        ("Most Important Upcoming Comms Milestone", project_incomplete_rows, msgs.BLANK_IF_PROJECT_INCOMPLETE),
-        (
-            "Date of Most Important Upcoming Comms Milestone (e.g. Dec-22)",
-            project_incomplete_rows,
-            msgs.BLANK_IF_PROJECT_INCOMPLETE,
-        ),
     ]
 
     failures = []

--- a/tests/validation_tests/specific_validation_tests/towns_fund_round_four_tests/test_tf_r4_specific_validations.py
+++ b/tests/validation_tests/specific_validation_tests/towns_fund_round_four_tests/test_tf_r4_specific_validations.py
@@ -1221,7 +1221,7 @@ def test_validate_project_progress_leading_success_with_delay():
     assert failures == []
 
 
-def test_validate_project_progress_current_project_delivery_status_and_upcoming_coms_failure():
+def test_validate_project_progress_current_project_delivery_status_failure():
     project_progress_df = pd.DataFrame(
         index=[21],
         data=[
@@ -1244,20 +1244,6 @@ def test_validate_project_progress_current_project_delivery_status_and_upcoming_
             table="Project Progress",
             section="Projects Progress Summary",
             column="Current Project Delivery Stage",
-            message="The cell is blank but is required for incomplete projects.",
-            row_index=21,
-        ),
-        GenericFailure(
-            table="Project Progress",
-            section="Projects Progress Summary",
-            column="Most Important Upcoming Comms Milestone",
-            message="The cell is blank but is required for incomplete projects.",
-            row_index=21,
-        ),
-        GenericFailure(
-            table="Project Progress",
-            section="Projects Progress Summary",
-            column="Date of Most Important Upcoming Comms Milestone (" "e.g. Dec-22)",
             message="The cell is blank but is required for incomplete projects.",
             row_index=21,
         ),


### PR DESCRIPTION
### Change description
make comms milestone and comms milestone date optional. We have existing ingested submissions which don't populate these fields and TF have confirmed they should be optional

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Unit tests should pass, fields should be optional and not fail ingest if not populated.

### Screenshots of UI changes (if applicable)
