### PR TITLE
Start tracking reporting round on programme junction

### DIFF
--- a/core/controllers/ingest_dependencies.py
+++ b/core/controllers/ingest_dependencies.py
@@ -43,7 +43,7 @@ class IngestDependencies:
         - messenger: a Messenger class that converts failures to user messages, used by messaging/messaging.py
     """
 
-    transform_data: Callable[[dict[str, pd.DataFrame]], dict[str, pd.DataFrame]]
+    transform_data: Callable[[dict[str, pd.DataFrame], int], dict[str, pd.DataFrame]]
     validation_schema: dict
     initial_validation_schema: list[Check]
     table_to_load_function_mapping: dict[str, Callable]

--- a/core/controllers/load_functions.py
+++ b/core/controllers/load_functions.py
@@ -99,7 +99,10 @@ def load_programme_junction(transformed_data: dict[str, pd.DataFrame], mapping: 
     :param submission_id: the ID of the submission associated with the data.
     """
     programme_id = transformed_data["Programme_Ref"]["Programme ID"].iloc[0]
-    programme_junction_df = pd.DataFrame({"Submission ID": [submission_id], "Programme ID": [programme_id]})
+    reporting_round = int(transformed_data["Submission_Ref"]["Reporting Round"].iloc[0])
+    programme_junction_df = pd.DataFrame(
+        {"Submission ID": [submission_id], "Programme ID": [programme_id], "Reporting Round": [reporting_round]}
+    )
     programme_junction = mapping.map_data_to_models(programme_junction_df)
 
     db.session.add(programme_junction[0])

--- a/core/controllers/mappings.py
+++ b/core/controllers/mappings.py
@@ -167,6 +167,7 @@ INGEST_MAPPINGS = (
         column_mapping={
             "Submission ID": "submission_id",
             "Programme ID": "programme_id",
+            "Reporting Round": "reporting_round",
         },
         fk_relations=[
             ("submission_id", ents.Submission, "submission_id", "submission_id"),

--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -373,6 +373,7 @@ class ProgrammeJunction(BaseModel):
         sqla.ForeignKey("submission_dim.id", ondelete="CASCADE"), nullable=False
     )
     programme_id: Mapped[GUID] = sqla.orm.mapped_column(sqla.ForeignKey("programme_dim.id"), nullable=False)
+    reporting_round = sqla.Column(sqla.Integer, nullable=True)
 
     # parent relationships
     submission: Mapped["Submission"] = sqla.orm.relationship(back_populates="programme_junction", single_parent=True)
@@ -402,6 +403,11 @@ class ProgrammeJunction(BaseModel):
         sqla.Index(
             "ix_programme_junction_join_programme",
             "programme_id",
+        ),
+        sqla.UniqueConstraint(
+            "programme_id",
+            "reporting_round",
+            name="uq_programme_junction_unique_submission_per_round",
         ),
     )
 

--- a/db/migrations/versions/030_programme_junction_reporting.py
+++ b/db/migrations/versions/030_programme_junction_reporting.py
@@ -1,0 +1,31 @@
+"""programme junction reporting round
+
+Revision ID: 030_programme_junction_reporting
+Revises: 029_add_account_id_and_email
+Create Date: 2024-05-08 08:13:55.775613
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "030_programme_junction_reporting"
+down_revision = "029_add_account_id_and_email"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("reporting_round", sa.Integer(), nullable=True))
+        batch_op.create_unique_constraint(
+            batch_op.f("uq_programme_junction_unique_submission_per_round"),
+            ["programme_id", "reporting_round"],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("uq_programme_junction_unique_submission_per_round"), type_="unique")
+        batch_op.drop_column("reporting_round")

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -8,7 +8,7 @@ from werkzeug.datastructures import FileStorage
 
 from core.controllers.ingest import save_submission_file_name_and_user_metadata
 from core.db import db
-from core.db.entities import Programme, Submission
+from core.db.entities import Programme, ProgrammeJunction, Submission
 
 
 @pytest.fixture()
@@ -133,6 +133,16 @@ def test_ingest_pf_r1_file_success_with_tf_data_already_in(
 
     # check submission id correctly generated
     assert len(Submission.query.filter(Submission.submission_id == "S-PF-R01-1").all()) == 1
+
+    # TODO FMD-260: remove after this is enforced via DB constraint and tested elsewhere
+    assert (
+        ProgrammeJunction.query.join(Submission, Submission.id == ProgrammeJunction.submission_id)
+        .join(Programme, Programme.id == ProgrammeJunction.programme_id)
+        .filter(Submission.submission_id == "S-PF-R01-1", Programme.programme_id == "PF-BOL")
+        .one()
+        .reporting_round
+        == 1
+    )
 
 
 def test_ingest_pf_r1_file_success_with_pf_submission_already_in(

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -202,6 +202,9 @@ def test_ingest_with_r4_file_success_with_load_re_ingest(
     submission_id_first_ingest = programme_junction_rows_first_ingest[0].submission_id
     project_detail_rows_first_ingest = Project.query.all()
 
+    # TODO FMD-260: remove after this is enforced via DB constraint and tested elsewhere
+    assert programme_junction_rows_first_ingest[0].reporting_round == 4
+
     # must commit to end the pending transaction so another can begin
     db.session.commit()
 
@@ -239,6 +242,9 @@ def test_ingest_with_r4_file_success_with_load_re_ingest(
     programme_id_second_ingest = programme_junction_rows_second_ingest[0].programme_id
     submission_id_second_ingest = programme_junction_rows_second_ingest[0].submission_id
     project_detail_rows_second_ingest = Project.query.all()
+
+    # TODO FMD-260: remove after this is enforced via DB constraint and tested elsewhere
+    assert programme_junction_rows_second_ingest[0].reporting_round == 4
 
     # the number of Programmes, Submissions, and their children should be the same after re-ingest
     assert len(programme_junction_rows_first_ingest) == len(programme_junction_rows_second_ingest)


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FMD/boards/139?selectedIssue=FMD-260

### Change description
Adds a new column `reporting_round` to the `programme_junction` table,
which will eventually replace the `submission.reporting_round` column.
This patch only starts populating the data and doesn't deal with
backfilling existing nulls. That will be done in a follow-up PR.


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* Upload some spreadsheets
* Check the DB table `programme_junction` and see that the reporting round has been recorded.