### PR TITLE
Backfill `reporting_round` and make non-nullable

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -373,7 +373,7 @@ class ProgrammeJunction(BaseModel):
         sqla.ForeignKey("submission_dim.id", ondelete="CASCADE"), nullable=False
     )
     programme_id: Mapped[GUID] = sqla.orm.mapped_column(sqla.ForeignKey("programme_dim.id"), nullable=False)
-    reporting_round = sqla.Column(sqla.Integer, nullable=True)
+    reporting_round = sqla.Column(sqla.Integer, nullable=False)
 
     # parent relationships
     submission: Mapped["Submission"] = sqla.orm.relationship(back_populates="programme_junction", single_parent=True)

--- a/db/migrations/versions/031_programme_junction_2.py
+++ b/db/migrations/versions/031_programme_junction_2.py
@@ -1,0 +1,35 @@
+"""programme junction reporting round
+
+Revision ID: 031_programme_junction_2
+Revises: 030_programme_junction_reporting
+Create Date: 2024-05-08 08:13:55.775613
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "031_programme_junction_2"
+down_revision = "030_programme_junction_reporting"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE programme_junction pj
+        SET reporting_round = sd.reporting_round
+        FROM submission_dim sd
+        WHERE pj.submission_id = sd.id AND pj.reporting_round IS NULL;
+        """
+    )
+
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.alter_column("reporting_round", existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.alter_column("reporting_round", existing_type=sa.INTEGER(), nullable=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,7 @@ def additional_test_data() -> dict[str, Any]:
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
+        reporting_round=submission.reporting_round,
     )
     db.session.add(programme_junction)
     db.session.flush()
@@ -452,6 +453,7 @@ def towns_fund_bolton_round_1_test_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
+        reporting_round=submission.reporting_round,
     )
     db.session.add(programme_junction)
     db.session.commit()
@@ -484,6 +486,7 @@ def pathfinders_round_1_submission_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
+        reporting_round=submission.reporting_round,
     )
     db.session.add(programme_junction)
     db.session.commit()
@@ -516,6 +519,7 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
+        reporting_round=submission.reporting_round,
     )
     db.session.add(programme_junction)
     db.session.commit()

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -443,6 +443,7 @@ def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback,
     programme_junction_2 = ProgrammeJunction(
         programme_id=programme_2.id,
         submission_id=submission_2.id,
+        reporting_round=submission_2.reporting_round,
     )
 
     db.session.add(programme_junction_2)

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -153,6 +153,7 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     prog_junction = ProgrammeJunction(
         programme_id=read_prog.id,
         submission_id=read_sub.id,
+        reporting_round=read_sub.reporting_round,
     )
     db.session.add(prog_junction)
     read_prog_junction = ProgrammeJunction.query.first()
@@ -336,14 +337,17 @@ def populate_test_data(test_client_function):
     prog_junction_latest_persists = ProgrammeJunction(
         programme_id=read_prog_persists.id,
         submission_id=read_sub_latest.id,
+        reporting_round=read_sub_latest.reporting_round,
     )
     prog_junction_updated = ProgrammeJunction(
         submission_id=read_sub.id,
         programme_id=read_prog_updated.id,
+        reporting_round=read_sub.reporting_round,
     )
     prog_junction_old_updated = ProgrammeJunction(
         submission_id=read_sub_old.id,
         programme_id=read_prog_updated.id,
+        reporting_round=read_sub_old.reporting_round,
     )
     db.session.add_all((prog_junction_latest_persists, prog_junction_updated, prog_junction_old_updated))
     read_prog_junction_latest_persists = ProgrammeJunction.query.filter(
@@ -498,14 +502,17 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
     pj1 = ProgrammeJunction(
         programme_id=prog1.id,
         submission_id=sub1.id,
+        reporting_round=sub1.reporting_round,
     )
     pj2 = ProgrammeJunction(
         programme_id=prog2.id,
         submission_id=sub2.id,
+        reporting_round=sub2.reporting_round,
     )
     pj3 = ProgrammeJunction(
         programme_id=prog3.id,
         submission_id=sub3.id,
+        reporting_round=sub3.reporting_round,
     )
     db.session.add_all((pj1, pj2, pj3))
 
@@ -575,14 +582,17 @@ def test_next_submission_id_more_digits(test_client_rollback):
     pj1 = ProgrammeJunction(
         programme_id=prog1.id,
         submission_id=sub1.id,
+        reporting_round=sub1.reporting_round,
     )
     pj2 = ProgrammeJunction(
         programme_id=prog2.id,
         submission_id=sub2.id,
+        reporting_round=sub2.reporting_round,
     )
     pj3 = ProgrammeJunction(
         programme_id=prog3.id,
         submission_id=sub3.id,
+        reporting_round=sub3.reporting_round,
     )
     db.session.add_all((pj1, pj2, pj3))
 
@@ -621,6 +631,7 @@ def test_next_submission_numpy_type(test_client_rollback):
     pj = ProgrammeJunction(
         programme_id=prog.id,
         submission_id=sub.id,
+        reporting_round=sub.reporting_round,
     )
     db.session.add(pj)
     sub_id = next_submission_id(reporting_round=np.int64(1), fund_id="HS")

--- a/tests/resources/programme_junction.csv
+++ b/tests/resources/programme_junction.csv
@@ -1,2 +1,2 @@
-id,submission_id,programme_id
-6c934287-92d0-4b76-ae2c-95bc292c7608,97386631-d515-481b-8a79-46cc1317ea54,11179d84-e53e-41d0-afa8-54b3b8fe12d4
+id,submission_id,programme_id,reporting_round
+6c934287-92d0-4b76-ae2c-95bc292c7608,97386631-d515-481b-8a79-46cc1317ea54,11179d84-e53e-41d0-afa8-54b3b8fe12d4,3

--- a/tests/serialisation_tests/conftest.py
+++ b/tests/serialisation_tests/conftest.py
@@ -41,6 +41,7 @@ def non_transport_outcome_data(seeded_test_client):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme_no_transport_outcome_or_transport_child_projects.id,
+        reporting_round=submission.reporting_round,
     )
     db.session.add(programme_junction)
     db.session.flush()


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FMD/boards/139?selectedIssue=FMD-260


### Change description
Backfill the `programme_junction.reporting_round` column and make it non-nullable.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")