### PR TITLE
FMD-264: add pathfinders to fund ID mapping

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -193,7 +193,11 @@ class ITLRegion(StrEnum):
 
 
 # maps a fund id to its full name (we only store ids in the data model)
-FUND_ID_TO_NAME = {FundTypeIdEnum.HIGH_STREET_FUND: "High Street Fund", FundTypeIdEnum.TOWN_DEAL: "Town Deal"}
+FUND_ID_TO_NAME = {
+    FundTypeIdEnum.HIGH_STREET_FUND: "High Street Fund",
+    FundTypeIdEnum.TOWN_DEAL: "Town Deal",
+    FundTypeIdEnum.PATHFINDERS: "Pathfinders",
+}
 
 # TLZ is given to any location outside the primary 12 ITL 1 regions as stated on the link below (previously NUTS & UKZ)
 # This introduces the problem that TLZ now maps to multiple locations (Channel Islands, Isle of Man, Non-geographic)


### PR DESCRIPTION
### Change description
Add Pathfinders mapping (to stop data-store throwing exception if Pathfinders sheet was ingested)

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should be able to render find frontend download page if Pathfinders sheet has been ingested


### Screenshots of UI cha
<img width="288" alt="Screenshot 2024-04-02 at 15 12 55" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/1764158/c8138e4d-210c-4a89-bb6c-995e3155e731">
nges (if applicable)
