### PR TITLE
Smd 452/fix footfall indicators section

### DIFF
--- a/core/messaging/__init__.py
+++ b/core/messaging/__init__.py
@@ -22,6 +22,11 @@ class Message:
         self.description = description
         self.error_type = error_type
 
+    def __repr__(self):
+        return (
+            f"<Message({self.sheet=}, {self.section=}, {self.cell_indexes=}, {self.description=}, {self.error_type=})>"
+        )
+
     def __key(self):
         return self.sheet, self.section, self.cell_indexes, self.description, self.error_type
 

--- a/core/messaging/tf_messaging.py
+++ b/core/messaging/tf_messaging.py
@@ -265,7 +265,7 @@ class TFMessenger(MessengerBase):
             project_number = get_project_number_by_position(validation_failure.row_index, validation_failure.table)
             section = f"Project Outputs - Project {project_number}"
         elif sheet == "Outcomes":
-            section = "Outcome Indicators (excluding footfall)"
+            section = self._get_section_for_outcomes_by_row_index(validation_failure.row_index)
         elif sheet == "Risk Register":
             project_id = validation_failure.row[1]
             section = self._risk_register_section(project_id, validation_failure.row_index, validation_failure.table)
@@ -415,6 +415,9 @@ class TFMessenger(MessengerBase):
         column_letter = self.TABLE_AND_COLUMN_TO_ORIGINAL_COLUMN_LETTER[table][column]
         return column_letter.format(i=row_index or "")
 
+    def _get_section_for_outcomes_by_row_index(self, index):
+        return "Outcomes Indicators (excluding footfall)" if index < 60 else "Footfall Indicator"
+
     def _get_cell_indexes_for_outcomes(self, failed_row: pd.Series) -> str:
         """
         Constructs cell indexes for outcomes based on the provided failed row.
@@ -436,7 +439,7 @@ class TFMessenger(MessengerBase):
         index = failed_row.name
 
         # footfall outcomes starts from row 60
-        if index >= 60:
+        if self._get_section_for_outcomes_by_row_index(index) == "Footfall Indicator":
             # row for 'Amount' column is end number of start year of financial year * 5 + 'Footfall Indicator' index
             row_index_gap = int(str(financial_year)[-1]) * 5
             index = int(index) + row_index_gap

--- a/tests/messaging_tests/test_tf_messaging.py
+++ b/tests/messaging_tests/test_tf_messaging.py
@@ -594,20 +594,35 @@ def test_failures_to_message_with_duplicated_errors():
 def test_tf_messaging_to_message():
     test_messger = TFMessenger()
 
-    test_messger.to_message(
+    assert test_messger.to_message(
         InvalidEnumValueFailure(
             table="Project Progress",
             column="Delivery (RAG)",
             row_index=2,
             row_values=("Value 1", "Value 2", "Value 3", "Value 4"),
         )
+    ) == Message(
+        sheet="Programme Progress",
+        section="Projects Progress Summary",
+        cell_indexes=("J2",),
+        description=(
+            "You’ve entered your own content, instead of selecting from the dropdown list provided. "
+            "Select an option from the dropdown list."
+        ),
+        error_type="InvalidEnumValueFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         NonNullableConstraintFailure(
             table="Project Progress", column="Current Project Delivery Stage", row_index=3, failed_row=None
         )
+    ) == Message(
+        sheet="Programme Progress",
+        section="Projects Progress Summary",
+        cell_indexes=("F3",),
+        description="The cell is blank but is required.",
+        error_type="NonNullableConstraintFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         WrongTypeFailure(
             table="Project Progress",
             column="Start Date",
@@ -616,16 +631,33 @@ def test_tf_messaging_to_message():
             row_index=22,
             failed_row=None,
         )
+    ) == Message(
+        sheet="Programme Progress",
+        section="Projects Progress Summary",
+        cell_indexes=("D22",),
+        description=(
+            "You entered text instead of a date. Check the cell is formatted as a date, for example, Dec-22 or Jun-23"
+        ),
+        error_type="WrongTypeFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         InvalidEnumValueFailure(
             table="Outcome_Data",
             column="GeographyIndicator",
             row_index=60,
             row_values=("Value 1", "Value 2", "Value 3", "Value 4", "Year-on-year % change in monthly footfall"),
         )
+    ) == Message(
+        sheet="Outcomes",
+        section="Footfall Indicator",
+        cell_indexes=("C65",),
+        description=(
+            "You’ve entered your own content, instead of selecting from the dropdown list provided. "
+            "Select an option from the dropdown list."
+        ),
+        error_type="InvalidEnumValueFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         NonUniqueCompositeKeyFailure(
             table="Output_Data",
             column=["Project ID", "Output", "Start_Date", "End_Date", "Unit of Measurement", "Actual/Forecast"],
@@ -639,17 +671,35 @@ def test_tf_messaging_to_message():
             ],
             row_index=82,
         )
+    ) == Message(
+        sheet="Project Outputs",
+        section="Project Outputs - Project 2",
+        cell_indexes=("C82", "D82"),
+        description="You entered duplicate data. Remove or replace the duplicate data.",
+        error_type="NonUniqueCompositeKeyFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         UnauthorisedSubmissionFailure(value_descriptor="Fund Type", entered_value="TD", expected_values=("HS",))
+    ) == Message(
+        sheet=None,
+        section=None,
+        cell_indexes=None,
+        description="You’re not authorised to submit for TD. You can only submit for HS.",
+        error_type="UnauthorisedSubmissionFailure",
     )
-    test_messger.to_message(
+    assert test_messger.to_message(
         GenericFailure(
             table="Output_Data",
             section="A Section",
             cell_index="C1",
             message="A message",
         )
+    ) == Message(
+        sheet="Project Outputs",
+        section="A Section",
+        cell_indexes=("C1",),
+        description="A message",
+        error_type="GenericFailure",
     )
 
 

--- a/tests/messaging_tests/test_tf_messaging.py
+++ b/tests/messaging_tests/test_tf_messaging.py
@@ -672,7 +672,7 @@ def test_tf_messaging_to_message():
         )
     ) == Message(
         sheet="Outcomes",
-        section="Outcome Indicators (excluding footfall)",
+        section="Footfall Indicator",
         cell_indexes=("B92", "E92"),
         description="You entered duplicate data. Remove or replace the duplicate data.",
         error_type="NonUniqueCompositeKeyFailure",

--- a/tests/messaging_tests/test_tf_messaging.py
+++ b/tests/messaging_tests/test_tf_messaging.py
@@ -659,6 +659,26 @@ def test_tf_messaging_to_message():
     )
     assert test_messger.to_message(
         NonUniqueCompositeKeyFailure(
+            table="Outcome_Data",
+            column=["Project ID", "Outcome", "Start_Date", "End_Date", "GeographyIndicator"],
+            row=[
+                "HS-WRC-01",
+                "Year on Year monthly % change in footfall",
+                "2020-04-01 00:00:00",
+                "2020-09-30 00:00:00",
+                "Travel corridor",
+            ],
+            row_index=92,
+        )
+    ) == Message(
+        sheet="Outcomes",
+        section="Outcome Indicators (excluding footfall)",
+        cell_indexes=("B92", "E92"),
+        description="You entered duplicate data. Remove or replace the duplicate data.",
+        error_type="NonUniqueCompositeKeyFailure",
+    )
+    assert test_messger.to_message(
+        NonUniqueCompositeKeyFailure(
             table="Output_Data",
             column=["Project ID", "Output", "Start_Date", "End_Date", "Unit of Measurement", "Actual/Forecast"],
             row=[


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-452?atlOrigin=eyJpIjoiNDBjYzI5Yjg0OTU3NDg5YzhjNjhiMWMxNTMyNzBhNmMiLCJwIjoiaiJ9

### Change description
Fix the section reference when duplicate data has been entered in the footfall indicators section of the outcomes sheet.

This ticket also flagged that the cell references themselves were not super useful, however fixing that is a much more involved issue which I do not think is worth doing at the moment, given the fairly low (anticipated) impact of this bug. 

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)

## Before
<img width="1016" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/2920760/f65a1d57-913b-46ca-8b76-f51015acd316">


## After
<img width="1009" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/2920760/2f967dc7-cd6e-4d66-b1f7-2c3e8e97efac">
