### PR TITLE
FMD-259: Add DB constraint to check date ranges

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -50,6 +50,10 @@ class Funding(BaseModel):
             or_(start_date.isnot(None), end_date.isnot(None)),
             name="ck_funding_start_or_end_date",
         ),
+        sqla.CheckConstraint(
+            "start_date IS NULL OR end_date IS NULL OR (start_date <= end_date)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
+        ),
         sqla.Index(
             "ix_funding_join_project",
             "project_id",
@@ -145,6 +149,10 @@ class OutcomeData(BaseModel):
             ),
             name="ck_outcome_data_programme_junction_id_or_project_id",
         ),
+        sqla.CheckConstraint(
+            "(start_date <= end_date)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
+        ),
         sqla.Index(
             "ix_outcome_join_programme_junction",
             "programme_junction_id",
@@ -206,6 +214,10 @@ class OutputData(BaseModel):
                 and_(programme_junction_id.is_(None), project_id.isnot(None)),
             ),
             name="ck_output_data_programme_junction_id_or_project_id",
+        ),
+        sqla.CheckConstraint(
+            "(start_date <= end_date)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
         ),
         sqla.Index(
             "ix_output_join_programme_junction",
@@ -329,6 +341,10 @@ class ProgrammeFundingManagement(BaseModel):
         sqla.Index(
             "ix_programme_funding_management_join_programme_junction",
             "programme_junction_id",
+        ),
+        sqla.CheckConstraint(
+            "start_date IS NULL OR end_date IS NULL OR (start_date <= end_date)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
         ),
     )
 
@@ -487,6 +503,10 @@ class ProjectProgress(BaseModel):
             "ix_project_progress_join_project",
             "project_id",
         ),
+        sqla.CheckConstraint(
+            "start_date IS NULL OR end_date IS NULL OR (start_date <= end_date)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
+        ),
     )
 
 
@@ -552,6 +572,10 @@ class Submission(BaseModel):
         sqla.Index(
             "ix_submission_filter_end_date",
             "reporting_period_end",
+        ),
+        sqla.CheckConstraint(
+            "(reporting_period_start <= reporting_period_end)",
+            name="start_before_end",  # gets prefixed with `ck_{table}`
         ),
     )
 

--- a/db/migrations/alembic.ini
+++ b/db/migrations/alembic.ini
@@ -25,7 +25,7 @@ handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
+level = INFO
 handlers =
 qualname = sqlalchemy.engine
 

--- a/db/migrations/versions/027_start_date_before_end.py
+++ b/db/migrations/versions/027_start_date_before_end.py
@@ -1,0 +1,56 @@
+"""require start_dates to be before end_dates, if both fields are present in a row
+
+Revision ID: 027_start_date_before_end
+Revises: 026_standardise_actual_forecast
+Create Date: 2024-04-04 13:59:15.747254
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "027_start_date_before_end"
+down_revision = "026_standardise_actual_forecast"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table in ["funding", "programme_funding_management", "project_progress"]:
+        op.create_check_constraint(
+            "start_before_end",  # gets prefixed with `ck_{table}`
+            table,
+            "start_date IS NULL OR end_date IS NULL OR (start_date <= end_date)",
+            postgresql_not_valid=True,
+        )
+
+    for table in ["outcome_data", "output_data"]:
+        op.create_check_constraint(
+            "start_before_end",  # gets prefixed with `ck_{table}`
+            table,
+            "(start_date <= end_date)",
+            postgresql_not_valid=True,
+        )
+
+    for table in ["submission_dim"]:
+        op.create_check_constraint(
+            "start_before_end",  # gets prefixed with `ck_{table}`
+            table,
+            "(reporting_period_start <= reporting_period_end)",
+            postgresql_not_valid=True,
+        )
+
+
+def downgrade():
+    for table in [
+        "funding",
+        "programme_funding_management",
+        "project_progress",
+        "outcome_data",
+        "output_data",
+        "submission_dim",
+    ]:
+        op.drop_constraint(
+            f"ck_{table}_start_before_end",
+            table,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,7 +311,7 @@ def additional_test_data() -> dict[str, Any]:
         programme_junction_id=programme_junction.id,
         outcome_id=test_outcome_dim.id,  # linked to Transport OutcomeDim
         start_date=datetime(2024, 1, 1),
-        end_date=datetime(2023, 12, 31),
+        end_date=datetime(2024, 12, 31),
         data_blob={
             "unit_of_measurement": "Units",
             "geography_indicator": GeographyIndicatorEnum.TOWN,
@@ -349,7 +349,7 @@ def additional_test_data() -> dict[str, Any]:
         project_id=None,
         outcome_id=test_outcome_dim.id,  # linked to TEST-OUTCOME-CATEGORY OutcomeDim
         start_date=datetime(2024, 1, 1),
-        end_date=datetime(2023, 12, 31),
+        end_date=datetime(2024, 12, 31),
         data_blob={
             "unit_of_measurement": "TEST Units",
         },

--- a/tests/db_tests/test_constraints.py
+++ b/tests/db_tests/test_constraints.py
@@ -1,6 +1,6 @@
 """Tests for sqla CheckConstraints table_args on model."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -12,9 +12,12 @@ from core.db.entities import (
     OutcomeDim,
     OutputData,
     OutputDim,
+    ProgrammeFundingManagement,
     ProgrammeJunction,
     Project,
+    ProjectProgress,
     RiskRegister,
+    Submission,
 )
 
 
@@ -114,3 +117,91 @@ def test_output_constraint_project_xor_programme(seeded_test_client_rollback):
     db.session.add(invalid_output_row_neither)
     with pytest.raises(IntegrityError):
         db.session.commit()
+
+
+class TestConstraintOnStartAndEndDates:
+    def test_funding_model_nullable_dates(self, seeded_test_client_rollback):
+        f = Funding(
+            programme_junction_id=ProgrammeJunction.query.first().id,
+            data_blob={},
+            start_date=datetime.now(),
+            end_date=datetime.now() - timedelta(seconds=1),
+        )
+        db.session.add(f)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_funding_start_before_end" in str(e.value)
+
+    def test_programme_funding_management_model_nullable_dates(self, seeded_test_client_rollback):
+        pfm = ProgrammeFundingManagement(
+            programme_junction_id=ProgrammeJunction.query.first().id,
+            data_blob={},
+            start_date=datetime.now(),
+            end_date=datetime.now() - timedelta(seconds=1),
+        )
+        db.session.add(pfm)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_programme_funding_management_start_before_end" in str(e.value)
+
+    def test_project_progress_model_nullable_dates(self, seeded_test_client_rollback):
+        pp = ProjectProgress(
+            project_id=Project.query.first().id,
+            data_blob={},
+            start_date=datetime.now(),
+            end_date=datetime.now() - timedelta(seconds=1),
+        )
+        db.session.add(pp)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_project_progress_start_before_end" in str(e.value)
+
+    def test_outcome_data_model_non_nullable_dates(self, seeded_test_client_rollback):
+        od = OutcomeData(
+            programme_junction_id=ProgrammeJunction.query.first().id,
+            outcome_id=OutcomeDim.query.first().id,
+            start_date=datetime.now(),
+            end_date=datetime.now() - timedelta(seconds=1),
+            data_blob={},
+        )
+        db.session.add(od)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_outcome_data_start_before_end" in str(e.value)
+
+    def test_output_data_model_non_nullable_dates(self, seeded_test_client_rollback):
+        od = OutputData(
+            programme_junction_id=ProgrammeJunction.query.first().id,
+            output_id=OutputDim.query.first().id,
+            start_date=datetime.now(),
+            end_date=datetime.now() - timedelta(seconds=1),
+            data_blob={},
+        )
+        db.session.add(od)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_output_data_start_before_end" in str(e.value)
+
+    def test_reporting_period_start_and_end_dates(self, seeded_test_client_rollback):
+        s = Submission(
+            submission_id="TEST",
+            reporting_period_start=datetime.now(),
+            reporting_period_end=datetime.now() - timedelta(seconds=1),
+            reporting_round=1,
+        )
+        db.session.add(s)
+
+        with pytest.raises(IntegrityError) as e:
+            db.session.commit()
+
+        assert "ck_submission_dim_start_before_end" in str(e.value)

--- a/tests/integration_tests/mock_tf_r3_transformed_data/Outcome_Data.csv
+++ b/tests/integration_tests/mock_tf_r3_transformed_data/Outcome_Data.csv
@@ -20,7 +20,7 @@ FHSFDCC001,,2021-09-01,2021-09-30,Usual method of travel to work: Taxi,%,Local A
 ,FHSF001,2021-10-01,2021-10-31,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,41,Actual,
 ,FHSF001,2021-11-01,2021-11-30,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,66,Actual,Some Example Data
 ,FHSF001,2021-12-01,2021-12-31,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,45,Actual,Some Example Data
-,FHSF001,2022-01-01,2021-01-31,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,8,Actual,Some Example Data
+,FHSF001,2022-01-01,2022-01-31,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,8,Actual,Some Example Data
 ,FHSF001,2022-02-01,2022-02-28,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,71,Actual,Some Example Data
 ,FHSF001,2022-03-01,2022-03-31,Year on Year monthly % change in footfall,Year on Year % Change in Monthly Footfall,Town,39,Actual,Some Example Data
 ,FHSF001,2022-04-01,2022-04-30,Usual method of travel to work: Taxi,%,Local Authority,21,Forecast,Some Example Data

--- a/tests/resources/outcome_data.csv
+++ b/tests/resources/outcome_data.csv
@@ -20,7 +20,7 @@ aa1c616a-c7c2-40d7-9514-25e8efc11fa4,01e1f6fc-1b79-4dec-adef-977e775a5e03,,01/09
 703e7734-605e-46cd-8fea-ae02f5e6fc6e,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/10/2021,10/31/2021,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,41,Actual,
 eacb4e9e-a8ca-464f-9b12-cbbbff0dfcb3,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/11/2021,11/30/2021,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,66,Actual,Some Example Data
 ca92e271-75f8-48f2-b83c-ea1acbed0b09,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/12/2021,12/31/2021,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,45,Actual,Some Example Data
-16b08832-7a87-4d71-8fb3-5c102cf617ed,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/01/2022,01/31/2021,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,8,Actual,Some Example Data
+16b08832-7a87-4d71-8fb3-5c102cf617ed,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/01/2022,01/31/2022,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,8,Actual,Some Example Data
 d48bd618-667c-49bd-b6d6-12ece771557c,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/02/2022,02/28/2022,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,71,Actual,Some Example Data
 13af18c2-5b9e-44db-8d78-bd40daf0a91f,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/03/2022,03/31/2022,ed352a80-b5c2-4234-9306-3e8841de5e5a,Year on Year % Change in Monthly Footfall,Town,39,Actual,Some Example Data
 e5bbf864-89c3-4923-bedf-460390becce1,,6c934287-92d0-4b76-ae2c-95bc292c7608,01/04/2022,04/30/2022,55682ab8-d2a9-4a0f-a916-ba96f03cdd5f,%,Local Authority,21,Forecast,Some Example Data


### PR DESCRIPTION
### Change description
Add constraints to our DB tables which have start/end dates, ensuring that end dates can't be before start dates.

Includes a couple of extra commits which tweak config so that:
* SQL is logged when migrations run, for information/records
* Migrations run in separate transactions (see 586359ca9d77cf746beadb309815035fd368573c for more info)

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
