### PR TITLE
SMD-769 - Order error cell indexes logically

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -161,7 +161,7 @@ def extract_process_validate_tables(
                     Message(
                         sheet=worksheet_name,
                         section=table_name,
-                        cell_index=error.cell.str_ref if error.cell else None,
+                        cell_indexes=(error.cell.str_ref,) if error.cell else None,
                         description=error.message,
                         error_type=None,
                     )
@@ -202,7 +202,7 @@ def build_validation_error_response(
             status=400,
             title="Bad Request",
             pre_transformation_errors=initial_validation_messages or [],
-            validation_errors=[vars(error) for error in validation_messages] if validation_messages else [],
+            validation_errors=[error.to_dict() for error in validation_messages] if validation_messages else [],
         ),
         400,
     )

--- a/core/messaging/__init__.py
+++ b/core/messaging/__init__.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 class Message:
     """Generic Message class that defines the components of a validation error message"""
 
-    cell_index_pattern = re.compile(r"^([a-zA-Z]+)(\d+)?$")
+    cell_index_pattern = re.compile(r"^([A-Z]+)(\d+)?$")
 
     def __init__(self, sheet, section, cell_indexes: tuple[str, ...] | None, description, error_type):
         self.sheet = sheet
@@ -48,12 +48,12 @@ class Message:
             return None
         if None in cell_indexes:
             raise ValueError("`cell_indexes` cannot contain None elements; must be None directly")
+
+        # Split cell indexes into column and row parts, ie 'A1' becomes ('A', '1')
         try:
-            # Split cell indexes into column and row parts, ie 'A1' becomes ('A', '1')
             split_cell_indexes = [cls.cell_index_pattern.match(cell_index).groups() for cell_index in set(cell_indexes)]
-        except AttributeError:
-            # Regex failed to match somehow - returning unsorted is better than dying
-            return cell_indexes
+        except AttributeError as e:
+            raise ValueError(f"Badly structured or formatted cell_indexes: {cell_indexes}") from e
 
         # Sort cell indexes by column (Excel-wise) then by row (numerically) - being careful that there may not
         # be a row number.

--- a/core/messaging/messaging.py
+++ b/core/messaging/messaging.py
@@ -49,7 +49,7 @@ def remove_errors_already_caught_by_null_failure(error_messages: list[Message]) 
         (message.sheet, cell_index)
         for message in error_messages
         if message.description in null_descriptions
-        for cell_index in message.cell_index.split(", ")
+        for cell_index in message.cell_indexes.split(", ")
     ]
 
     filtered_errors = [
@@ -57,7 +57,7 @@ def remove_errors_already_caught_by_null_failure(error_messages: list[Message]) 
         for message in error_messages
         if not any(
             ((message.sheet, cell_index) in cells_covered_by_null_failures)
-            for cell_index in message.cell_index.split(", ")
+            for cell_index in message.cell_indexes.split(", ")
         )
         or message.description in null_descriptions
     ]

--- a/core/messaging/messaging.py
+++ b/core/messaging/messaging.py
@@ -49,15 +49,14 @@ def remove_errors_already_caught_by_null_failure(error_messages: list[Message]) 
         (message.sheet, cell_index)
         for message in error_messages
         if message.description in null_descriptions
-        for cell_index in message.cell_indexes.split(", ")
+        for cell_index in message.cell_indexes
     ]
 
     filtered_errors = [
         message
         for message in error_messages
         if not any(
-            ((message.sheet, cell_index) in cells_covered_by_null_failures)
-            for cell_index in message.cell_indexes.split(", ")
+            ((message.sheet, cell_index) in cells_covered_by_null_failures) for cell_index in message.cell_indexes
         )
         or message.description in null_descriptions
     ]

--- a/core/messaging/tf_messaging.py
+++ b/core/messaging/tf_messaging.py
@@ -288,7 +288,7 @@ class TFMessenger(MessengerBase):
             ]  # these columns do not translate to the spreadsheet
         )
 
-        return Message(sheet, section, cell_index, message, validation_failure.__class__.__name__)
+        return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
 
     def _wrong_type_failure_message(self, validation_failure: WrongTypeFailure) -> Message:
         sheet = self.INTERNAL_TABLE_TO_FORM_SHEET[validation_failure.table]
@@ -315,7 +315,7 @@ class TFMessenger(MessengerBase):
         else:
             message = self.msgs.WRONG_TYPE_UNKNOWN
 
-        return Message(sheet, section, cell_index, message, validation_failure.__class__.__name__)
+        return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
 
     def _invalid_enum_value_failure_message(self, validation_failure: InvalidEnumValueFailure) -> Message:
         sheet = self.INTERNAL_TABLE_TO_FORM_SHEET[validation_failure.table]
@@ -329,7 +329,7 @@ class TFMessenger(MessengerBase):
             if column == "Geography Indicator":
                 actual_index = validation_failure.row_index + 5
                 cell_index = f"C{actual_index}"
-                return Message(sheet, section, cell_index, message, validation_failure.__class__.__name__)
+                return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
 
         # additional logic for risk location
         if sheet == "Risk Register":
@@ -344,7 +344,7 @@ class TFMessenger(MessengerBase):
             table=validation_failure.table, column=validation_failure.column, row_index=validation_failure.row_index
         )
 
-        return Message(sheet, section, cell_index, message, validation_failure.__class__.__name__)
+        return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
 
     def _non_nullable_constraint_failure_message(self, validation_failure: NonNullableConstraintFailure) -> Message:
         """Generate error message components for NonNullableConstraintFailure.
@@ -380,7 +380,7 @@ class TFMessenger(MessengerBase):
         elif section == "Programme-Wide Progress Summary":
             message = self.msgs.BLANK
 
-        return Message(sheet, section, cell_index, message, validation_failure.__class__.__name__)
+        return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
 
     def _unauthorised_submission_failure(self, validation_failure: UnauthorisedSubmissionFailure) -> Message:
         places_or_funds = join_as_string(validation_failure.expected_values)
@@ -399,7 +399,7 @@ class TFMessenger(MessengerBase):
         return Message(
             sheet,
             validation_failure.section,
-            validation_failure.cell_index,
+            (validation_failure.cell_index,),
             validation_failure.message,
             validation_failure.__class__.__name__,
         )

--- a/core/messaging/tf_messaging.py
+++ b/core/messaging/tf_messaging.py
@@ -273,7 +273,7 @@ class TFMessenger(MessengerBase):
             raise ValueError(f"Unrecognised sheet during messaging, {sheet}")
 
         # TODO: Can we return a Failure for each column separately and let them be joined together downstream
-        cell_index = ", ".join(
+        cell_indexes = tuple(
             self._construct_cell_index(
                 table=validation_failure.table, column=column, row_index=validation_failure.row_index
             )
@@ -288,7 +288,7 @@ class TFMessenger(MessengerBase):
             ]  # these columns do not translate to the spreadsheet
         )
 
-        return Message(sheet, section, (cell_index,), message, validation_failure.__class__.__name__)
+        return Message(sheet, section, cell_indexes, message, validation_failure.__class__.__name__)
 
     def _wrong_type_failure_message(self, validation_failure: WrongTypeFailure) -> Message:
         sheet = self.INTERNAL_TABLE_TO_FORM_SHEET[validation_failure.table]
@@ -413,7 +413,7 @@ class TFMessenger(MessengerBase):
         :return: indexes tuple of constructed letter and number indexes
         """
         column_letter = self.TABLE_AND_COLUMN_TO_ORIGINAL_COLUMN_LETTER[table][column]
-        return column_letter.format(i=row_index)
+        return column_letter.format(i=row_index or "")
 
     def _get_cell_indexes_for_outcomes(self, failed_row: pd.Series) -> str:
         """

--- a/core/validation/specific_validation/pathfinders/round_1.py
+++ b/core/validation/specific_validation/pathfinders/round_1.py
@@ -56,7 +56,7 @@ def _error_message(sheet: str, section: str, description: str, cell_index: str =
     :param cell_index: Index of the cell where the error occurred
     :return: Message object
     """
-    return Message(sheet=sheet, section=section, cell_index=cell_index, description=description, error_type=None)
+    return Message(sheet=sheet, section=section, cell_indexes=(cell_index,), description=description, error_type=None)
 
 
 def _check_values_against_allowed(df: pd.DataFrame, value_column: str, allowed_values: list[str]) -> list[str]:

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -645,7 +645,7 @@ def test_ingest_with_r4_file_hs_file_failure(test_client, towns_fund_round_4_fil
         "title": "Bad Request",
         "validation_errors": [
             {
-                "cell_index": "DNone",
+                "cell_index": "D",
                 "description": "You’ve not entered any Other Funding Sources. You "
                 "must enter at least 1 over all projects.",
                 "error_type": "GenericFailure",

--- a/tests/messaging_tests/test_messaging.py
+++ b/tests/messaging_tests/test_messaging.py
@@ -306,12 +306,9 @@ def test_combined_messages_removes_duplicates():
     assert m1.cell_indexes == ("A1", "A2", "A3")
 
 
-def test_combined_messages_enforce_uppercase_cell_columns():
-    assert Message("Tab A", "Section A", ("a1", "ab1", "Abc"), "grouped message", "SomeInputFailure").cell_indexes == (
-        "A1",
-        "AB1",
-        "ABC",
-    )
+def test_combined_messages_errors_on_lowercase_cell_indexes():
+    with pytest.raises(ValueError):
+        assert Message("Tab A", "Section A", ("a1", "ab1", "Abc"), "grouped message", "SomeInputFailure")
 
 
 def test_errors_if_initialising_with_none_cell_index():

--- a/tests/messaging_tests/test_messaging.py
+++ b/tests/messaging_tests/test_messaging.py
@@ -284,6 +284,11 @@ def test_failures_to_message_group(test_messenger):
         (("A1", "AA1", "Z1"), ("A1", "Z1", "AA1")),  # Sorts all 2-letter columns after all 1-letter columns
         (("A1", "AA1", "B"), ("A1", "B", "AA1")),  # Can handle column-only cell indexes
         (("B1", "B"), ("B", "B1")),  # Sorts column-only before column-with-row
+        (
+            ("B2", "A3 to B3", "A1"),
+            ("A1", "A3 to B3", "B2"),
+        ),  # Sorts column ranges based on the first part of the range
+        (("B2", "A3 or B3", "A4"), ("A3 or B3", "A4", "B2")),  # Can handle "or" as well as "to"
     ),
 )
 def test_message_cell_indexes_sort_as_expected(input_cell_indexes, expected_cell_indexes):

--- a/tests/messaging_tests/test_messaging.py
+++ b/tests/messaging_tests/test_messaging.py
@@ -35,64 +35,72 @@ def test_messenger():
 def test_group_validation_messages():
     data = [
         # A - combine these
-        Message("Project Admin", "Project Details", "A1", "You left cells blank.", "GenericFailure"),
-        Message("Project Admin", "Project Details", "A2", "You left cells blank.", "GenericFailure"),
+        Message("Project Admin", "Project Details", ("A1",), "You left cells blank.", "GenericFailure"),
+        Message("Project Admin", "Project Details", ("A2",), "You left cells blank.", "GenericFailure"),
         # B - combine these
-        Message("Project Admin", "Programme Details", "D4", "You left cells blank.", "GenericFailure"),
+        Message("Project Admin", "Programme Details", ("D4",), "You left cells blank.", "GenericFailure"),
         Message(
             "Project Admin",
             "Programme Details",
-            "D4, D5, D7",
+            ("D4", "D5", "D7"),
             "You left cells blank.",
             "GenericFailure",
         ),
         # C - do not combine these due to different sections
-        Message("Risk Register", "Project Risks - Project 1", "G24", "Select from the dropdown.", "WrongInputFailure"),
-        Message("Risk Register", "Project Risks - Project 2", "G43", "Select from the dropdown.", "WrongInputFailure"),
+        Message(
+            "Risk Register", "Project Risks - Project 1", ("G24",), "Select from the dropdown.", "WrongInputFailure"
+        ),
+        Message(
+            "Risk Register", "Project Risks - Project 2", ("G43",), "Select from the dropdown.", "WrongInputFailure"
+        ),
         # D - do not combine these due to different descriptions
-        Message("Outcomes", "Programme-level Outcomes", "E5", "You left cells blank.", "WrongInputFailure"),
-        Message("Outcomes", "Programme-level Outcomes", "E7", "Select from the dropdown.", "WrongInputFailure"),
+        Message("Outcomes", "Programme-level Outcomes", ("E5",), "You left cells blank.", "WrongInputFailure"),
+        Message("Outcomes", "Programme-level Outcomes", ("E7",), "Select from the dropdown.", "WrongInputFailure"),
     ]
 
     grouped = group_validation_messages(data)
 
     assert grouped == [
-        Message("Project Admin", "Project Details", "A1, A2", "You left cells blank.", "GenericFailure"),
+        Message("Project Admin", "Project Details", ("A1", "A2"), "You left cells blank.", "GenericFailure"),
         Message(
             "Project Admin",
             "Programme Details",
-            "D4, D4, D5, D7",
+            ("D4", "D4", "D5", "D7"),
             "You left cells blank.",
             "GenericFailure",
         ),
-        Message("Risk Register", "Project Risks - Project 1", "G24", "Select from the dropdown.", "WrongInputFailure"),
-        Message("Risk Register", "Project Risks - Project 2", "G43", "Select from the dropdown.", "WrongInputFailure"),
-        Message("Outcomes", "Programme-level Outcomes", "E5", "You left cells blank.", "WrongInputFailure"),
-        Message("Outcomes", "Programme-level Outcomes", "E7", "Select from the dropdown.", "WrongInputFailure"),
+        Message(
+            "Risk Register", "Project Risks - Project 1", ("G24",), "Select from the dropdown.", "WrongInputFailure"
+        ),
+        Message(
+            "Risk Register", "Project Risks - Project 2", ("G43",), "Select from the dropdown.", "WrongInputFailure"
+        ),
+        Message("Outcomes", "Programme-level Outcomes", ("E5",), "You left cells blank.", "WrongInputFailure"),
+        Message("Outcomes", "Programme-level Outcomes", ("E7",), "Select from the dropdown.", "WrongInputFailure"),
     ]
 
 
 def test_remove_errors_already_caught_by_null_failure():
     errors = [
-        Message("Tab 1", "Sheet 1", "C7", "The cell is blank but is required.", "NonNullableConstraintFailure"),
+        Message("Tab 1", "Sheet 1", ("C7",), "The cell is blank but is required.", "NonNullableConstraintFailure"),
         Message(
             "Tab 1",
             "Sheet 1",
-            "C8",
+            ("C8",),
             "The cell is blank but is required. Enter a value, even if it’s zero.",
             "NonNullableConstraintFailure",
         ),
-        Message("Tab 1", "Sheet 1", "C7", "Some other message", "NonUniqueCompositeKeyFailure"),
+        Message("Tab 1", "Sheet 1", ("C7",), "Some other message", "NonUniqueCompositeKeyFailure"),
     ]
 
     errors = remove_errors_already_caught_by_null_failure(errors)
 
     assert errors == [
-        Message("Tab 1", "Sheet 1", "C7", "The cell is blank but is required.", "NonNullableConstraintFailure"),
+        Message("Tab 1", "Sheet 1", ("C7",), "The cell is blank but is required.", "NonNullableConstraintFailure"),
         Message(
             "Tab 1",
             "Sheet 1",
-            "C8",
+            ("C8",),
             "The cell is blank but is required. Enter a value, even if it’s zero.",
             "NonNullableConstraintFailure",
         ),
@@ -101,14 +109,18 @@ def test_remove_errors_already_caught_by_null_failure():
 
 def test_remove_errors_already_caught_by_null_failure_complex():
     errors = [
-        Message("Tab 1", "Sheet 1", "C7, C8, C9", "The cell is blank but is required.", "NonNullableConstraintFailure"),
-        Message("Tab 1", "Sheet 1", "C7", "Some other message", "SomeOtherInputFailure"),
+        Message(
+            "Tab 1", "Sheet 1", ("C7", "C8", "C9"), "The cell is blank but is required.", "NonNullableConstraintFailure"
+        ),
+        Message("Tab 1", "Sheet 1", ("C7",), "Some other message", "SomeOtherInputFailure"),
     ]
 
     errors = remove_errors_already_caught_by_null_failure(errors)
 
     assert errors == [
-        Message("Tab 1", "Sheet 1", "C7, C8, C9", "The cell is blank but is required.", "NonNullableConstraintFailure")
+        Message(
+            "Tab 1", "Sheet 1", ("C7", "C8", "C9"), "The cell is blank but is required.", "NonNullableConstraintFailure"
+        )
     ]
 
 
@@ -117,14 +129,14 @@ def test_remove_errors_already_caught_by_null_failure_risks():
         Message(
             "Tab 1",
             "Programme / Project Risks",
-            "C12, C13, C17",
+            ("C12", "C13", "C17"),
             "The cell is blank but is required.",
             "GenericFailure",
         ),
-        Message("Tab 1", "Programme Risks", "C12", "Some other message", "GenericFailure"),
-        Message("Tab 1", "Project Risks - Project 1", "C13", "Some other message", "SomeOtherInputFailure"),
-        Message("Tab 1", "Project Risks - Project 2", "C17", "Some other message", "SomeOtherInputFailure"),
-        Message("Tab 1", "Project Risks - Project 2", "C19", "Some other message", "SomeOtherInputFailure"),
+        Message("Tab 1", "Programme Risks", ("C12",), "Some other message", "GenericFailure"),
+        Message("Tab 1", "Project Risks - Project 1", ("C13",), "Some other message", "SomeOtherInputFailure"),
+        Message("Tab 1", "Project Risks - Project 2", ("C17",), "Some other message", "SomeOtherInputFailure"),
+        Message("Tab 1", "Project Risks - Project 2", ("C19",), "Some other message", "SomeOtherInputFailure"),
     ]
 
     errors = remove_errors_already_caught_by_null_failure(errors)
@@ -133,11 +145,11 @@ def test_remove_errors_already_caught_by_null_failure_risks():
         Message(
             "Tab 1",
             "Programme / Project Risks",
-            "C12, C13, C17",
+            ("C12", "C13", "C17"),
             "The cell is blank but is required.",
             "GenericFailure",
         ),
-        Message("Tab 1", "Project Risks - Project 2", "C19", "Some other message", "SomeOtherInputFailure"),
+        Message("Tab 1", "Project Risks - Project 2", ("C19",), "Some other message", "SomeOtherInputFailure"),
     ]
 
 
@@ -149,107 +161,113 @@ def test_messaging_class_factory():
 
 def test_compare_Messages():
     # equal comparison
-    assert Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure") == Message(
-        "Tab A", "Section A", "A1", "Some message", "SomeInputFailure"
+    assert Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure") == Message(
+        "Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure"
     )
 
     # compare sheet
-    assert Message("Tab A", "Section B", "A2", "Some message", "SomeInputFailure") < Message(
-        "Tab B", "Section A", "A1", "Some message", "SomeInputFailure"
+    assert Message("Tab A", "Section B", ("A2",), "Some message", "SomeInputFailure") < Message(
+        "Tab B", "Section A", ("A1",), "Some message", "SomeInputFailure"
     )
 
     # compare section
-    assert Message("Tab A", "Section A", "A2", "Some message", "SomeInputFailure") < Message(
-        "Tab A", "Section B", "A1", "Some message", "SomeInputFailure"
+    assert Message("Tab A", "Section A", ("A2",), "Some message", "SomeInputFailure") < Message(
+        "Tab A", "Section B", ("A1",), "Some message", "SomeInputFailure"
     )
 
     # compare cell
-    assert Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure") < Message(
-        "Tab A", "Section A", "A2", "Some message", "SomeInputFailure"
+    assert Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure") < Message(
+        "Tab A", "Section A", ("A2",), "Some message", "SomeInputFailure"
     )
 
     # compare message
-    assert Message("Tab A", "Section A", "A1", "Some message about something", "SomeInputFailure") < Message(
-        "Tab A", "Section A", "A1", "Some message because something", "SomeInputFailure"
+    assert Message("Tab A", "Section A", ("A1",), "Some message about something", "SomeInputFailure") < Message(
+        "Tab A", "Section A", ("A1",), "Some message because something", "SomeInputFailure"
     )
 
 
 def test_sort_Messages():
     sorted_messages = sorted(
         [
-            Message("Tab D", "Section A", "A1", "Some message", "SomeInputFailure"),
-            Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure"),
-            Message("Tab C", "Section A", "A1", "A message", "SomeInputFailure"),
-            Message("Tab D", "Section A", "A1", "Some message", "SomeInputFailure"),
-            Message("Tab B", "Section A", "A2", "Some message", "SomeInputFailure"),
-            Message("Tab C", "Section A", "A1", "b message", "SomeInputFailure"),
-            Message("Tab B", "Section A", "A1", "Some message", "SomeInputFailure"),
-            Message("Tab A", "Section B", "A1", "Some message", "SomeInputFailure"),
+            Message("Tab D", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+            Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+            Message("Tab C", "Section A", ("A1",), "A message", "SomeInputFailure"),
+            Message("Tab D", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+            Message("Tab B", "Section A", ("A2",), "Some message", "SomeInputFailure"),
+            Message("Tab C", "Section A", ("A1",), "b message", "SomeInputFailure"),
+            Message("Tab B", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+            Message("Tab A", "Section B", ("A1",), "Some message", "SomeInputFailure"),
         ]
     )
 
     assert sorted_messages == [
-        Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab A", "Section B", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A2", "Some message", "SomeInputFailure"),
-        Message("Tab C", "Section A", "A1", "A message", "SomeInputFailure"),
-        Message("Tab C", "Section A", "A1", "b message", "SomeInputFailure"),
-        Message("Tab D", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab D", "Section A", "A1", "Some message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab A", "Section B", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A2",), "Some message", "SomeInputFailure"),
+        Message("Tab C", "Section A", ("A1",), "A message", "SomeInputFailure"),
+        Message("Tab C", "Section A", ("A1",), "b message", "SomeInputFailure"),
+        Message("Tab D", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab D", "Section A", ("A1",), "Some message", "SomeInputFailure"),
     ]
 
 
 def test_combine_Message():
-    message_1 = Message("Tab 1", "Project Risks - Project 1", "C13", "Some other message", "SomeInputFailure")
-    message_2 = Message("Tab 1", "Project Risks - Project 1", "C17", "Some other message", "SomeInputFailure")
+    message_1 = Message("Tab 1", "Project Risks - Project 1", ("C13",), "Some other message", "SomeInputFailure")
+    message_2 = Message("Tab 1", "Project Risks - Project 1", ("C17",), "Some other message", "SomeInputFailure")
 
     message_1.combine(message_2)
 
     assert message_1 == Message(
-        "Tab 1", "Project Risks - Project 1", "C13, C17", "Some other message", "SomeInputFailure"
+        "Tab 1", "Project Risks - Project 1", ("C13", "C17"), "Some other message", "SomeInputFailure"
     )
 
 
 def test_failures_to_message(test_messenger):
     messages_to_return = [
-        Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab C", "Section A", "A1", "Some message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab C", "Section A", ("A1",), "Some message", "SomeInputFailure"),
     ]
 
     error_messages = failures_to_messages([GenericFailure("_", "_", "_", "_")] * 3, test_messenger(messages_to_return))
 
     assert error_messages == [
-        Message("Tab A", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A1", "Some message", "SomeInputFailure"),
-        Message("Tab C", "Section A", "A1", "Some message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A1",), "Some message", "SomeInputFailure"),
+        Message("Tab C", "Section A", ("A1",), "Some message", "SomeInputFailure"),
     ]
 
 
 def test_failures_to_message_remove(test_messenger):
     messages_to_return = [
-        Message("Tab B", "Section A", "A1, A2", "The cell is blank but is required.", "NonNullableConstraintFailure"),
-        Message("Tab B", "Section A", "A1", "removed message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A2", "removed message", "SomeInputFailure"),
-        Message("Tab B", "Section A", "A3", "not removed message", "SomeInputFailure"),
+        Message(
+            "Tab B", "Section A", ("A1", "A2"), "The cell is blank but is required.", "NonNullableConstraintFailure"
+        ),
+        Message("Tab B", "Section A", ("A1",), "removed message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A2",), "removed message", "SomeInputFailure"),
+        Message("Tab B", "Section A", ("A3",), "not removed message", "SomeInputFailure"),
     ]
 
     error_messages = failures_to_messages([GenericFailure("_", "_", "_", "_")] * 4, test_messenger(messages_to_return))
 
     assert error_messages == [
-        Message("Tab B", "Section A", "A1, A2", "The cell is blank but is required.", "NonNullableConstraintFailure"),
-        Message("Tab B", "Section A", "A3", "not removed message", "SomeInputFailure"),
+        Message(
+            "Tab B", "Section A", ("A1", "A2"), "The cell is blank but is required.", "NonNullableConstraintFailure"
+        ),
+        Message("Tab B", "Section A", ("A3",), "not removed message", "SomeInputFailure"),
     ]
 
 
 def test_failures_to_message_group(test_messenger):
     messages_to_return = [
-        Message("Tab A", "Section A", "A321", "grouped message", "SomeInputFailure"),
-        Message("Tab A", "Section A", "A456", "grouped message", "SomeInputFailure"),
-        Message("Tab A", "Section A", "A123", "grouped message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A321",), "grouped message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A456",), "grouped message", "SomeInputFailure"),
+        Message("Tab A", "Section A", ("A123",), "grouped message", "SomeInputFailure"),
     ]
 
     error_messages = failures_to_messages([GenericFailure("_", "_", "_", "_")] * 3, test_messenger(messages_to_return))
 
-    assert error_messages == [Message("Tab A", "Section A", "A123, A321, A456", "grouped message", "SomeInputFailure")]
+    assert error_messages == [
+        Message("Tab A", "Section A", ("A123", "A321", "A456"), "grouped message", "SomeInputFailure")
+    ]

--- a/tests/messaging_tests/test_tf_messaging.py
+++ b/tests/messaging_tests/test_tf_messaging.py
@@ -339,7 +339,7 @@ def test_enum_failure_with_footfall_geography_indicator_wrong():
     assert test_messeger._invalid_enum_value_failure_message(failure) == Message(
         "Outcomes",
         "Footfall Indicator",
-        "C65",
+        ("C65",),
         "You’ve entered your own content, instead of selecting from the dropdown list "
         "provided. Select an option from the dropdown list.",
         "InvalidEnumValueFailure",
@@ -521,14 +521,14 @@ def test_failures_to_message_with_outcomes_column_amount():
     assert test_messger.to_message(failure1) == Message(
         "Outcomes",
         "Outcome Indicators (excluding footfall) / Footfall Indicator",
-        "E75",
+        ("E75",),
         "The cell is blank but is required. Enter a value, even if it’s zero.",
         "NonNullableConstraintFailure",
     )
     assert test_messger.to_message(failure2) == Message(
         "Outcomes",
         "Outcome Indicators (excluding footfall) and Footfall Indicator",
-        "I23",
+        ("I23",),
         "You entered text instead of a number. Remove any units of measurement and only use numbers, for example, 9.",
         "WrongTypeFailure",
     )
@@ -577,14 +577,14 @@ def test_failures_to_message_with_duplicated_errors():
         Message(
             "Outcomes",
             "Outcome Indicators (excluding footfall) / Footfall Indicator",
-            "B22, B23",
+            ("B22", "B23"),
             "The cell is blank but is required.",
             "NonNullableConstraintFailure",
         ),
         Message(
             "Outcomes",
             "Outcome Indicators (excluding footfall) / Footfall Indicator",
-            "E75, F75",
+            ("E75", "F75"),
             "The cell is blank but is required. Enter a value, even if it’s zero.",
             "NonNullableConstraintFailure",
         ),

--- a/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
+++ b/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
@@ -101,21 +101,21 @@ def test_cross_table_validation_fails(mock_df_dict, mock_control_mappings):
         Message(
             sheet="Progress",
             section="Project progress",
-            cell_index="B1",
+            cell_indexes=("B1",),
             description="Project name 'Invalid Project' is not allowed for this organisation.",
             error_type=None,
         ),
         Message(
             sheet="Outputs",
             section="Standard outputs",
-            cell_index="D1",
+            cell_indexes=("D1",),
             description="Unit of measurement 'Invalid Unit of Measurement' is not allowed for this output or outcome.",
             error_type=None,
         ),
         Message(
             sheet="Outcomes",
             section="Outcomes",
-            cell_index="C1",
+            cell_indexes=("C1",),
             description="Standard outcome value 'Invalid Outcome' is not allowed for intervention theme"
             " 'Enhancing subregional and regional connectivity'.",
             error_type=None,
@@ -123,14 +123,14 @@ def test_cross_table_validation_fails(mock_df_dict, mock_control_mappings):
         Message(
             sheet="Outputs",
             section="Bespoke outputs",
-            cell_index="C1",
+            cell_indexes=("C1",),
             description="Bespoke output value 'Invalid Bespoke Output' is not allowed for this organisation.",
             error_type=None,
         ),
         Message(
             sheet="Finances",
             section="Total underspend",
-            cell_index="B1",
+            cell_indexes=("B1",),
             description="If you have selected 'Yes' for 'Credible Plan', you must answer Q2, Q3 and Q4.",
             error_type=None,
         ),
@@ -150,7 +150,7 @@ def test__check_projects_fails(mock_df_dict, mock_control_mappings):
         Message(
             sheet="Progress",
             section="Project progress",
-            cell_index="B1",
+            cell_indexes=("B1",),
             description="Project name 'Invalid Project' is not allowed for this organisation.",
             error_type=None,
         )
@@ -170,7 +170,7 @@ def test__check_standard_outcomes_fails(mock_df_dict, mock_control_mappings):
         Message(
             sheet="Outcomes",
             section="Outcomes",
-            cell_index="C1",
+            cell_indexes=("C1",),
             description="Standard outcome value 'Invalid Outcome' is not allowed for intervention theme"
             " 'Enhancing subregional and regional connectivity'.",
             error_type=None,
@@ -191,7 +191,7 @@ def test__check_bespoke_outputs_fails(mock_df_dict, mock_control_mappings):
         Message(
             sheet="Outputs",
             section="Bespoke outputs",
-            cell_index="C1",
+            cell_indexes=("C1",),
             description="Bespoke output value 'Invalid Bespoke Output' is not allowed for this organisation.",
             error_type=None,
         )
@@ -211,7 +211,7 @@ def test__check_credible_plan_fields_fails(mock_df_dict):
         Message(
             sheet="Finances",
             section="Total underspend",
-            cell_index="B1",
+            cell_indexes=("B1",),
             description="If you have selected 'Yes' for 'Credible Plan', you must answer Q2, Q3 and Q4.",
             error_type=None,
         )
@@ -238,14 +238,14 @@ def test__check_intervention_themes_in_pfcs_fails(mock_df_dict, mock_control_map
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index="E1",
+            cell_indexes=("E1",),
             description="Intervention theme 'Invalid Intervention Theme' is not allowed.",
             error_type=None,
         ),
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index="I1",
+            cell_indexes=("I1",),
             description="Intervention theme 'Another Invalid Intervention Theme' is not allowed.",
             error_type=None,
         ),
@@ -268,7 +268,7 @@ def test_check_actual_forecast_reporting_period(mock_df_dict):
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index="P1",
+            cell_indexes=("P1",),
             description="Reporting period must not be in the future if 'Actual, forecast or cancelled' is 'Actual'.",
             error_type=None,
         )
@@ -283,7 +283,7 @@ def test_check_actual_forecast_reporting_period(mock_df_dict):
         Message(
             sheet="Finances",
             section="Project finance changes",
-            cell_index="P1",
+            cell_indexes=("P1",),
             description="Reporting period must be in the future if 'Actual, forecast or cancelled' is 'Forecast'.",
             error_type=None,
         ),


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-773

### Change description
_A brief description of the pull request_

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* Edit a valid spreadsheet and introduce multiple instances of a specific type of error across the same rows and/or columns.
* On `main` branch, upload the spreadsheet and confirm that the cell references as unordered.
* Checkout this branch, re-upload and confirm that the cell references are now ordered.


### Screenshots of UI changes (if applicable)
#### Before
<img width="1067" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/2920760/9703ab86-af84-4dbd-8b0b-a76d88d6a408">


#### After
<img width="1093" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/2920760/8b0ef636-1e9c-4c76-bf62-4a91e6fe2b09">
