### PR TITLE
SMD-776: Add some quick metrics via sentry

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from werkzeug.serving import WSGIRequestHandler
 from config import Config
 from core.cli import create_cli
 from core.db import db, migrate
+from core.metrics import metrics_reporter
 
 WORKING_DIR = Path(__file__).parent
 
@@ -53,6 +54,8 @@ def create_app(config_class=Config) -> Flask:
 
     if flask_app.config["ENABLE_PROFILER"]:
         flask_app.wsgi_app = ProfilerMiddleware(flask_app.wsgi_app, profile_dir="profiler")
+
+    metrics_reporter.init_app(flask_app)
 
     return flask_app
 

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,142 @@
+import enum
+import functools
+from collections import Counter
+
+import sentry_sdk.metrics
+from flask import g
+from werkzeug.datastructures import FileStorage
+
+
+class FundingMetrics(enum.StrEnum):
+    """Tracks all the metrics that we track/emit from this app.
+
+    Every metric defined here should have a corresponding method on the MetricsReporter class below so that
+    we keep a central view of all metrics we emit and what tags/etc they take.
+    """
+
+    SUBMISSION = "submission"
+    SUBMISSION_INGEST_RESULT = "submission-ingest-result"
+    SUBMISSION_VALIDATION_ERRORS = "submission-validation-errors"
+    SUBMISSION_VALIDATION_ERRORS_TOTAL = "submission-validation-errors-total"
+
+
+class MetricsReporter:
+    def __init__(self):
+        self.logger = None
+
+    def init_app(self, app):
+        self.logger = app.logger
+
+    def track_report_submission(self, fund: str, reporting_round: int, organisation_name: str):
+        sentry_sdk.metrics.incr(
+            FundingMetrics.SUBMISSION,
+            1,
+            tags={"fund": fund, "reporting_round": reporting_round, "organisation": organisation_name},
+        )
+
+    def track_report_submission_ingest_result(
+        self, fund: str, reporting_round: int, organisation_name: str, result: str
+    ):
+        if result not in {"success", "invalid", "error"}:
+            self.logger.warning(
+                "Rejecting metric `%(metric_name)s` with invalid result: %(result)s",
+                dict(metric_name=FundingMetrics.SUBMISSION_INGEST_RESULT, result=result),
+            )
+            return
+
+        sentry_sdk.metrics.incr(
+            FundingMetrics.SUBMISSION_INGEST_RESULT,
+            1,
+            tags={
+                "fund": fund,
+                "reporting_round": reporting_round,
+                "organisation": organisation_name,
+                "result": result,
+            },
+        )
+
+    def track_report_submission_validation_errors_total(
+        self, fund: str, reporting_round: int, organisation_name: str, num_validation_errors: int
+    ):
+        sentry_sdk.metrics.distribution(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS_TOTAL,
+            num_validation_errors,
+            tags={"fund": fund, "reporting_round": reporting_round, "organisation": organisation_name},
+        )
+
+    def track_report_submission_validation_errors(
+        self, fund: str, reporting_round: int, organisation_name: str, validation_error_counts: Counter
+    ):
+        for validation_error, count in validation_error_counts.items():
+            sentry_sdk.metrics.distribution(
+                FundingMetrics.SUBMISSION_VALIDATION_ERRORS,
+                count,
+                tags={
+                    "fund": fund,
+                    "reporting_round": reporting_round,
+                    "organisation": organisation_name,
+                    "validation_error": validation_error,
+                },
+            )
+
+
+metrics_reporter = MetricsReporter()
+
+
+def capture_ingest_metrics(view_func):
+    """Decorator for the `core.controllers.ingest` function below to track the outcome of a spreadsheet ingest.
+
+    Reports on whether the submission succeeded, raised validation errors, or had some other kind of (probably internal)
+    server error. Tracks the number of validation errors raised, if any, and splits to track each kind of validation
+    error too.
+
+    There's a risk of this being too many dimensions for Sentry when we're mega-multi-fund and have lots of reporting
+    rounds, but that'll be a nice problem to have. If it happens we'll have to deal with it.
+    See also: https://docs.sentry.io/product/metrics/#cardinality
+    """
+
+    @functools.wraps(view_func)
+    def decorator(body: dict, excel_file: FileStorage):
+        # `ingest` function should set correct values of these three dimensions as part of processing
+        g.fund_name = "unknown"
+        g.reporting_round = -1
+        g.organisation_name = "unknown"
+
+        retval: tuple[dict, int] = view_func(body=body, excel_file=excel_file)
+
+        metrics_reporter.track_report_submission(
+            fund=g.fund_name, reporting_round=g.reporting_round, organisation_name=g.organisation_name
+        )
+        metrics_reporter.track_report_submission_ingest_result(
+            fund=g.fund_name,
+            reporting_round=g.reporting_round,
+            organisation_name=g.organisation_name,
+            result="success" if retval[1] == 200 else "invalid" if retval[1] == 400 else "error",
+        )
+        validation_errors = retval[0].get("validation_errors", [])
+        error_counts = Counter(
+            [
+                error
+                for error, cells in map(
+                    lambda error_dict: (error_dict["description"], error_dict["cell_index"].split(", ")),
+                    validation_errors,
+                )
+                for _ in cells
+            ]
+        )
+        metrics_reporter.track_report_submission_validation_errors_total(
+            fund=g.fund_name,
+            reporting_round=g.reporting_round,
+            organisation_name=g.organisation_name,
+            num_validation_errors=sum(error_counts.values()),
+        )
+        metrics_reporter.track_report_submission_validation_errors(
+            fund=g.fund_name,
+            reporting_round=g.reporting_round,
+            organisation_name=g.organisation_name,
+            validation_error_counts=error_counts,
+        )
+
+        return retval
+
+    return decorator

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -178,6 +178,7 @@ markupsafe==2.1.2
     #   -r requirements.txt
     #   jinja2
     #   mako
+    #   sentry-sdk
     #   werkzeug
 marshmallow==3.20.1
     # via
@@ -340,7 +341,7 @@ semver==2.13.0
     # via
     #   -r requirements.txt
     #   prance
-sentry-sdk[flask]==1.20.0
+sentry-sdk[flask]==1.45.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils

--- a/requirements.in
+++ b/requirements.in
@@ -35,3 +35,9 @@ marshmallow-sqlalchemy
 #   tables
 #-----------------------------------
 pandera==0.17.*
+
+
+#-----------------------------------
+#   monitoring and observability
+#-----------------------------------
+sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,6 +108,7 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   mako
+    #   sentry-sdk
     #   werkzeug
 marshmallow==3.20.1
     # via marshmallow-sqlalchemy
@@ -201,8 +202,10 @@ s3transfer==0.6.0
     # via boto3
 semver==2.13.0
     # via prance
-sentry-sdk[flask]==1.20.0
-    # via funding-service-design-utils
+sentry-sdk[flask]==1.45.0
+    # via
+    #   -r requirements.in
+    #   funding-service-design-utils
 six==1.16.0
     # via
     #   prance

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import BinaryIO
+from unittest import mock
 
 import pytest
 
@@ -57,3 +58,16 @@ def towns_fund_round_4_file_success() -> BinaryIO:
     """An example spreadsheet for reporting round 4 of Towns Fund that should ingest without validation errors."""
     with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Success.xlsx", "rb") as file:
         yield file
+
+
+@pytest.fixture(scope="function")
+def towns_fund_round_4_round_agnostic_failures() -> BinaryIO:
+    """An example spreadsheet for reporting round 4 of Towns Fund that should raise TF round agnostic failures"""
+    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Round_Agnostic_Failures.xlsx", "rb") as file:
+        yield file
+
+
+@pytest.fixture(scope="function")
+def mock_sentry_metrics():
+    with mock.patch("core.metrics.sentry_sdk.metrics") as mock_sentry_metrics:
+        yield mock_sentry_metrics

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -15,6 +15,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
     towns_fund_round_4_file_success,
     pathfinders_round_1_file_success,
     test_buckets,
+    mock_sentry_metrics,
 ):
     """Tests that the ingestion of multiple rounds and funds will be loaded into the database
     and serialised out in an Excel file correctly.

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -72,13 +72,6 @@ def towns_fund_round_4_file_hs_funding_failure() -> BinaryIO:
 
 
 @pytest.fixture(scope="function")
-def towns_fund_round_4_round_agnostic_failures() -> BinaryIO:
-    """An example spreadsheet for reporting round 4 of Towns Fund that should raise TF round agnostic failures"""
-    with open(Path(__file__).parent / "mock_tf_returns" / "TF_Round_4_Round_Agnostic_Failures.xlsx", "rb") as file:
-        yield file
-
-
-@pytest.fixture(scope="function")
 def wrong_format_test_file() -> BinaryIO:
     """An invalid text test file."""
     with open(Path(__file__).parent / "mock_tf_returns" / "wrong_format_test_file.txt", "rb") as file:

--- a/tests/integration_tests/test_ingest_metrics.py
+++ b/tests/integration_tests/test_ingest_metrics.py
@@ -1,0 +1,170 @@
+import json
+from unittest import mock
+
+from core.db import db
+from core.metrics import FundingMetrics
+
+
+def test_sentry_metrics_emitted_from_ingest_endpoint(
+    test_client_reset,
+    towns_fund_round_3_file_success,
+    towns_fund_round_4_round_agnostic_failures,
+    pathfinders_round_1_file_success,
+    test_buckets,
+    mock_sentry_metrics,
+):
+    """Runs some ingest cycles across different funds and asserts that the expected sentry metrics have been
+    generated for them, so that we can get reporting on successful/failed uploads and the kind of failures that were
+    hit.
+    """
+
+    endpoint = "/ingest"
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": towns_fund_round_3_file_success,
+            "fund_name": "Towns Fund",
+            "reporting_round": 3,
+            "do_load": True,
+        },
+    )
+
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": towns_fund_round_4_round_agnostic_failures,
+            "fund_name": "Towns Fund",
+            "reporting_round": 4,
+            "auth": json.dumps(
+                {
+                    "Place Names": ["Blackfriars - Northern City Centre"],
+                    "Fund Types": ["Town_Deal", "Future_High_Street_Fund"],
+                }
+            ),
+            "do_load": False,
+        },
+    )
+
+    test_client_reset.post(
+        endpoint,
+        data={
+            "excel_file": pathfinders_round_1_file_success,
+            "fund_name": "Pathfinders",
+            "reporting_round": 1,
+            "auth": json.dumps(
+                {
+                    "Programme": [
+                        "Bolton Council",
+                    ],
+                    "Fund Types": [
+                        "Pathfinders",
+                    ],
+                }
+            ),
+            "do_load": True,
+        },
+    )
+
+    db.session.commit()
+
+    # Validate sentry metrics have been collected
+    assert mock_sentry_metrics.incr.call_args_list == [
+        mock.call(
+            FundingMetrics.SUBMISSION,
+            1,
+            tags={"fund": "Towns Fund", "reporting_round": 3, "organisation": "USS Enterprise"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_INGEST_RESULT,
+            1,
+            tags={"fund": "Towns Fund", "reporting_round": 3, "organisation": "USS Enterprise", "result": "success"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION,
+            1,
+            tags={"fund": "Towns Fund", "reporting_round": 4, "organisation": "Worcester City Council"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_INGEST_RESULT,
+            1,
+            tags={
+                "fund": "Towns Fund",
+                "reporting_round": 4,
+                "organisation": "Worcester City Council",
+                "result": "invalid",
+            },
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION,
+            1,
+            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_INGEST_RESULT,
+            1,
+            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council", "result": "success"},
+        ),
+    ]
+    assert mock_sentry_metrics.distribution.call_args_list == [
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS_TOTAL,
+            0,
+            tags={"fund": "Towns Fund", "reporting_round": 3, "organisation": "USS Enterprise"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS_TOTAL,
+            4,
+            tags={"fund": "Towns Fund", "reporting_round": 4, "organisation": "Worcester City Council"},
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS,
+            1,
+            tags={
+                "fund": "Towns Fund",
+                "reporting_round": 4,
+                "organisation": "Worcester City Council",
+                "validation_error": (
+                    "You’ve entered your own content, instead of selecting from the dropdown list provided. Select "
+                    + "an option from the dropdown list."
+                ),
+            },
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS,
+            1,
+            tags={
+                "fund": "Towns Fund",
+                "reporting_round": 4,
+                "organisation": "Worcester City Council",
+                "validation_error": "The cell is blank but is required. Enter a value, even if it’s zero.",
+            },
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS,
+            1,
+            tags={
+                "fund": "Towns Fund",
+                "reporting_round": 4,
+                "organisation": "Worcester City Council",
+                "validation_error": (
+                    "You entered text instead of a number. Remove any units of measurement and only use numbers, "
+                    + "for example, 9."
+                ),
+            },
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS,
+            1,
+            tags={
+                "fund": "Towns Fund",
+                "reporting_round": 4,
+                "organisation": "Worcester City Council",
+                "validation_error": "You entered duplicate data. Remove or replace the duplicate data.",
+            },
+        ),
+        mock.call(
+            FundingMetrics.SUBMISSION_VALIDATION_ERRORS_TOTAL,
+            0,
+            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council"},
+        ),
+    ]


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-776


### Change description
Track some metrics around spreadsheet ingest success/failures so that we can get some indication as to the amount of pleasure/pain our users are having submitting funding progress reports. We'll be able to break down stats by organisation (LA), fund, reporting round, and validation error.

Unit tests pending, putting up as draft for early review.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* check the branch out locally
* configure data-store with its sentry DSN so that it can report metrics
* Upload some spreadsheets for a fund - try a mix of successes and different failures
* Look in Sentry under the 'Metrics' tab and choose some metrics+dimensions to graph.


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/2920760/2aa28002-59cf-41aa-8f11-23ffe27fa943)
