### PR TITLE
Allow turning on SQL logging

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -12,3 +12,4 @@ class DevelopmentConfig(DefaultConfig):
     AWS_SECRET_ACCESS_KEY = getenv("AWS_SECRET_ACCESS_KEY")
     AWS_ENDPOINT_OVERRIDE = getenv("AWS_ENDPOINT_OVERRIDE")
     AWS_CONFIG = Config(retries={"max_attempts": 1, "mode": "standard"})
+    SQLALCHEMY_ECHO = getenv("SQLALCHEMY_ECHO", "false") in {"true", "yes", "1"}


### PR DESCRIPTION
SQLAlchemy has a simple config option that enables logging of all queries send to the DB. By adding this to dev config we can make it easy (easier) to turn on in local.