### PR TITLE
SMD-759: bug fix postcode validation

### DIFF
--- a/tables/checks.py
+++ b/tables/checks.py
@@ -19,6 +19,7 @@ However, there are two main disadvantages of schemas with inline custom checks:
 
 import re
 from datetime import datetime
+from typing import Any
 
 import pandas as pd
 import pandera as pa
@@ -49,7 +50,7 @@ def is_float(element):
 
 
 @pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def not_in_future(element):
+def not_in_future(element: Any):
     """Checks that a datetime is not in the future.
 
     :param element: an element to check
@@ -61,7 +62,7 @@ def not_in_future(element):
 
 
 @pa.extensions.register_check_method(statistics=["max_words"], check_type=CheckType.ELEMENT_WISE)
-def max_word_count(element, *, max_words):
+def max_word_count(element: Any, *, max_words):
     """Checks that a string split up by whitespace characters is less than or equal to "max_words" elements long.
 
     :param element: an element to check
@@ -74,7 +75,7 @@ def max_word_count(element, *, max_words):
 
 
 @pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def postcode_list(element):
+def postcode_list(element: Any):
     """Checks that a string can be split on commas and each element matches a basic UK postcode regex.
 
     :param element: an element to check

--- a/tables/tests/test_checks.py
+++ b/tables/tests/test_checks.py
@@ -45,9 +45,7 @@ def test_postcode_list_empty_input():
 
 @pytest.mark.parametrize("invalid_input", [123, ["SW1A1AA", "EC1A 1BB"]])
 def test_postcode_list_non_string_input(invalid_input):
-    with pytest.raises(TypeError) as excinfo:
-        postcode_list(invalid_input)
-    assert str(excinfo.value) == "Value must be a string"
+    assert postcode_list(invalid_input) is False
 
 
 @pytest.mark.parametrize("partial_func", [not_in_future, partial(max_word_count, max_words=100), postcode_list])

--- a/tables/tests/test_checks.py
+++ b/tables/tests/test_checks.py
@@ -1,6 +1,8 @@
+from functools import partial
+
 import pytest
 
-from tables.checks import postcode_list
+from tables.checks import max_word_count, not_in_future, postcode_list
 
 
 @pytest.mark.parametrize(
@@ -46,3 +48,8 @@ def test_postcode_list_non_string_input(invalid_input):
     with pytest.raises(TypeError) as excinfo:
         postcode_list(invalid_input)
     assert str(excinfo.value) == "Value must be a string"
+
+
+@pytest.mark.parametrize("partial_func", [not_in_future, partial(max_word_count, max_words=100), postcode_list])
+def test_checks_return_false_on_nan(partial_func):
+    assert partial_func(float("nan")) is False


### PR DESCRIPTION
### Change description
Fixes two things:

1) When uploading a spreadsheet with null data and invalid postcodes in the postcode columns, only the null data is reported. (If each failure state is uploaded separately they are reported - but in combination only one is). Now both failures will be reported up front.
2) If entering invalid postcode data that is a non-string type (eg int, datetime), that would previously be accepted. Now it will be rejected correctly.

---

I would have liked to update an integration test spreadsheet to contain some int/datetime postcodes but I don't have excel, so ... what can you do 🤷  help please?

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Edit the `tests/integration_tests/mock_pf_returns/PF_Round_1_Success.xlsx` file on the `Project location` tab. Change some of the postcode lists to be numeric eg `1234`, or date eg `10/04/24`, or null eg ``. Upload it via submit and check that all errors are reportedly accurately and in one go.


### Screenshots of UI changes (if applicable)
