### PR TITLE
update ProgrrammeManagementFunding tab name in serialised extract

### DIFF
--- a/core/const.py
+++ b/core/const.py
@@ -700,7 +700,7 @@ TABLE_SORT_ORDERS = {
     "RiskRegister": ["SubmissionID", "ProgrammeID", "ProjectID", "RiskName"],
     "ProjectFinanceChange": ["SubmissionID", "ProgrammeID"],
     "SubmissionRef": ["SubmissionID"],
-    "ProgrammeFundingManagement": ["SubmissionID", "ProgrammeID", "PaymentType", "StartDate", "EndDate"],
+    "ProgrammeManagementFunding": ["SubmissionID", "ProgrammeID", "PaymentType", "StartDate", "EndDate"],
 }
 
 # map place to fund type associated with it

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -142,7 +142,7 @@ def serialise_download_data(
         "OutcomeData": (outcome_data_query, OutcomeDataSchema),
         "RiskRegister": (risk_register_query, RiskRegisterSchema),
         "ProjectFinanceChange": (project_finance_change_query, ProjectFinanceChangeSchema),
-        "ProgrammeFundingManagement": (programme_funding_management_query, ProgrammeFundingManagementSchema),
+        "ProgrammeManagementFunding": (programme_funding_management_query, ProgrammeFundingManagementSchema),
         "SubmissionRef": (submission_metadata_query, SubmissionSchema),
     }
 

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -63,7 +63,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
     assert test_serialised_data.get("RiskRegister")
     assert test_serialised_data.get("ProjectFinanceChange")
     assert test_serialised_data.get("SubmissionRef")
-    assert test_serialised_data.get("ProgrammeFundingManagement")
+    assert test_serialised_data.get("ProgrammeManagementFunding")
     assert len(test_serialised_data) == 18
 
     # assert all tables contain place and organisation (apart from OrgRef, OutputRef, SubmissionRef and OutcomeRef)
@@ -276,7 +276,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "ReportingPeriodEnd",
         "ReportingRound",
     ]
-    assert list(pd.DataFrame.from_records(test_serialised_data["ProgrammeFundingManagement"]).columns) == [
+    assert list(pd.DataFrame.from_records(test_serialised_data["ProgrammeManagementFunding"]).columns) == [
         "SubmissionID",
         "ProgrammeID",
         "PaymentType",
@@ -287,7 +287,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "Place",
         "OrganisationName",
     ]
-    assert len(test_serialised_data["ProgrammeFundingManagement"]) == 24
+    assert len(test_serialised_data["ProgrammeManagementFunding"]) == 24
 
     # check a couple of tables that all results are returned
     assert len(test_serialised_data["SubmissionRef"]) == len(Submission.query.all()) == 2


### PR DESCRIPTION
### Change description
Changing name in data extract for this table due to request from Towns Fund (currently they are they are the only user of this tab). Request copied from teams channel TF Hotline, (Renata Walton, 12:45, 04/04/2024):

_"Hi 
Gideon_
 
_Goldberg
, without fully checking the contents as I'll need to pull this into out dashboard. Thank you all for finally getting this information in there. It's actually ProgrammeManagementFunding, as it's a specific type of payment which is made to LAs for PM activity. So can the name be changed?"_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


