### PR TITLE
SMD-819 - Pathfinders - current underspend cross-table validation

### DIFF
--- a/core/table_configs/pathfinders/round_1.py
+++ b/core/table_configs/pathfinders/round_1.py
@@ -110,6 +110,7 @@ class PFErrors:
     UOM_NOT_ALLOWED = "Unit of measurement '{unit_of_measurement}' is not allowed for this output or outcome."
     CREDIBLE_PLAN_YES = "If you have selected 'Yes' for 'Credible Plan', you must answer Q2, Q3 and Q4."
     CREDIBLE_PLAN_NO = "If you have selected 'No' for 'Credible Plan', Q2, Q3 and Q4 must be left blank."
+    CURRENT_UNDERSPEND = "Current underspend must be filled in if the reporting period is not Q4."
     INTERVENTION_THEME_NOT_ALLOWED = "Intervention theme '{intervention_theme}' is not allowed."
     ACTUAL_REPORTING_PERIOD = (
         "Reporting period must not be in the future if 'Actual, forecast or cancelled' is 'Actual'."


### PR DESCRIPTION
### Ticket

[Validation on ingest for PF current underspend question](https://dluhcdigital.atlassian.net/browse/SMD-819)

### Change summary
- [A separate PR](https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/559) makes current underspend optional (nullable), allowing users to leave this field blank, which is fine as we are currently in Q4 (quarter 4)
- Outside of Q4 we want to validate that current underspend has been entered
- This requires cross-table validation as we need to check reporting period alongside current underspend
- This PR adds that cross-table validation check