### PR TITLE
BAU: cells for actual forecast error pfc

### DIFF
--- a/core/validation/specific_validation/pathfinders/round_1.py
+++ b/core/validation/specific_validation/pathfinders/round_1.py
@@ -530,7 +530,7 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
     submission_reporting_period_start_date = PF_REPORTING_PERIOD_TO_DATES_PFCS[reporting_period]["start"]
     pfcs_df = extracted_table_dfs["Project finance changes"]
     error_messages = []
-    for _, row in pfcs_df.iterrows():
+    for idx, row in pfcs_df.iterrows():
         change_reporting_period_start_date = PF_REPORTING_PERIOD_TO_DATES_PFCS[
             row["Reporting period change takes place"]
         ]["start"]
@@ -542,6 +542,7 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
                         sheet="Finances",
                         section="Project finance changes",
                         description=PFErrors.ACTUAL_REPORTING_PERIOD,
+                        cell_index=f"P{idx + 1}",
                     )
                 )
         elif actual_forecast_cancelled == "Forecast":
@@ -551,6 +552,7 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
                         sheet="Finances",
                         section="Project finance changes",
                         description=PFErrors.FORECAST_REPORTING_PERIOD,
+                        cell_index=f"P{idx + 1}",
                     )
                 )
     return error_messages

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -439,7 +439,7 @@ def test_ingest_pf_r1_cross_validation_errors(
             "sheet": "Finances",
         },
         {
-            "cell_index": None,
+            "cell_index": "P70",
             "description": "Reporting period must be in the future if 'Actual, forecast or cancelled' is 'Forecast'.",
             "error_type": None,
             "section": "Project finance changes",

--- a/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
+++ b/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
@@ -269,7 +269,7 @@ def test_check_actual_forecast_reporting_period(mock_df_dict):
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index=None,
+            cell_index="P1",
             description="Reporting period must not be in the future if 'Actual, forecast or cancelled' is 'Actual'.",
             error_type=None,
         )
@@ -284,7 +284,7 @@ def test_check_actual_forecast_reporting_period(mock_df_dict):
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index=None,
+            cell_index="P1",
             description="Reporting period must be in the future if 'Actual, forecast or cancelled' is 'Forecast'.",
             error_type=None,
         ),


### PR DESCRIPTION
Adds cell_index for ```_check_actual_forecast_reporting_period``` errors.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
