### PR TITLE
[FMD-256]: standardise actual forecast in db

### DIFF
--- a/core/controllers/mappings.py
+++ b/core/controllers/mappings.py
@@ -319,14 +319,14 @@ INGEST_MAPPINGS = (
             "Start_Date": "start_date",
             "End_Date": "end_date",
             "Spend for Reporting Period": "spend_for_reporting_period",
-            "Actual/Forecast": "status",
+            "Actual/Forecast": "state",
         },
         cols_to_jsonb=[
             "funding_source_name",
             "funding_source_type",
             "secured",
             "spend_for_reporting_period",
-            "status",
+            "state",
         ],
         fk_relations=[
             ("project_id", ents.Project, "project_id", "project_id"),
@@ -509,7 +509,7 @@ INGEST_MAPPINGS = (
             "Amount Moved": "amount_moved",
             "Change Made": "changes_made",
             "Reason for Change": "reasons_for_change",
-            "Actual or Forecast": "forecast_or_actual_change",
+            "Actual or Forecast": "state",
             "Reporting Period Change Takes Place": "reporting_period_change_takes_place",
         },
         cols_to_jsonb=[
@@ -521,7 +521,7 @@ INGEST_MAPPINGS = (
             "amount_moved",
             "changes_made",
             "reasons_for_change",
-            "forecast_or_actual_change",
+            "state",
             "reporting_period_change_takes_place",
         ],
         fk_relations=[

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -217,7 +217,7 @@ class FundingSchema(SQLAlchemySchema):
     spend_for_reporting_period = fields.Number(
         attribute="data_blob.spend_for_reporting_period", data_key="SpendforReportingPeriod"
     )
-    status = JSONBStringField(attribute="data_blob.status", data_key="ActualOrForecast")
+    state = JSONBStringField(attribute="data_blob.state", data_key="ActualOrForecast")
     project_name = auto_field(model=Project, data_key="ProjectName")
     programme_name = auto_field(model=Programme, data_key="Place")
     organisation_name = auto_field(model=Organisation, data_key="OrganisationName")
@@ -412,9 +412,7 @@ class ProjectFinanceChangeSchema(SQLAlchemySchema):
     amount_moved = JSONBFloatField(attribute="data_blob.amount_moved", data_key="AmountMoved")
     changes_made = JSONBStringField(attribute="data_blob.changes_made", data_key="ChangesMade")
     reasons_for_change = JSONBStringField(attribute="data_blob.reasons_for_change", data_key="ReasonsForChange")
-    forecast_or_actual_change = JSONBStringField(
-        attribute="data_blob.forecast_or_actual_change", data_key="ForecastOrActualChange"
-    )
+    state = JSONBStringField(attribute="data_blob.state", data_key="ForecastOrActualChange")
     reporting_period_change_takes_place = JSONBStringField(
         attribute="data_blob.reporting_period_change_takes_place",
         data_key="ReportingPeriodChangeTakesPlace",

--- a/db/migrations/versions/026_standardise_actual_forecast.py
+++ b/db/migrations/versions/026_standardise_actual_forecast.py
@@ -1,0 +1,44 @@
+"""empty message
+
+Revision ID: 026_standardise_actual_forecast
+Revises: 025_rename_pg_management
+Create Date: 2024-03-28 15:49:44.420890
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "026_standardise_actual_forecast"
+down_revision = "025_rename_pg_management"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 'status' in Funding's data_blob to 'state'
+    op.execute(
+        """
+        UPDATE funding
+        SET data_blob = jsonb_set(data_blob, '{state}', data_blob->'status', true)
+        WHERE data_blob ? 'status';
+
+        UPDATE funding
+        SET data_blob = data_blob - 'status'
+        WHERE data_blob ? 'status';
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE funding
+        SET data_blob = jsonb_set(data_blob, '{status}', data_blob->'state', true)
+        WHERE data_blob ? 'state';
+
+        UPDATE funding
+        SET data_blob = data_blob - 'state'
+        WHERE data_blob ? 'state';
+        """
+    )


### PR DESCRIPTION
Standardise actual/forecast column to always be 'state' in data_blob for both Funding and ProjectFinanceChange.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

