### PR TITLE
Stop logging with eagerly-formatted strings / move to `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,6 @@ repos:
   hooks:
     # Run the linter.
     - id: ruff
+      args: [ --fix ]
     # Run the formatter.
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,17 @@ ci:
   autofix_prs: false
 
 repos:
--   repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-    - id: black
-      language_version: python3.11
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-    - id: flake8
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-ast
--   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: [ "--profile", "black" ]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-ast
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.4.1
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format

--- a/app.py
+++ b/app.py
@@ -44,7 +44,9 @@ def create_app(config_class=Config) -> Flask:
         compare_type=True,
         compare_server_default=True,
     )
-    flask_app.logger.info(f"Database: {str(flask_app.config.get('SQLALCHEMY_DATABASE_URI')).split('://')[0]}")
+    flask_app.logger.info(
+        "Database: {db_name}", extra=dict(db_name=str(flask_app.config.get("SQLALCHEMY_DATABASE_URI")).split("://")[0])
+    )
 
     create_cli(flask_app)
 

--- a/core/controllers/load_functions.py
+++ b/core/controllers/load_functions.py
@@ -20,7 +20,7 @@ def load_programme_ref(
     transformed_data: dict[str, pd.DataFrame],
     mapping: DataMapping,
     programme_exists_previous_round: Programme,
-    **kwargs
+    **kwargs,
 ):
     """Loads data into the 'Programme_Ref' table.
 

--- a/core/db/utils.py
+++ b/core/db/utils.py
@@ -33,10 +33,14 @@ def transaction_retry_wrapper(max_retries: int, sleep_duration: float, error_typ
                     if retry < max_retries:
                         time.sleep(sleep_duration)
                         current_app.logger.warning(
-                            f"{func.__name__} failed with {transaction_error}. " f"Retry count: {retry}."
+                            "{func_name} failed with {transaction_error}. Retry count: {retry}.",
+                            extra=dict(func_name=func.__name__, transaction_error=transaction_error, retry=retry),
                         )
                     else:
-                        current_app.logger.error(f"Number of max retries exceeded for function '{func.__name__}'")
+                        current_app.logger.error(
+                            "Number of max retries exceeded for function '{func_name}'",
+                            extra=dict(func_name=func.__name__),
+                        )
                         raise transaction_error
 
         return wrapper

--- a/core/messaging/tf_messaging.py
+++ b/core/messaging/tf_messaging.py
@@ -299,8 +299,9 @@ class TFMessenger(MessengerBase):
         )
 
         if sheet == "Outcomes":
-            _, section = "Financial Year 2022/21 - Financial Year 2029/30", (
-                "Outcome Indicators (excluding " "footfall) and Footfall Indicator"
+            _, section = (
+                "Financial Year 2022/21 - Financial Year 2029/30",
+                ("Outcome Indicators (excluding " "footfall) and Footfall Indicator"),
             )
             cell_index = self._get_cell_indexes_for_outcomes(validation_failure.failed_row)
 

--- a/core/transformation/pathfinders/round_1/transform.py
+++ b/core/transformation/pathfinders/round_1/transform.py
@@ -97,7 +97,7 @@ def _place_details(
     answers = [df_dict[q].iloc[0, 0] for q in questions]
     answers = [(answer.isoformat() if isinstance(answer, pd.Timestamp) else answer) for answer in answers]
     # Filter out nan values from answers and corresponding questions
-    questions, answers = zip(*[(q, a) for q, a in zip(questions, answers) if pd.notna(a)])
+    questions, answers = zip(*[(q, a) for q, a in zip(questions, answers, strict=False) if pd.notna(a)], strict=False)
     return create_dataframe(
         {
             "Programme ID": [programme_id] * len(questions),

--- a/core/transformation/towns_fund/round_3.py
+++ b/core/transformation/towns_fund/round_3.py
@@ -142,7 +142,7 @@ def extract_project_lookup(df_lookup: pd.DataFrame, df_place: pd.DataFrame) -> d
 
     # filter on current place / programme and convert to dict
     df_lookup = df_lookup.loc[df_lookup["Town"].str.lower().str.strip() == str(place_name).lower().strip()]
-    project_lookup = dict(zip(df_lookup["Project Name"], df_lookup["Unique Project Identifier"]))
+    project_lookup = dict(zip(df_lookup["Project Name"], df_lookup["Unique Project Identifier"], strict=False))
 
     return project_lookup
 
@@ -273,7 +273,7 @@ def extract_project(df_project: pd.DataFrame, project_lookup: dict, programme_id
     # replace NaN with ""
     header_row_2 = [field if field is not np.nan else "" for field in list(df_project.iloc[1])]
     # zip together headers (deals with merged cells issues)
-    header_row_combined = ["__".join([x, y]).rstrip("_") for x, y in zip(header_row_1, header_row_2)]
+    header_row_combined = ["__".join([x, y]).rstrip("_") for x, y in zip(header_row_1, header_row_2, strict=False)]
     # apply header to df with top rows stripped
     df_project = pd.DataFrame(df_project.values[2:], columns=header_row_combined)
 
@@ -403,7 +403,7 @@ def extract_programme_management(df_data: pd.DataFrame, programme_id: str) -> pd
     header_row_2 = [field if field is not np.nan else "" for field in list(df_data.iloc[23, 6:24])]
     header_row_3 = [field if field is not np.nan else "" for field in list(df_data.iloc[24, 6:24])]
     header_row_combined = [
-        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3)
+        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3, strict=False)
     ]
     header = header_prefix + header_row_combined
     transformed_df = df_data.iloc[25:27, [2] + list(range(6, 24))]
@@ -533,7 +533,7 @@ def extract_funding_data(df_input: pd.DataFrame, project_lookup: dict, reporting
     header_row_2 = [field if field is not np.nan else "" for field in list(df_input.iloc[3, 3:])]
     header_row_3 = [field if field is not np.nan else "" for field in list(df_input.iloc[4, 3:])]
     header_row_combined = [
-        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3)
+        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3, strict=False)
     ]
     header = header_prefix + header_row_combined
     header.append("Project Name")
@@ -782,7 +782,7 @@ def extract_outputs(df_input: pd.DataFrame, project_lookup: dict) -> pd.DataFram
     header_row_2 = [field if field is not np.nan else "" for field in list(df_input.iloc[5])]
     header_row_3 = [field if field is not np.nan else "" for field in list(df_input.iloc[6])]
     header_row_combined = [
-        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3)
+        "__".join([x, y, z]).rstrip("_") for x, y, z in zip(header_row_1, header_row_2, header_row_3, strict=False)
     ]
     header_row_combined.append("Project Name")
     outputs_df = pd.DataFrame()
@@ -912,7 +912,7 @@ def extract_outcomes(df_input: pd.DataFrame, project_lookup: dict, programme_id:
 
     header_row_1 = list(df_input.iloc[0])
     header_row_2 = [field if field is not np.nan else "" for field in list(df_input.iloc[1])]
-    header_row_combined = ["__".join([x, y]).rstrip("_") for x, y in zip(header_row_1, header_row_2)]
+    header_row_combined = ["__".join([x, y]).rstrip("_") for x, y in zip(header_row_1, header_row_2, strict=False)]
 
     outcomes_df = pd.DataFrame(df_input.values[6:26], columns=header_row_combined, index=df_input.index[6:26])
     custom_outcomes_df = pd.DataFrame(df_input.values[27:37], columns=header_row_combined, index=df_input.index[27:37])
@@ -1000,13 +1000,14 @@ def extract_footfall_outcomes(df_input: pd.DataFrame, project_lookup: dict, prog
     # within each footfall section data/header is spread over 6 lines, each 5 cells apart
     for year_idx in range(0, 30, 5):
         header_monthly_row_1 = [
-            x := y if y is not np.nan else x for y in df_input.iloc[(year_idx + 2), 2:-1]  # noqa: F841,F821
+            x := y if y is not np.nan else x  # noqa: F841, F821
+            for y in df_input.iloc[(year_idx + 2), 2:-1]  # noqa: F841,F821
         ]
         header_monthly_row_2 = [str(field) for field in df_input.iloc[(year_idx + 4), 2:-1]]
         header_monthly_row_3 = list(df_input.iloc[year_idx + 5, 2:-1])
         header_monthly_combined = [
             "__".join([x, y, z]).rstrip("_")
-            for x, y, z in zip(header_monthly_row_1, header_monthly_row_2, header_monthly_row_3)
+            for x, y, z in zip(header_monthly_row_1, header_monthly_row_2, header_monthly_row_3, strict=False)
         ]
         header.extend(header_monthly_combined)
 

--- a/core/validation/failures/__init__.py
+++ b/core/validation/failures/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC
 
 
-class ValidationFailureBase(ABC):
+class ValidationFailureBase(ABC):  # noqa: B024
     pass

--- a/core/validation/schema_validation/casting.py
+++ b/core/validation/schema_validation/casting.py
@@ -21,7 +21,7 @@ def cast_to_schema(data: dict[str, pd.DataFrame], schema: dict) -> None:
 
         column_to_type = schema[table]["columns"]
 
-        for pos, (index, row) in enumerate(table_data.iterrows()):
+        for pos, (_, row) in enumerate(table_data.iterrows()):
             for column, value in row.items():
                 # Forcible conversion of values to target_type == "list" occurs in extract_postcodes()
                 if isinstance(value, (datetime, pd.Timestamp, list)) or pd.isna(value):

--- a/core/validation/schema_validation/schema.py
+++ b/core/validation/schema_validation/schema.py
@@ -17,7 +17,7 @@ def parse_schema(schema: dict) -> Optional[dict]:
     try:
         for table, table_schema in schema.items():
             # Check all defined types are part of the schema
-            for column, dtype in table_schema["columns"].items():
+            for _, dtype in table_schema["columns"].items():
                 validation_schema_types = (str, float, int, list, bool, datetime)
                 assert dtype in validation_schema_types, f"Variable {dtype} must be str, float, int, or datetime"
 
@@ -69,7 +69,7 @@ def parse_schema(schema: dict) -> Optional[dict]:
                 assert column in columns, f"{column} - not in columns - {columns}"
 
     except (KeyError, AttributeError, AssertionError) as schema_err:
-        logger.error(schema_err, exc_info=True)
+        logger.exception("Failed to parse schema: {schema_err}", extra=dict(schema_err=str(schema_err)))
         raise SchemaError("Schema is invalid and cannot be parsed." + str(schema_err)) from schema_err
 
     return schema

--- a/core/validation/specific_validation/pathfinders/round_1.py
+++ b/core/validation/specific_validation/pathfinders/round_1.py
@@ -489,7 +489,7 @@ def _check_intervention_themes_in_pfcs(
                 cell_index=f"{col_letter}{row + 1}",  # +1 because DataFrames are 0-indexed and Excel is not
                 description=PFErrors.INTERVENTION_THEME_NOT_ALLOWED.format(intervention_theme=theme),
             )
-            for row, theme in zip(breaching_indices, breaching_themes)
+            for row, theme in zip(breaching_indices, breaching_themes, strict=False)
         )
     return error_messages
 

--- a/core/validation/specific_validation/towns_fund_round_four/validate.py
+++ b/core/validation/specific_validation/towns_fund_round_four/validate.py
@@ -184,7 +184,7 @@ def validate_funding_profiles_funding_source_enum(workbook: dict[str, pd.DataFra
 
 
 def validate_funding_profiles_at_least_one_other_funding_source_fhsf(
-    workbook: dict[str, pd.DataFrame]
+    workbook: dict[str, pd.DataFrame],
 ) -> list["GenericFailure"] | None:
     """Validates that there is at least one Other Funding Source entry across any projects for a FHSF submission.
 
@@ -218,7 +218,7 @@ def validate_funding_profiles_at_least_one_other_funding_source_fhsf(
 
 
 def validate_funding_profiles_funding_secured_not_null(
-    workbook: dict[str, pd.DataFrame]
+    workbook: dict[str, pd.DataFrame],
 ) -> list["GenericFailure"] | None:
     """Validates that Secured is not null for custom funding sources.
 
@@ -290,7 +290,7 @@ def validate_locations(workbook: dict[str, pd.DataFrame]) -> list["GenericFailur
     failures = []
 
     # empty cell validation
-    for table_column, form_column, column_data in empty_cell_validation:
+    for table_column, _, column_data in empty_cell_validation:
         for idx, value in column_data.items():
             if is_blank(value):
                 failures.append(

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -93,7 +93,7 @@ def run_migrations_online():
             connection=connection,
             target_metadata=get_metadata(),
             process_revision_directives=process_revision_directives,
-            **current_app.extensions["migrate"].configure_args
+            **current_app.extensions["migrate"].configure_args,
         )
 
         with context.begin_transaction():

--- a/db/migrations/versions/025_rename_pg_management.py
+++ b/db/migrations/versions/025_rename_pg_management.py
@@ -49,7 +49,6 @@ def upgrade():
 
 
 def downgrade():
-
     # Rename table.
     new_name = "programme_management"
     op.rename_table("programme_funding_management", new_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,23 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
+
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
+]
+ignore = []
+exclude = [
+    "db/migrations/versions/",
+    "venv*",
+    ".venv*",
+    "__pycache__",
+]
+mccabe.max-complexity = 12

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,3 +14,4 @@ pytest-mock
 #   Code Quality
 #-----------------------------------
 pre-commit
+ruff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -333,6 +333,8 @@ ruamel-yaml==0.17.21
     # via
     #   -r requirements.txt
     #   prance
+ruff==0.4.1
+    # via -r requirements-dev.in
 s3transfer==0.6.0
     # via
     #   -r requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 120
-extend-ignore = E203
-
-[tool.isort]
-profile = "black"

--- a/tables/extract.py
+++ b/tables/extract.py
@@ -67,14 +67,17 @@ class TableExtractor:
         end_tags, start_tags = self._get_tags(id_tag, worksheet)
         paired_tags = self._pair_tags(start_tags, end_tags, file_width=len(worksheet.columns))
         dfs = self._extract_dfs(worksheet, paired_tags)
-        tables = [Table(df=df, start_tag=start_tag, id_tag=id_tag) for df, (start_tag, _) in zip(dfs, paired_tags)]
+        tables = [
+            Table(df=df, start_tag=start_tag, id_tag=id_tag)
+            for df, (start_tag, _) in zip(dfs, paired_tags, strict=False)
+        ]
         return tables
 
     def _get_tags(self, id_tag: str, worksheet: pd.DataFrame) -> tuple[list[Cell], list[Cell]]:
         start_tag = self.START_TAG.format(id=id_tag)
         end_tag = self.END_TAG.format(id=id_tag)
-        start_tags = list(zip(*np.where(worksheet == start_tag)))
-        end_tags = list(zip(*np.where(worksheet == end_tag)))
+        start_tags = list(zip(*np.where(worksheet == start_tag), strict=False))
+        end_tags = list(zip(*np.where(worksheet == end_tag), strict=False))
         start_tags = [Cell(row, col) for row, col in start_tags]
         end_tags = [Cell(row, col) for row, col in end_tags]
         if not start_tags and not end_tags:

--- a/tables/table.py
+++ b/tables/table.py
@@ -65,7 +65,7 @@ class Table:
         self.start_tag = start_tag
         self.id_tag = id_tag
         self.first_col_idx = start_tag.column
-        self.col_idx_map = dict(zip(df.columns, range(len(df.columns))))
+        self.col_idx_map = dict(zip(df.columns, range(len(df.columns)), strict=False))
 
     def get_cell(self, row_idx: int, col_name: str) -> Cell:
         """

--- a/tables/validate.py
+++ b/tables/validate.py
@@ -89,7 +89,7 @@ class TableValidator:
             failures = self._filter_ignored(failures)
             if failures:
                 validation_errors = [self._parse_failure(failure, table) for failure in failures]
-                raise TableValidationErrors(validation_errors=validation_errors)
+                raise TableValidationErrors(validation_errors=validation_errors) from schema_errors
 
     def _check_columns(self, table: Table):
         if cols_in_df_not_in_schema := set(table.df.columns).difference(set(self.schema.columns.keys())):

--- a/tests/controller_tests/test_ingest_functions.py
+++ b/tests/controller_tests/test_ingest_functions.py
@@ -86,7 +86,8 @@ def test_extract_data_handles_corrupt_file(test_session, mocker, caplog, excepti
         extract_data(file)
 
     assert str(bad_request_exc.value) == "400 Bad Request: bad excel_file"
-    assert caplog.messages[0] == "Cannot read the bad excel file: Error message"
+    assert caplog.messages[0] == "Cannot read the bad excel file: {bad_file_error}"
+    assert str(caplog.records[0].bad_file_error) == "Error message"
 
 
 def test_extract_data_extracts_from_multiple_sheets(towns_fund_round_3_file_success):

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -348,7 +348,8 @@ def test_transaction_retry_wrapper_wrapper_max_retries(mocker, test_session, cap
             decorated_function()
 
     assert mocked_function.call_count == max_retries
-    assert caplog.messages[-1] == ("Number of max retries exceeded for function 'mocked_function'")
+    assert caplog.messages[-1] == "Number of max retries exceeded for function '{func_name}'"
+    assert caplog.records[-1].func_name == "mocked_function"
     assert patched_time_sleep.call_count == 4
 
 
@@ -374,7 +375,8 @@ def test_transaction_retry_wrapper_wrapper_successful_retry(mocker, test_session
         decorated_function()
 
     assert mocked_function.call_count == 2
-    assert "Retry count: 1" in caplog.messages[0]
+    assert "Retry count: {retry}" in caplog.messages[0]
+    assert caplog.records[0].retry == 1
     assert patched_time_sleep.call_count == 1
 
 

--- a/tests/transformation_tests/towns_fund/test_round_3_transformation.py
+++ b/tests/transformation_tests/towns_fund/test_round_3_transformation.py
@@ -375,20 +375,18 @@ def test_extract_outcomes_with_invalid_project(mock_outcomes_sheet, mock_project
     with pytest.raises(OldValidationError) as ve:
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 3)
     assert str(ve.value) == (
-        (
-            "[GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
-            "footfall)', message='You’ve entered your own content, instead of selecting "
-            "from the dropdown list provided. Select an option from the dropdown list.', "
-            "cell_index=None, column='Relevant project(s)', row_index=23), "
-            "GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
-            "footfall)', message='You’ve entered your own content, instead of selecting "
-            "from the dropdown list provided. Select an option from the dropdown list.', "
-            "cell_index=None, column='Relevant project(s)', row_index=24), "
-            "GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
-            "footfall)', message='You’ve entered your own content, instead of selecting "
-            "from the dropdown list provided. Select an option from the dropdown list.', "
-            "cell_index=None, column='Relevant project(s)', row_index=43)]"
-        )
+        "[GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
+        "footfall)', message='You’ve entered your own content, instead of selecting "
+        "from the dropdown list provided. Select an option from the dropdown list.', "
+        "cell_index=None, column='Relevant project(s)', row_index=23), "
+        "GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
+        "footfall)', message='You’ve entered your own content, instead of selecting "
+        "from the dropdown list provided. Select an option from the dropdown list.', "
+        "cell_index=None, column='Relevant project(s)', row_index=24), "
+        "GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding "
+        "footfall)', message='You’ve entered your own content, instead of selecting "
+        "from the dropdown list provided. Select an option from the dropdown list.', "
+        "cell_index=None, column='Relevant project(s)', row_index=43)]"
     )
 
     with pytest.raises(OldValidationError) as ve:

--- a/tests/transformation_tests/towns_fund/test_round_4_transformation.py
+++ b/tests/transformation_tests/towns_fund/test_round_4_transformation.py
@@ -205,17 +205,15 @@ def test_extract_outcomes_with_null_project(mock_outcomes_sheet, mock_project_lo
     with pytest.raises(OldValidationError) as ve:
         tf.extract_outcomes(mock_outcomes_sheet, mock_project_lookup, mock_programme_lookup, 4)
     assert str(ve.value.validation_failures) == (
-        (
-            "[GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve "
-            "entered your own content, instead of selecting from the dropdown list provided. Select an option from "
-            "the dropdown list.', cell_index=None, column='Relevant project(s)', row_index=23), GenericFailure("
-            "table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve entered your "
-            "own content, instead of selecting from the dropdown list provided. Select an option from the dropdown "
-            "list.', cell_index=None, column='Relevant project(s)', row_index=24), GenericFailure("
-            "table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve entered your "
-            "own content, instead of selecting from the dropdown list provided. Select an option from the dropdown "
-            "list.', cell_index=None, column='Relevant project(s)', row_index=43)]"
-        )
+        "[GenericFailure(table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve "
+        "entered your own content, instead of selecting from the dropdown list provided. Select an option from "
+        "the dropdown list.', cell_index=None, column='Relevant project(s)', row_index=23), GenericFailure("
+        "table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve entered your "
+        "own content, instead of selecting from the dropdown list provided. Select an option from the dropdown "
+        "list.', cell_index=None, column='Relevant project(s)', row_index=24), GenericFailure("
+        "table='Outcome_Data', section='Outcome Indicators (excluding footfall)', message='You’ve entered your "
+        "own content, instead of selecting from the dropdown list provided. Select an option from the dropdown "
+        "list.', cell_index=None, column='Relevant project(s)', row_index=43)]"
     )
 
 

--- a/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
+++ b/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
@@ -259,9 +259,9 @@ def test_check_actual_forecast_reporting_period(mock_df_dict):
 
     # Test case where there is an error for an "Actual" change in a future reporting period
     original_reporting_period = mock_df_dict["Project finance changes"]["Reporting period change takes place"][0]
-    mock_df_dict["Project finance changes"]["Reporting period change takes place"][
-        0
-    ] = "Q1 2024/25: Apr 2024 - Jun 2024"
+    mock_df_dict["Project finance changes"]["Reporting period change takes place"][0] = (
+        "Q1 2024/25: Apr 2024 - Jun 2024"
+    )
     error_messages = _check_actual_forecast_reporting_period(mock_df_dict)
     mock_df_dict["Project finance changes"]["Reporting period change takes place"][0] = original_reporting_period
     assert error_messages == [


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-812

### Change description
Stop eagerly formatting log messages, which ends up causing some log messages to be double-formatted. When the initial format is injecting a dictionary into the string, the second format (by fsd_utils.logging) can error because the dict looks like a format injection point, but is incorrectly structured.

I've also switched black+flake8+isort out for [ruff](https://docs.astral.sh/ruff/), which is a fast modern tool that combines a bunch of formatting and linting rules. One of these will raise linting issues for log call that have eagerly-formatted log lines.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")