### PR TITLE
[FMD-265]: normalise fund reference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Seeds or re-seed the database with the geospatial reference table in isolation w
 flask seed-geospatial
 ```
 
+### seed-fund
+Seeds or re-seed the database with the fund reference table in isolation with the csv from tests/resources
+
+```python
+flask seed-fund
+```
+
 ### seed-test
 Returns "success" if the db contains some data
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -63,6 +63,7 @@ def create_cli(app):
             db.drop_all()
             db.create_all()
             seed_geospatial_dim_table()
+            seed_fund()
 
         print("Database reset and geospatial data re-seeded.")
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -4,7 +4,7 @@ import requests
 from flask import current_app
 
 from core.db import db
-from core.reference_data import seed_geospatial_dim_table
+from core.reference_data import seed_fund_table, seed_geospatial_dim_table
 from core.util import load_example_data
 
 resources = Path(__file__).parent / ".." / "tests" / "resources"
@@ -77,3 +77,14 @@ def create_cli(app):
         with current_app.app_context():
             seed_geospatial_dim_table()
             print("Geospatial data re-seeded.")
+
+    @app.cli.command("seed-fund")
+    def seed_fund():
+        """CLI command to seed (or re-seed) the fund reference table in isolation.
+        Example usage:
+            flask seed-fund
+        """
+
+        with current_app.app_context():
+            seed_fund_table()
+            print("Fund data re-seeded.")

--- a/core/controllers/get_filters.py
+++ b/core/controllers/get_filters.py
@@ -32,16 +32,16 @@ def get_organisation_names():
 
 def get_funds():
     """
-    Fetches all funds sorted alphabetically by fund_type_id.
+    Fetches all funds sorted alphabetically by fund_code.
 
     :return: A tuple - list of funds and status code 200. If no funds found, aborts with 404 error.
     """
-    funds = Fund.query.order_by(Fund.fund_type_id).with_entities(Fund.fund_type_id).all()
+    funds = Fund.query.order_by(Fund.fund_code).with_entities(Fund.fund_code).all()
 
     if not funds:
         return abort(404, "No funds found.")
 
-    fund_list = [{"name": FUND_ID_TO_NAME[row.fund_type_id], "id": row.fund_type_id} for row in funds]
+    fund_list = [{"name": FUND_ID_TO_NAME[row.fund_code], "id": row.fund_code} for row in funds]
 
     return fund_list, 200
 

--- a/core/controllers/get_filters.py
+++ b/core/controllers/get_filters.py
@@ -5,7 +5,7 @@ from core.const import FUND_ID_TO_NAME
 from core.db import db
 
 # isort: off
-from core.db.entities import Organisation, OutcomeDim, Programme, Project, Submission
+from core.db.entities import Organisation, OutcomeDim, Programme, Project, Submission, Fund
 
 
 # isort: on
@@ -32,20 +32,18 @@ def get_organisation_names():
 
 def get_funds():
     """
-    Fetches all unique funds sorted alphabetically by fund_type_id.
+    Fetches all funds sorted alphabetically by fund_type_id.
 
-    :return: A tuple - list of unique funds and status code 200. If no funds found, aborts with 404 error.
+    :return: A tuple - list of funds and status code 200. If no funds found, aborts with 404 error.
     """
-    programmes = Programme.query.order_by(Programme.fund_type_id).with_entities(Programme.fund_type_id).distinct().all()
+    funds = Fund.query.order_by(Fund.fund_type_id).with_entities(Fund.fund_type_id).all()
 
-    if not programmes:
+    if not funds:
         return abort(404, "No funds found.")
 
-    funds = [
-        {"name": FUND_ID_TO_NAME[programme.fund_type_id], "id": programme.fund_type_id} for programme in programmes
-    ]
+    fund_list = [{"name": FUND_ID_TO_NAME[row.fund_type_id], "id": row.fund_type_id} for row in funds]
 
-    return funds, 200
+    return fund_list, 200
 
 
 def get_outcome_categories():

--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -455,7 +455,7 @@ def save_submission_file_s3(excel_file: FileStorage, submission_id: str):
         .join(Submission)
         .join(Fund)
         .filter(Submission.submission_id == submission_id)
-        .with_entities(Submission.id, Fund.fund_type_id, Programme.programme_name)
+        .with_entities(Submission.id, Fund.fund_code, Programme.programme_name)
         .distinct()
     ).one()
 

--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -28,7 +28,7 @@ from core.controllers.load_functions import (
 )
 from core.controllers.mappings import INGEST_MAPPINGS, DataMapping
 from core.db import db
-from core.db.entities import Programme, ProgrammeJunction, Submission
+from core.db.entities import Fund, Programme, ProgrammeJunction, Submission
 from core.db.queries import (
     get_programme_by_id_and_previous_round,
     get_programme_by_id_and_round,
@@ -453,8 +453,9 @@ def save_submission_file_s3(excel_file: FileStorage, submission_id: str):
     uuid, fund_type, programme_name = (
         Programme.query.join(ProgrammeJunction)
         .join(Submission)
+        .join(Fund)
         .filter(Submission.submission_id == submission_id)
-        .with_entities(Submission.id, Programme.fund_type_id, Programme.programme_name)
+        .with_entities(Submission.id, Fund.fund_type_id, Programme.programme_name)
         .distinct()
     ).one()
 

--- a/core/controllers/mappings.py
+++ b/core/controllers/mappings.py
@@ -156,7 +156,10 @@ INGEST_MAPPINGS = (
             "FundType_ID": "fund_type_id",
             "Organisation": "organisation",
         },
-        fk_relations=[("organisation_name", ents.Organisation, "organisation_id", "organisation")],
+        fk_relations=[
+            ("organisation_name", ents.Organisation, "organisation_id", "organisation"),
+            ("fund_type_id", ents.Fund, "fund_type_id", "fund_type_id"),
+        ],
     ),
     DataMapping(
         table="Programme Junction",

--- a/core/controllers/mappings.py
+++ b/core/controllers/mappings.py
@@ -158,7 +158,7 @@ INGEST_MAPPINGS = (
         },
         fk_relations=[
             ("organisation_name", ents.Organisation, "organisation_id", "organisation"),
-            ("fund_type_id", ents.Fund, "fund_type_id", "fund_type_id"),
+            ("fund_code", ents.Fund, "fund_type_id", "fund_type_id"),
         ],
     ),
     DataMapping(

--- a/core/controllers/retrieve_submission_file.py
+++ b/core/controllers/retrieve_submission_file.py
@@ -22,7 +22,7 @@ def retrieve_submission_file(submission_id):
             .join(Submission)
             .join(Fund)
             .filter(Submission.submission_id == submission_id)
-            .with_entities(Submission.id, Fund.fund_type_id)
+            .with_entities(Submission.id, Fund.fund_code)
             .distinct()
         )
         .distinct()

--- a/core/controllers/retrieve_submission_file.py
+++ b/core/controllers/retrieve_submission_file.py
@@ -4,7 +4,7 @@ from flask import abort
 
 from config import Config
 from core.aws import get_file
-from core.db.entities import Programme, ProgrammeJunction, Submission
+from core.db.entities import Fund, Programme, ProgrammeJunction, Submission
 
 
 def retrieve_submission_file(submission_id):
@@ -20,8 +20,9 @@ def retrieve_submission_file(submission_id):
         (
             Programme.query.join(ProgrammeJunction)
             .join(Submission)
+            .join(Fund)
             .filter(Submission.submission_id == submission_id)
-            .with_entities(Submission.id, Programme.fund_type_id)
+            .with_entities(Submission.id, Fund.fund_type_id)
             .distinct()
         )
         .distinct()

--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -24,7 +24,7 @@ class Fund(BaseModel):
 
     __tablename__ = "fund_dim"
 
-    fund_type_id = sqla.Column(sqla.String(), nullable=False, unique=True)
+    fund_code = sqla.Column(sqla.String(), nullable=False, unique=True)
 
     programmes: Mapped[List["Programme"]] = sqla.orm.relationship(back_populates="fund")
 

--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -19,6 +19,16 @@ class BaseModel(db.Model):
     id: Mapped[GUID] = sqla.orm.mapped_column(GUID(), default=uuid.uuid4, primary_key=True)
 
 
+class Fund(BaseModel):
+    """Stores Fund Entities."""
+
+    __tablename__ = "fund_dim"
+
+    fund_type_id = sqla.Column(sqla.String(), nullable=False, unique=True)
+
+    programmes: Mapped[List["Programme"]] = sqla.orm.relationship(back_populates="fund")
+
+
 class Funding(BaseModel):
     """Stores Funding Entities."""
 
@@ -296,11 +306,12 @@ class Programme(BaseModel):
     programme_id = sqla.Column(sqla.String(), nullable=False, unique=True)
 
     programme_name = sqla.Column(sqla.String(), nullable=False)
-    fund_type_id = sqla.Column(sqla.String(), nullable=False)
     organisation_id = sqla.Column(GUID(), sqla.ForeignKey("organisation_dim.id"), nullable=False)
+    fund_type_id = sqla.Column(GUID(), sqla.ForeignKey("fund_dim.id"), nullable=False)
 
     organisation: Mapped["Organisation"] = sqla.orm.relationship(back_populates="programmes")
     in_round_programmes: Mapped[List["ProgrammeJunction"]] = sqla.orm.relationship(back_populates="programme_ref")
+    fund: Mapped["Fund"] = sqla.orm.relationship(back_populates="programmes")
 
     __table_args__ = (
         sqla.Index(
@@ -310,7 +321,7 @@ class Programme(BaseModel):
             unique=True,
         ),
         sqla.Index(
-            "ix_programme_filter_fund_type",
+            "ix_programme_join_fund_type",
             "fund_type_id",
         ),
         sqla.Index(

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -81,7 +81,7 @@ def download_data_base_query(
 
     project_region_condition = ents.Project.id.in_(itl_rows) if itl_rows else True
     submission_period_condition = set_submission_period_condition(min_rp_start, max_rp_end)
-    fund_type_condition = ents.Fund.fund_type_id.in_(fund_type_ids) if fund_type_ids else True
+    fund_type_condition = ents.Fund.fund_code.in_(fund_type_ids) if fund_type_ids else True
     organisation_name_condition = ents.Organisation.id.in_(organisation_uuids) if organisation_uuids else True
 
     base_query = (
@@ -451,7 +451,7 @@ def programme_query(base_query: Query) -> Query:
     extended_query = base_query.with_entities(
         ents.Programme.programme_id,
         ents.Programme.programme_name,
-        ents.Fund.fund_type_id,
+        ents.Fund.fund_code,
         ents.Organisation.organisation_name,
     ).distinct()
 
@@ -736,7 +736,7 @@ def get_latest_submission_by_round_and_fund(reporting_round: int, fund_id: str) 
         .join(ents.Programme)
         .join(ents.Fund)
         .filter(ents.Submission.reporting_round == reporting_round)
-        .filter(ents.Fund.fund_type_id.in_(fund_types))
+        .filter(ents.Fund.fund_code.in_(fund_types))
         .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, id_character_offset[fund_id]), Integer)))
         .first()
     )

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -81,7 +81,7 @@ def download_data_base_query(
 
     project_region_condition = ents.Project.id.in_(itl_rows) if itl_rows else True
     submission_period_condition = set_submission_period_condition(min_rp_start, max_rp_end)
-    programme_fund_condition = ents.Programme.fund_type_id.in_(fund_type_ids) if fund_type_ids else True
+    fund_type_condition = ents.Fund.fund_type_id.in_(fund_type_ids) if fund_type_ids else True
     organisation_name_condition = ents.Organisation.id.in_(organisation_uuids) if organisation_uuids else True
 
     base_query = (
@@ -89,9 +89,10 @@ def download_data_base_query(
         .join(ents.Programme)
         .join(ents.Organisation)
         .join(ents.Project)
+        .join(ents.Fund)
         .filter(project_region_condition)
         .filter(submission_period_condition)
-        .filter(programme_fund_condition)
+        .filter(fund_type_condition)
         .filter(organisation_name_condition)
     )
 
@@ -450,7 +451,7 @@ def programme_query(base_query: Query) -> Query:
     extended_query = base_query.with_entities(
         ents.Programme.programme_id,
         ents.Programme.programme_name,
-        ents.Programme.fund_type_id,
+        ents.Fund.fund_type_id,
         ents.Organisation.organisation_name,
     ).distinct()
 
@@ -733,8 +734,9 @@ def get_latest_submission_by_round_and_fund(reporting_round: int, fund_id: str) 
     latest_submission_id = (
         ents.Submission.query.join(ents.ProgrammeJunction)
         .join(ents.Programme)
+        .join(ents.Fund)
         .filter(ents.Submission.reporting_round == reporting_round)
-        .filter(ents.Programme.fund_type_id.in_(fund_types))
+        .filter(ents.Fund.fund_type_id.in_(fund_types))
         .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, id_character_offset[fund_id]), Integer)))
         .first()
     )

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -32,6 +32,7 @@ from sqlalchemy.sql import text
 
 from core.db import db
 from core.db.entities import (
+    Fund,
     Funding,
     FundingComment,
     FundingQuestion,
@@ -384,7 +385,7 @@ class ProgrammeSchema(SQLAlchemySchema):
 
     programme_id = auto_field(data_key="ProgrammeID")
     programme_name = auto_field(data_key="ProgrammeName")
-    fund_type_id = auto_field(data_key="FundTypeID")
+    fund_type_id = auto_field(model=Fund, data_key="FundTypeID")
     organisation_name = auto_field(model=Organisation, data_key="OrganisationName")
 
 

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -385,7 +385,7 @@ class ProgrammeSchema(SQLAlchemySchema):
 
     programme_id = auto_field(data_key="ProgrammeID")
     programme_name = auto_field(data_key="ProgrammeName")
-    fund_type_id = auto_field(model=Fund, data_key="FundTypeID")
+    fund_code = auto_field(model=Fund, data_key="FundTypeID")
     organisation_name = auto_field(model=Organisation, data_key="OrganisationName")
 
 

--- a/db/migrations/versions/028_create_fund_ref_table.py
+++ b/db/migrations/versions/028_create_fund_ref_table.py
@@ -6,8 +6,6 @@ Create Date: 2024-04-23 09:41:50.279834
 
 """
 
-import uuid
-
 import sqlalchemy as sa
 from alembic import op
 
@@ -23,22 +21,20 @@ depends_on = None
 def upgrade():
     op.create_table(
         "fund_dim",
-        sa.Column("fund_type_id", sa.String(), nullable=False),
+        sa.Column("fund_code", sa.String(), nullable=False),
         sa.Column("id", core.db.types.GUID(), nullable=False),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_fund_dim")),
-        sa.UniqueConstraint("fund_type_id", name=op.f("uq_fund_dim_fund_type_id")),
+        sa.UniqueConstraint("fund_code", name=op.f("uq_fund_dim_fund_code")),
     )
 
     op.execute(
         """
-        INSERT INTO fund_dim (id, fund_type_id)
+        INSERT INTO fund_dim (id, fund_code)
         VALUES
-        ('{0}', 'HS'),
-        ('{1}', 'TD'),
-        ('{2}', 'PF');
-        """.format(
-            str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-        )
+        ('4a6e9f7d-fc9d-4c12-b1b6-89e784c310e1', 'HS'),
+        ('9fde58b2-8a89-4b2c-af7d-1f968b03c7b9', 'TD'),
+        ('e8c7c1c8-90d3-4b2d-aa50-4a2d4091d4f3', 'PF');
+        """
     )
 
     op.add_column("programme_dim", sa.Column("temp", core.db.types.GUID(), nullable=True))
@@ -48,7 +44,7 @@ def upgrade():
         UPDATE programme_dim AS p
         SET temp = f.id
         FROM fund_dim AS f
-        WHERE p.fund_type_id = f.fund_type_id;
+        WHERE p.fund_type_id = f.fund_code;
         """
     )
 
@@ -71,7 +67,7 @@ def downgrade():
     op.execute(
         """
         UPDATE programme_dim AS p
-        SET temp = f.fund_type_id
+        SET temp = f.fund_code
         FROM fund_dim AS f
         WHERE p.fund_type_id = f.id;
         """

--- a/db/migrations/versions/028_create_fund_ref_table.py
+++ b/db/migrations/versions/028_create_fund_ref_table.py
@@ -1,0 +1,89 @@
+"""empty message
+
+Revision ID: 028_normalise_fund_ref_data
+Revises: 027_start_date_before_end
+Create Date: 2024-04-23 09:41:50.279834
+
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+import core
+
+# revision identifiers, used by Alembic.
+revision = "028_normalise_fund_ref_data"
+down_revision = "027_start_date_before_end"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "fund_dim",
+        sa.Column("fund_type_id", sa.String(), nullable=False),
+        sa.Column("id", core.db.types.GUID(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_fund_dim")),
+        sa.UniqueConstraint("fund_type_id", name=op.f("uq_fund_dim_fund_type_id")),
+    )
+
+    op.execute(
+        """
+        INSERT INTO fund_dim (id, fund_type_id)
+        VALUES
+        ('{0}', 'HS'),
+        ('{1}', 'TD'),
+        ('{2}', 'PF');
+        """.format(
+            str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        )
+    )
+
+    op.add_column("programme_dim", sa.Column("temp", core.db.types.GUID(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE programme_dim AS p
+        SET temp = f.id
+        FROM fund_dim AS f
+        WHERE p.fund_type_id = f.fund_type_id;
+        """
+    )
+
+    with op.batch_alter_table("programme_dim", schema=None) as batch_op:
+        batch_op.drop_index("ix_programme_filter_fund_type")
+        batch_op.drop_column("fund_type_id")
+        batch_op.alter_column("temp", new_column_name="fund_type_id", nullable=False)
+        batch_op.create_foreign_key(
+            batch_op.f("fk_programme_dim_fund_type_id_fund_dim"), "fund_dim", ["fund_type_id"], ["id"]
+        )
+        batch_op.create_index("ix_programme_join_fund_type", ["fund_type_id"], unique=False)
+        batch_op.create_index("ix_unique_programme_name_per_fund", ["programme_name", "fund_type_id"], unique=True)
+
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.add_column("programme_dim", sa.Column("temp", sa.String(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE programme_dim AS p
+        SET temp = f.fund_type_id
+        FROM fund_dim AS f
+        WHERE p.fund_type_id = f.id;
+        """
+    )
+
+    with op.batch_alter_table("programme_dim", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("fk_programme_dim_fund_type_id_fund_dim"), type_="foreignkey")
+        batch_op.drop_index("ix_programme_join_fund_type")
+        batch_op.drop_index("ix_unique_programme_name_per_fund")
+        batch_op.drop_column("fund_type_id")
+        batch_op.alter_column("temp", new_column_name="fund_type_id", nullable=False)
+        batch_op.create_index("ix_programme_filter_fund_type", ["fund_type_id"], unique=False)
+
+    op.drop_table("fund_dim")
+    # ### end Alembic commands ###

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,7 @@ def additional_test_data() -> dict[str, Any]:
     db.session.flush()
 
     fund = Fund(
-        fund_type_id="TEST",
+        fund_code="TEST",
     )
     db.session.add(fund)
     db.session.flush()
@@ -442,7 +442,7 @@ def towns_fund_bolton_round_1_test_data(test_client_reset):
     programme = Programme(
         programme_id="TD-BOL",
         programme_name="Bolton Council",
-        fund_type_id=Fund.query.filter_by(fund_type_id="TD").first().id,
+        fund_type_id=Fund.query.filter_by(fund_code="TD").first().id,
         organisation_id=organisation.id,
     )
 
@@ -474,7 +474,7 @@ def pathfinders_round_1_submission_data(test_client_reset):
     programme = Programme(
         programme_id="PF-ROM",
         programme_name="Romulan Star Empire",
-        fund_type_id=Fund.query.filter_by(fund_type_id="PF").first().id,
+        fund_type_id=Fund.query.filter_by(fund_code="PF").first().id,
         organisation_id=organisation.id,
     )
 
@@ -506,7 +506,7 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
     programme = Programme(
         programme_id="TD-ROM",
         programme_name="Romulan Star Empire",
-        fund_type_id=Fund.query.filter_by(fund_type_id="TD").first().id,
+        fund_type_id=Fund.query.filter_by(fund_code="TD").first().id,
         organisation_id=organisation.id,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from app import create_app
 from core.const import GeographyIndicatorEnum
 from core.db import db
 from core.db.entities import (
+    Fund,
     FundingQuestion,
     Organisation,
     OutcomeData,
@@ -37,6 +38,7 @@ from core.db.entities import (
     RiskRegister,
     Submission,
 )
+from core.reference_data import seed_fund_table
 from core.util import load_example_data
 from tests.resources.extracted_data import EXTRACTED_TABLES
 
@@ -129,6 +131,8 @@ def seeded_test_client(test_client: FlaskClient) -> FlaskClient:
     """
     Yield a test client with pushed application context preloaded example data in test database.
 
+    This test first seeds the 'fund_dim' reference table, and then calls load_example_data to
+    load data into the other tables via csvs.
     This is a fixture. Extends test_client.
 
     Use for tests that:
@@ -141,6 +145,7 @@ def seeded_test_client(test_client: FlaskClient) -> FlaskClient:
     :param test_client: a Flask test client
     :yield: a flask test client with application context and seeded db.
     """
+    seed_fund_table()
     load_example_data()
     yield test_client
 
@@ -172,9 +177,11 @@ def test_client_reset(test_client: FlaskClient) -> FlaskClient:
     Returns a test client with pushed application context. Removes DB data at a function scope.
 
     Intended for use where a test involves a commit to DB.
+    Seeds the fund_dim table with pre-existing values, or else ingestion will not work.
     Empties existing DB tables after use, to prevent "test leakage" into other tests.
     For use at function level scope. Inherits module scoped setup/tear-down.
     Avoid using for tests that do not commit to DB, to avoid the extra overhead of setup/teardown once per funtion.
+    The 'fund_dim' table is seeded at the beginning of each test as the application requires prior data for funds.
 
     Use for tests that:
     - need application context
@@ -184,7 +191,7 @@ def test_client_reset(test_client: FlaskClient) -> FlaskClient:
     :param test_client: Flask test client with empty DB.
     :yield: a flask test client with application context.
     """
-
+    seed_fund_table()
     yield test_client
     db.session.rollback()
     # disable foreign key checks
@@ -219,10 +226,16 @@ def additional_test_data() -> dict[str, Any]:
     db.session.add_all((submission, organisation, organisation2))
     db.session.flush()
 
+    fund = Fund(
+        fund_type_id="TEST",
+    )
+    db.session.add(fund)
+    db.session.flush()
+
     programme = Programme(
         programme_id="TEST-PROGRAMME-ID",
         programme_name="TEST-PROGRAMME-NAME",
-        fund_type_id="TEST",
+        fund_type_id=fund.id,
         organisation_id=organisation.id,
     )
 
@@ -389,6 +402,7 @@ def additional_test_data() -> dict[str, Any]:
     return {
         "organisation": organisation,
         "submission": submission,
+        "fund": fund,
         "programme": programme,
         "project1": project1,
         "project2": project2,
@@ -405,8 +419,8 @@ def additional_test_data() -> dict[str, Any]:
     }
 
 
-@pytest.fixture(scope="module")
-def towns_fund_bolton_round_1_test_data():
+@pytest.fixture(scope="function")
+def towns_fund_bolton_round_1_test_data(test_client_reset):
     """
     Add additional test data to DB (for specific use cases).
 
@@ -428,7 +442,7 @@ def towns_fund_bolton_round_1_test_data():
     programme = Programme(
         programme_id="TD-BOL",
         programme_name="Bolton Council",
-        fund_type_id="TD",
+        fund_type_id=Fund.query.filter_by(fund_type_id="TD").first().id,
         organisation_id=organisation.id,
     )
 
@@ -443,8 +457,8 @@ def towns_fund_bolton_round_1_test_data():
     db.session.commit()
 
 
-@pytest.fixture(scope="module")
-def pathfinders_round_1_submission_data():
+@pytest.fixture(scope="function")
+def pathfinders_round_1_submission_data(test_client_reset):
     """Pre-populates Submission table with an already existing PF submission."""
     submission = Submission(
         submission_id="S-PF-R01-1",
@@ -460,7 +474,7 @@ def pathfinders_round_1_submission_data():
     programme = Programme(
         programme_id="PF-ROM",
         programme_name="Romulan Star Empire",
-        fund_type_id="PF",
+        fund_type_id=Fund.query.filter_by(fund_type_id="PF").first().id,
         organisation_id=organisation.id,
     )
 
@@ -475,8 +489,8 @@ def pathfinders_round_1_submission_data():
     db.session.commit()
 
 
-@pytest.fixture(scope="module")
-def towns_fund_td_round_3_submission_data():
+@pytest.fixture(scope="function")
+def towns_fund_td_round_3_submission_data(test_client_reset):
     """Pre-populates Submission table with an already existing TD submission."""
     submission = Submission(
         submission_id="S-R03-1",
@@ -492,7 +506,7 @@ def towns_fund_td_round_3_submission_data():
     programme = Programme(
         programme_id="TD-ROM",
         programme_name="Romulan Star Empire",
-        fund_type_id="TD",
+        fund_type_id=Fund.query.filter_by(fund_type_id="TD").first().id,
         organisation_id=organisation.id,
     )
 

--- a/tests/db_tests/test_constraints.py
+++ b/tests/db_tests/test_constraints.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from core.db import db
 from core.db.entities import (
+    Fund,
     Funding,
     OutcomeData,
     OutcomeDim,
@@ -205,3 +206,14 @@ class TestConstraintOnStartAndEndDates:
             db.session.commit()
 
         assert "ck_submission_dim_start_before_end" in str(e.value)
+
+
+def test_fund_dim_unique_constraint(test_client_rollback):
+    """Tests the unique constraint on fund_dim."""
+
+    fund = Fund(fund_code="JP")
+    same_fund = Fund(fund_code="JP")
+    db.session.add_all([fund, same_fund])
+
+    with pytest.raises(IntegrityError):
+        db.session.flush()

--- a/tests/db_tests/test_entities.py
+++ b/tests/db_tests/test_entities.py
@@ -5,7 +5,6 @@ from sqlalchemy.exc import IntegrityError
 
 from core.db import db
 from core.db import entities as ents
-from core.db.entities import Fund
 
 
 def test_programme_contact_organisation(test_client_rollback):
@@ -22,7 +21,7 @@ def test_programme_contact_organisation(test_client_rollback):
     )
     db.session.add(organisation)
 
-    fund = ents.Fund(fund_type_id="JP")
+    fund = ents.Fund(fund_code="JP")
     db.session.add(fund)
 
     read_org = ents.Organisation.query.first()
@@ -32,7 +31,7 @@ def test_programme_contact_organisation(test_client_rollback):
     programme = ents.Programme(
         programme_id="XXXYY",
         programme_name="test programme",
-        fund_type_id=Fund.query.first().id,
+        fund_type_id=ents.Fund.query.first().id,
         organisation_id=read_org.id,
     )
     db.session.add(programme)
@@ -44,7 +43,7 @@ def test_programme_contact_organisation(test_client_rollback):
 def test_database_integrity_error(test_client_rollback):
     """Test that an invalid FK ref raises IntegrityError exception."""
 
-    fund = ents.Fund(fund_type_id="JP")
+    fund = ents.Fund(fund_code="JP")
     db.session.add(fund)
 
     programme = ents.Programme(
@@ -134,14 +133,3 @@ def test_geospatial_dim_table(seeded_test_client_rollback):
         region_code = row.itl1_region_code
         region_name = row.data_blob["itl1_region_name"]
         assert itl1_region_pairs[region_code] == region_name
-
-
-def test_fund_dim_unique_constraint(test_client_rollback):
-    """Tests the unique constraint on fund_dim."""
-
-    fund = Fund(fund_type_id="JP")
-    same_fund = Fund(fund_type_id="JP")
-    db.session.add_all([fund, same_fund])
-
-    with pytest.raises(IntegrityError):
-        db.session.flush()

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -244,14 +244,14 @@ def test_get_download_data_fund_filter(seeded_test_client, additional_test_data)
     """Pass fund filter params and check rows"""
 
     fund = additional_test_data["fund"]
-    fund_type_ids = [fund.fund_type_id]
+    fund_type_ids = [fund.fund_code]
 
     test_query_fund_type = download_data_base_query(fund_type_ids=fund_type_ids)
 
     test_query_fund_ents = test_query_fund_type.with_entities(
         Submission.submission_id,
         Programme.programme_id,
-        Fund.fund_type_id,
+        Fund.fund_code,
         Project.project_id,
     ).distinct()
 
@@ -288,7 +288,7 @@ def test_get_download_data_region_and_fund(seeded_test_client, additional_test_d
     fund = additional_test_data["fund"]
     project4 = additional_test_data["project4"]
     itl_regions = {ITLRegion.SouthWest}
-    fund_type_ids = [fund.fund_type_id]
+    fund_type_ids = [fund.fund_code]
 
     test_query_region_fund = download_data_base_query(fund_type_ids=fund_type_ids, itl_regions=itl_regions)
 

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -10,6 +10,7 @@ from sqlalchemy import exc
 from core.const import ITLRegion
 from core.db import db
 from core.db.entities import (
+    Fund,
     Organisation,
     OutcomeData,
     OutcomeDim,
@@ -242,15 +243,15 @@ def test_get_download_data_organisation_filter(seeded_test_client, additional_te
 def test_get_download_data_fund_filter(seeded_test_client, additional_test_data):
     """Pass fund filter params and check rows"""
 
-    programme = additional_test_data["programme"]
-    fund_type_ids = [programme.fund_type_id]
+    fund = additional_test_data["fund"]
+    fund_type_ids = [fund.fund_type_id]
 
     test_query_fund_type = download_data_base_query(fund_type_ids=fund_type_ids)
 
     test_query_fund_ents = test_query_fund_type.with_entities(
         Submission.submission_id,
         Programme.programme_id,
-        Programme.fund_type_id,
+        Fund.fund_type_id,
         Project.project_id,
     ).distinct()
 
@@ -284,10 +285,10 @@ def test_get_download_data_region_filter(seeded_test_client, additional_test_dat
 def test_get_download_data_region_and_fund(seeded_test_client, additional_test_data):
     # when both ITL region and fund_type filter params are passed, return relevant results
 
-    programme = additional_test_data["programme"]
+    fund = additional_test_data["fund"]
     project4 = additional_test_data["project4"]
     itl_regions = {ITLRegion.SouthWest}
-    fund_type_ids = [programme.fund_type_id]
+    fund_type_ids = [fund.fund_type_id]
 
     test_query_region_fund = download_data_base_query(fund_type_ids=fund_type_ids, itl_regions=itl_regions)
 
@@ -432,7 +433,7 @@ def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback,
     programme_2 = Programme(
         programme_id="HS-ROW",
         programme_name="TEST-PROGRAMME-NAME",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
 

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -150,7 +150,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(organisation_ref_expected_first_row, df_dict["OrganisationRef"].iloc[0])
+    assert_series_equal(organisation_ref_expected_first_row, df_dict["OrganisationRef"].iloc[0], check_names=False)
 
     place_detail_expected_first_row = pd.Series(
         {
@@ -164,7 +164,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(place_detail_expected_first_row, df_dict["PlaceDetails"].iloc[0])
+    assert_series_equal(place_detail_expected_first_row, df_dict["PlaceDetails"].iloc[0], check_names=False)
 
     project_details_expected_first_row = pd.Series(
         {
@@ -182,7 +182,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(project_details_expected_first_row, df_dict["ProjectDetails"].iloc[0])
+    assert_series_equal(project_details_expected_first_row, df_dict["ProjectDetails"].iloc[0], check_names=False)
 
     programme_progress_expected_first_row = pd.Series(
         {
@@ -195,7 +195,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(programme_progress_expected_first_row, df_dict["ProgrammeProgress"].iloc[0])
+    assert_series_equal(programme_progress_expected_first_row, df_dict["ProgrammeProgress"].iloc[0], check_names=False)
 
     project_progress_expected_first_row = pd.Series(
         {
@@ -219,7 +219,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(project_progress_expected_first_row, df_dict["ProjectProgress"].iloc[0])
+    assert_series_equal(project_progress_expected_first_row, df_dict["ProjectProgress"].iloc[0], check_names=False)
 
     funding_questions_expected_first_row = pd.Series(
         {
@@ -234,7 +234,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(funding_questions_expected_first_row, df_dict["FundingQuestions"].iloc[0])
+    assert_series_equal(funding_questions_expected_first_row, df_dict["FundingQuestions"].iloc[0], check_names=False)
 
     funding_comments_expected_first_row = pd.Series(
         {
@@ -247,7 +247,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(funding_comments_expected_first_row, df_dict["FundingComments"].iloc[0])
+    assert_series_equal(funding_comments_expected_first_row, df_dict["FundingComments"].iloc[0], check_names=False)
 
     private_investments_expected_first_row = pd.Series(
         {
@@ -264,7 +264,9 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(private_investments_expected_first_row, df_dict["PrivateInvestments"].iloc[0])
+    assert_series_equal(
+        private_investments_expected_first_row, df_dict["PrivateInvestments"].iloc[0], check_names=False
+    )
 
     output_ref_expected_first_row = pd.Series(
         {
@@ -274,7 +276,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         name=0,
     )
 
-    assert_series_equal(output_ref_expected_first_row, df_dict["OutputRef"].iloc[0])
+    assert_series_equal(output_ref_expected_first_row, df_dict["OutputRef"].iloc[0], check_names=False)
 
     output_data_expected_first_row = pd.Series(
         {
@@ -294,7 +296,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(output_data_expected_first_row, df_dict["OutputData"].iloc[0])
+    assert_series_equal(output_data_expected_first_row, df_dict["OutputData"].iloc[0], check_names=False)
 
     outcome_ref_expected_first_row = pd.Series(
         {
@@ -303,7 +305,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(outcome_ref_expected_first_row, df_dict["OutcomeRef"].iloc[0])
+    assert_series_equal(outcome_ref_expected_first_row, df_dict["OutcomeRef"].iloc[0], check_names=False)
 
     outcome_data_expected_first_row = pd.Series(
         {
@@ -323,7 +325,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(outcome_data_expected_first_row, df_dict["OutputData"].iloc[0])
+    assert_series_equal(outcome_data_expected_first_row, df_dict["OutputData"].iloc[0], check_names=False)
 
     risk_register_expected_first_row = pd.Series(
         {
@@ -348,7 +350,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(risk_register_expected_first_row, df_dict["RiskRegister"].iloc[0])
+    assert_series_equal(risk_register_expected_first_row, df_dict["RiskRegister"].iloc[0], check_names=False)
 
     # PFC must be sorted as the current sort order will result in different rows being the first per ingest
     df_dict["ProjectFinanceChange"] = df_dict["ProjectFinanceChange"].sort_values(by="InterventionThemeMovedFrom")
@@ -371,7 +373,9 @@ def test_multiple_rounds_multiple_funds_end_to_end(
         },
         name=0,
     )
-    assert_series_equal(project_finance_change_expected_first_row, df_dict["ProjectFinanceChange"].iloc[0])
+    assert_series_equal(
+        project_finance_change_expected_first_row, df_dict["ProjectFinanceChange"].iloc[0], check_names=False
+    )
 
 
 def test_submit_pathfinders_for_towns_fund(

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError, EndpointConnectionError
 
 from core.db import db
 from core.db.entities import ProgrammeJunction, Project, ProjectProgress, Submission
+from core.reference_data import seed_fund_table
 
 
 @pytest.fixture(scope="function")
@@ -846,6 +847,8 @@ def test_ingest_endpoint_s3_upload_failure_db_rollback(
     """
     all_submissions = Submission.query.all()
     db.session.close()
+
+    seed_fund_table()  # the fund_dim table must be seeded before /ingest can be called
 
     mocker.patch("core.aws._S3_CLIENT.upload_fileobj", side_effect=raised_exception)
     with pytest.raises((ClientError, EndpointConnectionError)):

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -23,6 +23,7 @@ from core.controllers.load_functions import (
 from core.controllers.mappings import INGEST_MAPPINGS
 from core.db import db
 from core.db.entities import (
+    Fund,
     FundingComment,
     Organisation,
     OutcomeData,
@@ -143,7 +144,7 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     prog = Programme(
         programme_id="FHSF001",  # matches id for incoming ingest. Should be replaced along with all children
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id="FHSF",
+        fund_type_id=Fund.query.first().id,
         organisation_id=read_org.id,
     )
     db.session.add(prog)
@@ -316,13 +317,13 @@ def populate_test_data(test_client_function):
     prog1 = Programme(
         programme_id="FHSF001",  # matches id for incoming ingest. Should be replaced along with all children
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id="FHSF",
+        fund_type_id=Fund.query.first().id,
         organisation_id=read_org.id,
     )
     prog2 = Programme(
         programme_id="ZZZZZ",
         programme_name="test programme not replaced.",
-        fund_type_id="DDDD",
+        fund_type_id=Fund.query.first().id,
         organisation_id=read_org.id,
     )
     db.session.add_all((prog1, prog2))
@@ -435,6 +436,10 @@ def populate_test_data(test_client_function):
 
 
 def test_next_submission_id_existing_submissions(test_client_rollback):
+
+    fund = Fund(fund_type_id="HS")
+    db.session.add(fund)
+
     organisation = Organisation(
         organisation_name="Some new Org",
         geography="Mars",
@@ -469,19 +474,19 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
     prog1 = Programme(
         programme_id="HS-ROW",
         programme_name="TEST-PROGRAMME-NAME1",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
     prog2 = Programme(
         programme_id="HS-RDD",
         programme_name="TEST-PROGRAMME-NAME2",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
     prog3 = Programme(
         programme_id="HS-AAA",
         programme_name="TEST-PROGRAMME-NAME3",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
 
@@ -507,6 +512,9 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
 
 
 def test_next_submission_id_more_digits(test_client_rollback):
+    fund = Fund(fund_type_id="HS")
+    db.session.add(fund)
+
     sub1 = Submission(
         submission_id="S-R01-100",
         submission_date=datetime(2023, 5, 1),
@@ -541,21 +549,21 @@ def test_next_submission_id_more_digits(test_client_rollback):
     prog1 = Programme(
         programme_id="HS-ROW",
         programme_name="TEST-PROGRAMME-NAME1",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
 
     prog2 = Programme(
         programme_id="HS-RDD",
         programme_name="TEST-PROGRAMME-NAME2",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
 
     prog3 = Programme(
         programme_id="HS-AAA",
         programme_name="TEST-PROGRAMME-NAME3",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
 
@@ -586,6 +594,8 @@ def test_next_submission_numpy_type(test_client_rollback):
 
     NB, this test not appropriate if app used with SQLlite, as that can parse numpy types. Intended for PostgreSQL.
     """
+    fund = Fund(fund_type_id="HS")
+    db.session.add(fund)
     org = Organisation(
         organisation_name="test",
     )
@@ -601,7 +611,7 @@ def test_next_submission_numpy_type(test_client_rollback):
     prog = Programme(
         programme_id="HS-ROW",
         programme_name="TEST-PROGRAMME-NAME1",
-        fund_type_id="HS",
+        fund_type_id=Fund.query.first().id,
         organisation_id=Organisation.query.first().id,
     )
     db.session.add_all((sub, prog))
@@ -625,7 +635,7 @@ def test_remove_unreferenced_org(test_client_reset):
     prog = Programme(
         programme_id="FHSF001",
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id="FHSF",
+        fund_type_id=Fund.query.first().id,
         organisation_id=read_org.id,
     )
     db.session.add(prog)

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -141,10 +141,11 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     )
     db.session.add(organisation)
     read_org = Organisation.query.first()
+    hs_fund_id = Fund.query.filter_by(fund_code="HS").first().id
     prog = Programme(
         programme_id="FHSF001",  # matches id for incoming ingest. Should be replaced along with all children
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id=Fund.query.first().id,
+        fund_type_id=hs_fund_id,
         organisation_id=read_org.id,
     )
     db.session.add(prog)
@@ -314,16 +315,18 @@ def populate_test_data(test_client_function):
     db.session.add(organisation)
     read_org = Organisation.query.first()
 
+    hs_fund_id = Fund.query.filter_by(fund_code="HS").first().id
+
     prog1 = Programme(
         programme_id="FHSF001",  # matches id for incoming ingest. Should be replaced along with all children
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id=Fund.query.first().id,
+        fund_type_id=hs_fund_id,
         organisation_id=read_org.id,
     )
     prog2 = Programme(
         programme_id="ZZZZZ",
         programme_name="test programme not replaced.",
-        fund_type_id=Fund.query.first().id,
+        fund_type_id=hs_fund_id,
         organisation_id=read_org.id,
     )
     db.session.add_all((prog1, prog2))
@@ -436,8 +439,7 @@ def populate_test_data(test_client_function):
 
 
 def test_next_submission_id_existing_submissions(test_client_rollback):
-
-    fund = Fund(fund_type_id="HS")
+    fund = Fund(fund_code="HS")
     db.session.add(fund)
 
     organisation = Organisation(
@@ -512,7 +514,7 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
 
 
 def test_next_submission_id_more_digits(test_client_rollback):
-    fund = Fund(fund_type_id="HS")
+    fund = Fund(fund_code="HS")
     db.session.add(fund)
 
     sub1 = Submission(
@@ -594,7 +596,7 @@ def test_next_submission_numpy_type(test_client_rollback):
 
     NB, this test not appropriate if app used with SQLlite, as that can parse numpy types. Intended for PostgreSQL.
     """
-    fund = Fund(fund_type_id="HS")
+    fund = Fund(fund_code="HS")
     db.session.add(fund)
     org = Organisation(
         organisation_name="test",
@@ -626,6 +628,7 @@ def test_next_submission_numpy_type(test_client_rollback):
 
 
 def test_remove_unreferenced_org(test_client_reset):
+    hs_fund_id = Fund.query.filter_by(fund_code="HS").first().id
     organisation_1 = Organisation(
         organisation_name="Some new Org",
         geography="Mars",
@@ -635,7 +638,7 @@ def test_remove_unreferenced_org(test_client_reset):
     prog = Programme(
         programme_id="FHSF001",
         programme_name="I should get replaced in an upsert, but my old children (R1) still ref me.",
-        fund_type_id=Fund.query.first().id,
+        fund_type_id=hs_fund_id,
         organisation_id=read_org.id,
     )
     db.session.add(prog)

--- a/tests/resources/fund_dim.csv
+++ b/tests/resources/fund_dim.csv
@@ -1,4 +1,4 @@
-id,fund_type_id
+id,fund_code
 9fde58b2-8a89-4b2c-af7d-1f968b03c7b9,TD
 4a6e9f7d-fc9d-4c12-b1b6-89e784c310e1,HS
 e8c7c1c8-90d3-4b2d-aa50-4a2d4091d4f3,PF

--- a/tests/resources/fund_dim.csv
+++ b/tests/resources/fund_dim.csv
@@ -1,0 +1,4 @@
+id,fund_type_id
+9fde58b2-8a89-4b2c-af7d-1f968b03c7b9,TD
+4a6e9f7d-fc9d-4c12-b1b6-89e784c310e1,HS
+e8c7c1c8-90d3-4b2d-aa50-4a2d4091d4f3,PF

--- a/tests/resources/programme_dim.csv
+++ b/tests/resources/programme_dim.csv
@@ -1,2 +1,2 @@
 id,organisation_id,programme_id,programme_name,fund_type_id
-11179d84-e53e-41d0-afa8-54b3b8fe12d4,0f0fc549-80ca-4868-a115-ede076023076,FHSF001,Leaky Cauldron regeneration,HS
+11179d84-e53e-41d0-afa8-54b3b8fe12d4,0f0fc549-80ca-4868-a115-ede076023076,FHSF001,Leaky Cauldron regeneration,4a6e9f7d-fc9d-4c12-b1b6-89e784c310e1

--- a/tests/serialisation_tests/conftest.py
+++ b/tests/serialisation_tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from core.const import GeographyIndicatorEnum
 from core.db import db
 from core.db.entities import (
+    Fund,
     Organisation,
     OutcomeData,
     OutcomeDim,
@@ -31,7 +32,7 @@ def non_transport_outcome_data(seeded_test_client):
     programme_no_transport_outcome_or_transport_child_projects = Programme(
         programme_id="TEST-PROGRAMME-ID3",
         programme_name="TEST-PROGRAMME-NAME3",
-        fund_type_id="TEST3",
+        fund_type_id=Fund.query.first().id,
         organisation_id=organisation.id,
     )
     db.session.add(programme_no_transport_outcome_or_transport_child_projects)

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -581,7 +581,7 @@ def test_outcomes_with_non_outcome_filters(seeded_test_client, additional_test_d
     fund = additional_test_data["fund"]
     organisation_uuids = [organisation.id]
     itl_regions = {ITLRegion.SouthWest}
-    fund_type_ids = [fund.fund_type_id]
+    fund_type_ids = [fund.fund_code]
 
     base_query = download_data_base_query(
         fund_type_ids=fund_type_ids, itl_regions=itl_regions, organisation_uuids=organisation_uuids

--- a/tests/serialisation_tests/test_serialisation.py
+++ b/tests/serialisation_tests/test_serialisation.py
@@ -578,10 +578,10 @@ def test_outcomes_with_non_outcome_filters(seeded_test_client, additional_test_d
     """Specifically testing the OutcomeData joins when filters applied to OTHER tables."""
 
     organisation = additional_test_data["organisation"]
-    programme = additional_test_data["programme"]
+    fund = additional_test_data["fund"]
     organisation_uuids = [organisation.id]
     itl_regions = {ITLRegion.SouthWest}
-    fund_type_ids = [programme.fund_type_id]
+    fund_type_ids = [fund.fund_type_id]
 
     base_query = download_data_base_query(
         fund_type_ids=fund_type_ids, itl_regions=itl_regions, organisation_uuids=organisation_uuids


### PR DESCRIPTION
Adds a table, ```fund_dim```, which contains reference data relating to fund-specific metadata.

Changes ```fund_type_id``` in ```programme_dim``` to be an FK pointing to said table.


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
