### PR TITLE
SMD-823 - Re-scope PF mock data fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -521,7 +521,7 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
     db.session.commit()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def mock_df_dict() -> dict[str, pd.DataFrame]:
     return get_extracted_data()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ from core.db.entities import (
 )
 from core.reference_data import seed_fund_table
 from core.util import load_example_data
-from tests.resources.extracted_data import EXTRACTED_TABLES
+from tests.resources.extracted_data import get_extracted_data
 
 
 @pytest.fixture(scope="session")
@@ -523,7 +523,7 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
 
 @pytest.fixture(scope="module")
 def mock_df_dict() -> dict[str, pd.DataFrame]:
-    return EXTRACTED_TABLES
+    return get_extracted_data()
 
 
 @pytest.fixture(scope="function")

--- a/tests/resources/extracted_data.py
+++ b/tests/resources/extracted_data.py
@@ -1,307 +1,268 @@
 import pandas as pd
 
-REPORTING_PERIOD = pd.DataFrame({"Reporting period": ["Q4 2023/24: Jan 2024 - Mar 2024"]})
 
-FINANCIAL_COMPLETION_DATE = pd.DataFrame({"Financial completion date": [pd.Timestamp("2001-01-01")]})
-
-PRACTICAL_COMPLETION_DATE = pd.DataFrame({"Practical completion date": [pd.Timestamp("2001-01-01")]})
-
-ORGANISATION_NAME = pd.DataFrame({"Organisation name": ["Bolton Council"]})
-
-CONTACT_NAME = pd.DataFrame({"Contact name": ["Steve Jobs"]})
-
-CONTACT_EMAIL_ADDRESS = pd.DataFrame({"Contact email": ["testing@test.gov.uk"]})
-
-CONTACT_TELEPHONE = pd.DataFrame({"Contact telephone": [pd.NA]})
-
-PORTFOLIO_PROGRESS = pd.DataFrame({"Portfolio progress": ["word word word word word"]})
-
-PROJECT_PROGRESS = pd.DataFrame(
-    {
-        "Project name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
-        "Spend RAG rating": ["Amber/Green", "Green"],
-        "Delivery RAG rating": ["Green", "Amber"],
-        "Why have you given these ratings? Enter an explanation (100 words max)": [
-            "No comment",
-            "Wouldn't you like to know",
-        ],
+def get_extracted_data():
+    reporting_period = pd.DataFrame({"Reporting period": ["Q4 2023/24: Jan 2024 - Mar 2024"]})
+    financial_completion_date = pd.DataFrame({"Financial completion date": [pd.Timestamp("2001-01-01")]})
+    practical_completion_date = pd.DataFrame({"Practical completion date": [pd.Timestamp("2001-01-01")]})
+    organisation_name = pd.DataFrame({"Organisation name": ["Bolton Council"]})
+    contact_name = pd.DataFrame({"Contact name": ["Steve Jobs"]})
+    contact_email_address = pd.DataFrame({"Contact email": ["testing@test.gov.uk"]})
+    contact_telephone = pd.DataFrame({"Contact telephone": [pd.NA]})
+    portfolio_progress = pd.DataFrame({"Portfolio progress": ["word word word word word"]})
+    project_progress = pd.DataFrame(
+        {
+            "Project name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
+            "Spend RAG rating": ["Amber/Green", "Green"],
+            "Delivery RAG rating": ["Green", "Amber"],
+            "Why have you given these ratings? Enter an explanation (100 words max)": [
+                "No comment",
+                "Wouldn't you like to know",
+            ],
+        }
+    )
+    big_issues_across_portfolio = pd.DataFrame({"Big issues across portfolio": ["some big issues"]})
+    upcoming_significant_milestones = pd.DataFrame({"Upcoming significant milestones": ["some milestones"]})
+    project_location = pd.DataFrame(
+        {
+            "Project name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
+            "Project full postcode/postcodes (for example, AB1D 2EF)": ["BL1 1SE", "BL1 1TJ, BL1 1TQ"],
+        }
+    )
+    outputs = pd.DataFrame(
+        {
+            "Intervention theme": ["Enhancing subregional and regional connectivity"],
+            "Output": ["Total length of pedestrian paths improved"],
+            "Unit of measurement": ["km"],
+            "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0],
+            "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0],
+            "April 2026 and after, Total": [1.0],
+        }
+    )
+    bespoke_outputs = pd.DataFrame(
+        {
+            "Intervention theme": ["Bespoke"],
+            "Output": ["Potential entrepreneurs assisted"],
+            "Unit of measurement": ["n of"],
+            "Financial year 2023 to 2024, (Jan to Mar), Actual": [5.0],
+            "Financial year 2024 to 2025, (Apr to Jun), Forecast": [5.0],
+            "Financial year 2024 to 2025, (Jul to Sep), Forecast": [5.0],
+            "Financial year 2024 to 2025, (Oct to Dec), Forecast": [5.0],
+            "Financial year 2024 to 2025, (Jan to Mar), Forecast": [5.0],
+            "Financial year 2025 to 2026, (Apr to Jun), Forecast": [5.0],
+            "Financial year 2025 to 2026, (Jul to Sep), Forecast": [5.0],
+            "Financial year 2025 to 2026, (Oct to Dec), Forecast": [5.0],
+            "Financial year 2025 to 2026, (Jan to Mar), Forecast": [5.0],
+            "April 2026 and after, Total": [5.0],
+        }
+    )
+    outcomes = pd.DataFrame(
+        {
+            "Intervention theme": ["Enhancing subregional and regional connectivity"],
+            "Outcome": ["Vehicle flow"],
+            "Unit of measurement": ["n of"],
+            "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0],
+            "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0],
+            "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0],
+            "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0],
+            "April 2026 and after, Total": [1.0],
+        }
+    )
+    bespoke_outcomes = pd.DataFrame(
+        {
+            "Intervention theme": [],
+            "Outcome": [],
+            "Unit of measurement": [],
+            "Financial year 2023 to 2024, (Jan to Mar), Actual": [],
+            "Financial year 2024 to 2025, (Apr to Jun), Forecast": [],
+            "Financial year 2024 to 2025, (Jul to Sep), Forecast": [],
+            "Financial year 2024 to 2025, (Oct to Dec), Forecast": [],
+            "Financial year 2024 to 2025, (Jan to Mar), Forecast": [],
+            "Financial year 2025 to 2026, (Apr to Jun), Forecast": [],
+            "Financial year 2025 to 2026, (Jul to Sep), Forecast": [],
+            "Financial year 2025 to 2026, (Oct to Dec), Forecast": [],
+            "Financial year 2025 to 2026, (Jan to Mar), Forecast": [],
+            "April 2026 and after, Total": [],
+        }
+    )
+    risks = pd.DataFrame(
+        {
+            "Risk name": ["A risk"],
+            "Category": ["Strategy risks"],
+            "Description": ["a description"],
+            "Pre-mitigated likelihood score": ["3 - medium"],
+            "Pre-mitigated impact score": ["1 - very low"],
+            "Mitigations": ["some mitigations"],
+            "Post-mitigated likelihood score": ["1 - very low"],
+            "Post-mitigated impact score": ["1 - very low"],
+        }
+    )
+    credible_plan = pd.DataFrame({"Credible plan": ["Yes"]})
+    total_underspend = pd.DataFrame({"Total underspend": [0.0]})
+    proposed_underspend_use = pd.DataFrame({"Proposed underspend use": [0.0]})
+    credible_plan_summary = pd.DataFrame({"Credible plan summary": ["This is a summary"]})
+    current_underspend = pd.DataFrame({"Current underspend": [0.0]})
+    forecast_and_actual_spend = pd.DataFrame(
+        {
+            "Type of spend": [
+                "How much of your forecast is contractually committed?",
+                "How much of your forecast is not contractually committed?",
+                "Freedom and flexibilities spend",
+                "Secured match funding spend",
+                "Unsecured match funding",
+            ],
+            "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+            "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
+        }
+    )
+    uncommitted_funding_plan = pd.DataFrame({"Uncommitted funding plan": [pd.NA]})
+    summary_of_changes_below_change_request_threshold = pd.DataFrame(
+        {"Summary of changes below change request threshold": [pd.NA]}
+    )
+    project_finance_changes = pd.DataFrame(
+        {
+            "Change number": [1],
+            "Project funding moved from": ["PF-BOL-001: Wellsprings Innovation Hub"],
+            "Intervention theme moved from": ["Enhancing subregional and regional connectivity"],
+            "Project funding moved to": ["PF-BOL-001: Wellsprings Innovation Hub"],
+            "Intervention theme moved to": ["Strengthening the visitor and local service economy"],
+            "Amount moved": [100.32],
+            "What changes have you made / or are planning to make? (100 words max)": ["change"],
+            "Reason for change (100 words max)": ["reason"],
+            "Actual, forecast or cancelled": ["Actual"],
+            "Reporting period change takes place": ["Q4 2023/24: Jan 2024 - Mar 2024"],
+        }
+    )
+    signatory_name = pd.DataFrame({"Signatory name": ["Graham Bell"]})
+    signatory_role = pd.DataFrame({"Signatory role": ["Project Manager"]})
+    signature_date = pd.DataFrame({"Signature date": [pd.Timestamp("2024-03-05")]})
+    extracted_user_tables = {
+        "Reporting period": reporting_period,
+        "Financial completion date": financial_completion_date,
+        "Practical completion date": practical_completion_date,
+        "Organisation name": organisation_name,
+        "Contact name": contact_name,
+        "Contact email": contact_email_address,
+        "Contact telephone": contact_telephone,
+        "Portfolio progress": portfolio_progress,
+        "Project progress": project_progress,
+        "Big issues across portfolio": big_issues_across_portfolio,
+        "Upcoming significant milestones": upcoming_significant_milestones,
+        "Project location": project_location,
+        "Outputs": outputs,
+        "Bespoke outputs": bespoke_outputs,
+        "Outcomes": outcomes,
+        "Bespoke outcomes": bespoke_outcomes,
+        "Risks": risks,
+        "Credible plan": credible_plan,
+        "Total underspend": total_underspend,
+        "Proposed underspend use": proposed_underspend_use,
+        "Credible plan summary": credible_plan_summary,
+        "Current underspend": current_underspend,
+        "Forecast and actual spend": forecast_and_actual_spend,
+        "Uncommitted funding plan": uncommitted_funding_plan,
+        "Summary of changes below change request threshold": summary_of_changes_below_change_request_threshold,
+        "Project finance changes": project_finance_changes,
+        "Signatory name": signatory_name,
+        "Signatory role": signatory_role,
+        "Signature date": signature_date,
     }
-)
-
-BIG_ISSUES_ACROSS_PORTFOLIO = pd.DataFrame({"Big issues across portfolio": ["some big issues"]})
-
-UPCOMING_SIGNIFICANT_MILESTONES = pd.DataFrame({"Upcoming significant milestones": ["some milestones"]})
-
-PROJECT_LOCATION = pd.DataFrame(
-    {
-        "Project name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
-        "Project full postcode/postcodes (for example, AB1D 2EF)": ["BL1 1SE", "BL1 1TJ, BL1 1TQ"],
+    project_details_control = pd.DataFrame(
+        {
+            "Local Authority": ["Bolton Council", "Bolton Council"],
+            "Reference": ["PF-BOL-001", "PF-BOL-002"],
+            "Project name": ["Wellsprings Innovation Hub", "Bolton Market Upgrades"],
+            "Status": ["Active", "Active"],
+            "Full name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
+        }
+    )
+    standard_outputs_control = pd.DataFrame(
+        {
+            "Standard output": [
+                "Amount of existing parks/greenspace/outdoor improved",
+                "Total length of pedestrian paths improved",
+            ],
+            "UoM": [
+                "sqm",
+                "km",
+            ],
+            "Intervention theme": [
+                "Improving the quality of life of residents",
+                "Enhancing sub-regional and regional connectivity",
+            ],
+        }
+    )
+    standard_outcomes_control = pd.DataFrame(
+        {
+            "Standard outcome": [
+                "Audience numbers for cultural events",
+                "Vehicle flow",
+            ],
+            "UoM": [
+                "n of",
+                "n of",
+            ],
+            "Intervention theme": [
+                "Strengthening the visitor and local service economy",
+                "Enhancing sub-regional and regional connectivity",
+            ],
+        }
+    )
+    bespoke_outputs_control = pd.DataFrame(
+        {
+            "Local Authority": ["Bolton Council", "Bolton Council"],
+            "Output": ["Amount of new office space (m2)", "Potential entrepreneurs assisted"],
+            "UoM": ["sqm", "n of"],
+            "Intervention theme": ["Bespoke", "Bespoke"],
+        }
+    )
+    bespoke_outcomes_control = pd.DataFrame(
+        {
+            "Local Authority": ["Bolton Council"],
+            "Outcome": ["Travel times in corridors of interest"],
+            "UoM": ["%"],
+            "Intervention theme": ["Bespoke"],
+        }
+    )
+    intervention_themes_control = pd.DataFrame(
+        {
+            "Intervention theme": [
+                "Enhancing subregional and regional connectivity",
+                "Strengthening the visitor and local service economy",
+                "Improving the quality of life of residents",
+                "Unlocking and enabling industrial, commercial, and residential development",
+            ]
+        }
+    )
+    extracted_control_tables = {
+        "Project details control": project_details_control,
+        "Outputs control": standard_outputs_control,
+        "Outcomes control": standard_outcomes_control,
+        "Bespoke outputs control": bespoke_outputs_control,
+        "Bespoke outcomes control": bespoke_outcomes_control,
+        "Intervention themes control": intervention_themes_control,
     }
-)
-
-OUTPUTS = pd.DataFrame(
-    {
-        "Intervention theme": ["Enhancing subregional and regional connectivity"],
-        "Output": ["Total length of pedestrian paths improved"],
-        "Unit of measurement": ["km"],
-        "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0],
-        "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0],
-        "April 2026 and after, Total": [1.0],
+    extracted_tables = {
+        **extracted_user_tables,
+        **extracted_control_tables,
     }
-)
-
-# SHOULD THIS BE AMOUNT OF NEW OFFICE SPACE? SPREADSHEET HAS POTENTIAL ENTREPRENEURS, BUT MAPPINGS/MOCK DF HAS DIFFERENT
-BESPOKE_OUTPUTS = pd.DataFrame(
-    {
-        "Intervention theme": ["Bespoke"],
-        "Output": ["Potential entrepreneurs assisted"],
-        "Unit of measurement": ["n of"],
-        "Financial year 2023 to 2024, (Jan to Mar), Actual": [5.0],
-        "Financial year 2024 to 2025, (Apr to Jun), Forecast": [5.0],
-        "Financial year 2024 to 2025, (Jul to Sep), Forecast": [5.0],
-        "Financial year 2024 to 2025, (Oct to Dec), Forecast": [5.0],
-        "Financial year 2024 to 2025, (Jan to Mar), Forecast": [5.0],
-        "Financial year 2025 to 2026, (Apr to Jun), Forecast": [5.0],
-        "Financial year 2025 to 2026, (Jul to Sep), Forecast": [5.0],
-        "Financial year 2025 to 2026, (Oct to Dec), Forecast": [5.0],
-        "Financial year 2025 to 2026, (Jan to Mar), Forecast": [5.0],
-        "April 2026 and after, Total": [5.0],
-    }
-)
-
-OUTCOMES = pd.DataFrame(
-    {
-        "Intervention theme": ["Enhancing subregional and regional connectivity"],
-        "Outcome": ["Vehicle flow"],
-        "Unit of measurement": ["n of"],
-        "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0],
-        "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0],
-        "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0],
-        "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0],
-        "April 2026 and after, Total": [1.0],
-    }
-)
-
-BESPOKE_OUTCOMES = pd.DataFrame(
-    {
-        "Intervention theme": [],
-        "Outcome": [],
-        "Unit of measurement": [],
-        "Financial year 2023 to 2024, (Jan to Mar), Actual": [],
-        "Financial year 2024 to 2025, (Apr to Jun), Forecast": [],
-        "Financial year 2024 to 2025, (Jul to Sep), Forecast": [],
-        "Financial year 2024 to 2025, (Oct to Dec), Forecast": [],
-        "Financial year 2024 to 2025, (Jan to Mar), Forecast": [],
-        "Financial year 2025 to 2026, (Apr to Jun), Forecast": [],
-        "Financial year 2025 to 2026, (Jul to Sep), Forecast": [],
-        "Financial year 2025 to 2026, (Oct to Dec), Forecast": [],
-        "Financial year 2025 to 2026, (Jan to Mar), Forecast": [],
-        "April 2026 and after, Total": [],
-    }
-)
-
-RISKS = pd.DataFrame(
-    {
-        "Risk name": ["A risk"],
-        "Category": ["Strategy risks"],
-        "Description": ["a description"],
-        "Pre-mitigated likelihood score": ["3 - medium"],
-        "Pre-mitigated impact score": ["1 - very low"],
-        "Mitigations": ["some mitigations"],
-        "Post-mitigated likelihood score": ["1 - very low"],
-        "Post-mitigated impact score": ["1 - very low"],
-    }
-)
-
-CREDIBLE_PLAN = pd.DataFrame({"Credible plan": ["Yes"]})
-
-TOTAL_UNDERSPEND = pd.DataFrame({"Total underspend": [0.0]})
-
-PROPOSED_UNDERSPEND_USE = pd.DataFrame({"Proposed underspend use": [0.0]})
-
-CREDIBLE_PLAN_SUMMARY = pd.DataFrame({"Credible plan summary": ["This is a summary"]})
-
-CURRENT_UNDERSPEND = pd.DataFrame({"Current underspend": [0.0]})
-
-FORECAST_AND_ACTUAL_SPEND = pd.DataFrame(
-    {
-        "Type of spend": [
-            "How much of your forecast is contractually committed?",
-            "How much of your forecast is not contractually committed?",
-            "Freedom and flexibilities spend",
-            "Secured match funding spend",
-            "Unsecured match funding",
-        ],
-        "Financial year 2023 to 2024, (Jan to Mar), Actual": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2024 to 2025, (Apr to Jun), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2024 to 2025, (Jul to Sep), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2024 to 2025, (Oct to Dec), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2024 to 2025, (Jan to Mar), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2025 to 2026, (Apr to Jun), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2025 to 2026, (Jul to Sep), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2025 to 2026, (Oct to Dec), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-        "Financial year 2025 to 2026, (Jan to Mar), Forecast": [1.0, 0.0, 0.0, 0.0, 0.0],
-    }
-)
-
-UNCOMMITTED_FUNDING_PLAN = pd.DataFrame({"Uncommitted funding plan": [pd.NA]})
-
-SUMMARY_OF_CHANGES_BELOW_CHANGE_REQUEST_THRESHOLD = pd.DataFrame(
-    {"Summary of changes below change request threshold": [pd.NA]}
-)
-
-PROJECT_FINANCE_CHANGES = pd.DataFrame(
-    {
-        "Change number": [1],
-        "Project funding moved from": ["PF-BOL-001: Wellsprings Innovation Hub"],
-        "Intervention theme moved from": ["Enhancing subregional and regional connectivity"],
-        "Project funding moved to": ["PF-BOL-001: Wellsprings Innovation Hub"],
-        "Intervention theme moved to": ["Strengthening the visitor and local service economy"],
-        "Amount moved": [100.32],
-        "What changes have you made / or are planning to make? (100 words max)": ["change"],
-        "Reason for change (100 words max)": ["reason"],
-        "Actual, forecast or cancelled": ["Actual"],
-        "Reporting period change takes place": ["Q4 2023/24: Jan 2024 - Mar 2024"],
-    }
-)
-
-SIGNATORY_NAME = pd.DataFrame({"Signatory name": ["Graham Bell"]})
-
-SIGNATORY_ROLE = pd.DataFrame({"Signatory role": ["Project Manager"]})
-
-SIGNATURE_DATE = pd.DataFrame({"Signature date": [pd.Timestamp("2024-03-05")]})
-
-EXTRACTED_USER_TABLES = {
-    "Reporting period": REPORTING_PERIOD,
-    "Financial completion date": FINANCIAL_COMPLETION_DATE,
-    "Practical completion date": PRACTICAL_COMPLETION_DATE,
-    "Organisation name": ORGANISATION_NAME,
-    "Contact name": CONTACT_NAME,
-    "Contact email": CONTACT_EMAIL_ADDRESS,
-    "Contact telephone": CONTACT_TELEPHONE,
-    "Portfolio progress": PORTFOLIO_PROGRESS,
-    "Project progress": PROJECT_PROGRESS,
-    "Big issues across portfolio": BIG_ISSUES_ACROSS_PORTFOLIO,
-    "Upcoming significant milestones": UPCOMING_SIGNIFICANT_MILESTONES,
-    "Project location": PROJECT_LOCATION,
-    "Outputs": OUTPUTS,
-    "Bespoke outputs": BESPOKE_OUTPUTS,
-    "Outcomes": OUTCOMES,
-    "Bespoke outcomes": BESPOKE_OUTCOMES,
-    "Risks": RISKS,
-    "Credible plan": CREDIBLE_PLAN,
-    "Total underspend": TOTAL_UNDERSPEND,
-    "Proposed underspend use": PROPOSED_UNDERSPEND_USE,
-    "Credible plan summary": CREDIBLE_PLAN_SUMMARY,
-    "Current underspend": CURRENT_UNDERSPEND,
-    "Forecast and actual spend": FORECAST_AND_ACTUAL_SPEND,
-    "Uncommitted funding plan": UNCOMMITTED_FUNDING_PLAN,
-    "Summary of changes below change request threshold": SUMMARY_OF_CHANGES_BELOW_CHANGE_REQUEST_THRESHOLD,
-    "Project finance changes": PROJECT_FINANCE_CHANGES,
-    "Signatory name": SIGNATORY_NAME,
-    "Signatory role": SIGNATORY_ROLE,
-    "Signature date": SIGNATURE_DATE,
-}
-
-PROJECT_DETAILS_CONTROL = pd.DataFrame(
-    {
-        "Local Authority": ["Bolton Council", "Bolton Council"],
-        "Reference": ["PF-BOL-001", "PF-BOL-002"],
-        "Project name": ["Wellsprings Innovation Hub", "Bolton Market Upgrades"],
-        "Status": ["Active", "Active"],
-        "Full name": ["PF-BOL-001: Wellsprings Innovation Hub", "PF-BOL-002: Bolton Market Upgrades"],
-    }
-)
-
-STANDARD_OUTPUTS_CONTROL = pd.DataFrame(
-    {
-        "Standard output": [
-            "Amount of existing parks/greenspace/outdoor improved",
-            "Total length of pedestrian paths improved",
-        ],
-        "UoM": [
-            "sqm",
-            "km",
-        ],
-        "Intervention theme": [
-            "Improving the quality of life of residents",
-            "Enhancing sub-regional and regional connectivity",
-        ],
-    }
-)
-
-STANDARD_OUTCOMES_CONTROL = pd.DataFrame(
-    {
-        "Standard outcome": [
-            "Audience numbers for cultural events",
-            "Vehicle flow",
-        ],
-        "UoM": [
-            "n of",
-            "n of",
-        ],
-        "Intervention theme": [
-            "Strengthening the visitor and local service economy",
-            "Enhancing sub-regional and regional connectivity",
-        ],
-    }
-)
-
-
-BESPOKE_OUTPUTS_CONTROL = pd.DataFrame(
-    {
-        "Local Authority": ["Bolton Council", "Bolton Council"],
-        "Output": ["Amount of new office space (m2)", "Potential entrepreneurs assisted"],
-        "UoM": ["sqm", "n of"],
-        "Intervention theme": ["Bespoke", "Bespoke"],
-    }
-)
-
-BESPOKE_OUTCOMES_CONTROL = pd.DataFrame(
-    {
-        "Local Authority": ["Bolton Council"],
-        "Outcome": ["Travel times in corridors of interest"],
-        "UoM": ["%"],
-        "Intervention theme": ["Bespoke"],
-    }
-)
-
-
-INTERVENTION_THEMES_CONTROL = pd.DataFrame(
-    {
-        "Intervention theme": [
-            "Enhancing subregional and regional connectivity",
-            "Strengthening the visitor and local service economy",
-            "Improving the quality of life of residents",
-            "Unlocking and enabling industrial, commercial, and residential development",
-        ]
-    }
-)
-
-
-EXTRACTED_CONTROL_TABLES = {
-    "Project details control": PROJECT_DETAILS_CONTROL,
-    "Outputs control": STANDARD_OUTPUTS_CONTROL,
-    "Outcomes control": STANDARD_OUTCOMES_CONTROL,
-    "Bespoke outputs control": BESPOKE_OUTPUTS_CONTROL,
-    "Bespoke outcomes control": BESPOKE_OUTCOMES_CONTROL,
-    "Intervention themes control": INTERVENTION_THEMES_CONTROL,
-}
-
-
-EXTRACTED_TABLES = {
-    **EXTRACTED_USER_TABLES,
-    **EXTRACTED_CONTROL_TABLES,
-}
+    return extracted_tables

--- a/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
+++ b/tests/validation_tests/specific_validation_tests/pathfinders/test_round_1.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from unittest.mock import patch
 
 import pandas as pd
@@ -72,33 +71,17 @@ def test_cross_table_validation_passes(mock_df_dict, mock_control_mappings):
 
 
 def test_cross_table_validation_fails(mock_df_dict, mock_control_mappings):
-    original_project_name = mock_df_dict["Project progress"]["Project name"][0]
-    original_outcome = mock_df_dict["Outcomes"]["Outcome"][0]
-    original_outcome_uom = mock_df_dict["Outcomes"]["Unit of measurement"][0]
-    original_output = mock_df_dict["Bespoke outputs"]["Output"][0]
-    original_underspend = mock_df_dict["Total underspend"]["Total underspend"][0]
-    original_output_uom = mock_df_dict["Outputs"]["Unit of measurement"][0]
-
     mock_df_dict["Project progress"]["Project name"][0] = "Invalid Project"
     mock_df_dict["Outcomes"]["Outcome"][0] = "Invalid Outcome"
     mock_df_dict["Outcomes"]["Unit of measurement"][0] = "Invalid Unit of Measurement"
     mock_df_dict["Bespoke outputs"]["Output"][0] = "Invalid Bespoke Output"
     mock_df_dict["Total underspend"]["Total underspend"][0] = pd.NA
     mock_df_dict["Outputs"]["Unit of measurement"][0] = "Invalid Unit of Measurement"
-
     with patch(
         "core.validation.specific_validation.pathfinders.round_1.create_control_mappings"
     ) as mock_create_control_mappings:
         mock_create_control_mappings.return_value = mock_control_mappings
         error_messages = cross_table_validation(mock_df_dict)
-
-    mock_df_dict["Project progress"]["Project name"][0] = original_project_name
-    mock_df_dict["Outcomes"]["Outcome"][0] = original_outcome
-    mock_df_dict["Outcomes"]["Unit of measurement"][0] = original_outcome_uom
-    mock_df_dict["Bespoke outputs"]["Output"][0] = original_output
-    mock_df_dict["Total underspend"]["Total underspend"][0] = original_underspend
-    mock_df_dict["Outputs"]["Unit of measurement"][0] = original_output_uom
-
     assert error_messages == [
         Message(
             sheet="Progress",
@@ -144,10 +127,8 @@ def test__check_projects_passes(mock_df_dict, mock_control_mappings):
 
 
 def test__check_projects_fails(mock_df_dict, mock_control_mappings):
-    original_project_name = mock_df_dict["Project progress"]["Project name"][0]
     mock_df_dict["Project progress"]["Project name"][0] = "Invalid Project"
     error_messages = _check_projects(mock_df_dict, mock_control_mappings)
-    mock_df_dict["Project progress"]["Project name"][0] = original_project_name
     assert error_messages == [
         Message(
             sheet="Progress",
@@ -164,10 +145,8 @@ def test__check_standard_outcomes_passes(mock_df_dict, mock_control_mappings):
 
 
 def test__check_standard_outcomes_fails(mock_df_dict, mock_control_mappings):
-    original_outcome = mock_df_dict["Outcomes"]["Outcome"][0]
     mock_df_dict["Outcomes"]["Outcome"][0] = "Invalid Outcome"
     error_messages = _check_standard_outcomes(mock_df_dict, mock_control_mappings)
-    mock_df_dict["Outcomes"]["Outcome"][0] = original_outcome
     assert error_messages == [
         Message(
             sheet="Outcomes",
@@ -185,10 +164,8 @@ def test__check_bespoke_outputs_passes(mock_df_dict, mock_control_mappings):
 
 
 def test__check_bespoke_outputs_fails(mock_df_dict, mock_control_mappings):
-    original_output = mock_df_dict["Bespoke outputs"]["Output"][0]
     mock_df_dict["Bespoke outputs"]["Output"][0] = "Invalid Bespoke Output"
     error_messages = _check_bespoke_outputs(mock_df_dict, mock_control_mappings)
-    mock_df_dict["Bespoke outputs"]["Output"][0] = original_output
     assert error_messages == [
         Message(
             sheet="Outputs",
@@ -205,10 +182,8 @@ def test__check_credible_plan_fields_passes(mock_df_dict):
 
 
 def test__check_credible_plan_fields_fails(mock_df_dict):
-    original_underspend = mock_df_dict["Total underspend"]["Total underspend"][0]
     mock_df_dict["Total underspend"]["Total underspend"][0] = pd.NA
     error_messages = _check_credible_plan_fields(mock_df_dict)
-    mock_df_dict["Total underspend"]["Total underspend"][0] = original_underspend
     assert error_messages == [
         Message(
             sheet="Finances",
@@ -229,7 +204,6 @@ def test__check_credible_plan_fields_fails(mock_df_dict):
     ],
 )
 def test__check_current_underspend_passes(mock_df_dict, reporting_period, current_underspend):
-    mock_df_dict = deepcopy(mock_df_dict)
     mock_df_dict["Reporting period"].iloc[0, 0] = reporting_period
     mock_df_dict["Current underspend"].iloc[0, 0] = current_underspend
     error_messages = _check_current_underspend(mock_df_dict)
@@ -237,8 +211,6 @@ def test__check_current_underspend_passes(mock_df_dict, reporting_period, curren
 
 
 def test__check_current_underspend_fails(mock_df_dict):
-    mock_df_dict = deepcopy(mock_df_dict)
-
     # Test case with non-Q4 reporting period and missing current underspend
     mock_df_dict["Reporting period"].iloc[0, 0] = "Q1 2024/25: Apr 2024 - Jun 2024"
     mock_df_dict["Current underspend"].iloc[0, 0] = pd.NA
@@ -263,13 +235,9 @@ def test__check_intervention_themes_in_pfcs_fails(mock_df_dict, mock_control_map
         "Strengthening the visitor and local service economy",
         "Unlocking and enabling industrial, commercial, and residential development",
     ]
-    original_moved_from = mock_df_dict["Project finance changes"]["Intervention theme moved from"][0]
-    original_moved_to = mock_df_dict["Project finance changes"]["Intervention theme moved to"][0]
     mock_df_dict["Project finance changes"]["Intervention theme moved from"][0] = "Invalid Intervention Theme"
     mock_df_dict["Project finance changes"]["Intervention theme moved to"][0] = "Another Invalid Intervention Theme"
     error_messages = _check_intervention_themes_in_pfcs(mock_df_dict, mock_control_mappings)
-    mock_df_dict["Project finance changes"]["Intervention theme moved from"][0] = original_moved_from
-    mock_df_dict["Project finance changes"]["Intervention theme moved to"][0] = original_moved_to
     assert error_messages == [
         Message(
             sheet="Finances",


### PR DESCRIPTION
### Ticket
[Re-scope Pathfinders mock data fixture](https://dluhcdigital.atlassian.net/browse/SMD-823)

### Change summary
- **Refactor PF mock data creation into function for use in function-scoped fixture**
By moving all mock data creation into a function, we ensure that when this function is called from a Pytest function-scoped fixture, fresh mock data is created rather than the fixture simply recycling a reference to existing mock data.
- **Re-scoping PF mock data fixture from module to function**
Now that mock data is generated within a function that is called by the fixture, re-scoping the fixture from module to function level will work as intended and ensure that tests that use the fixture get a fresh set of mock data, minimising unintended side effects.
- **Removing mutation reversals to PF mock data fixture**
Pathfinders mock data fixture mock_df_dict is now function-scoped and so capturing original values and resetting to these post-test is a redundant operation. This change removes all code relating to that redundancy, with the exception of test_check_actual_forecast_reporting_period, which requires refactoring with parameterisation.
- **Refactoring unit test for check_actual_forecast_reporting_period**
Split unit test into two - passes and fails; added a new pass case; parameterised; and removed redundant capturing of original values and resetting.