### PR TITLE
SMD-503 - Tie Pandera check functions to error messages

### DIFF
--- a/core/validation/pathfinders/cross_table_validation/ct_validate_r1.py
+++ b/core/validation/pathfinders/cross_table_validation/ct_validate_r1.py
@@ -13,8 +13,8 @@ from copy import deepcopy
 import pandas as pd
 
 from core.messaging import Message
-from core.table_extraction.config.pf_r1_config import PFErrors
 from core.transformation.pathfinders.consts import PF_REPORTING_PERIOD_TO_DATES_PFCS
+from core.validation.pathfinders.schema_validation.consts import PFErrors
 
 
 def cross_table_validation(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:

--- a/core/validation/pathfinders/schema_validation/checks.py
+++ b/core/validation/pathfinders/schema_validation/checks.py
@@ -1,21 +1,4 @@
-"""Module for custom Check methods.
-
-NOTE: using hypothesis to synthesize dataframes from Pandera schemas is extremely slow.
-
-From pandera docs https://pandera.readthedocs.io/en/stable/extensions.html#extensions
-
-One of the strengths of pandera is its flexibility in enabling you to define in-line custom checks on the fly:
-
->>> import pandera as pa
->>> # checks elements in a column/dataframe
->>> element_wise_check = pa.Check(lambda x: x < 0, element_wise=True)
->>> # applies the check function to a dataframe/series
->>> vectorized_check = pa.Check(lambda series_or_df: series_or_df < 0)
-
-However, there are two main disadvantages of schemas with inline custom checks:
-    1. they are not serializable with the IO interface.
-    2. you can’t use them to synthesize data because the checks are not associated with a hypothesis strategy.
-"""
+"""Module for custom Pandera Check methods."""
 
 import math
 import re
@@ -24,12 +7,12 @@ from typing import Any, Literal
 
 import pandas as pd
 import pandera as pa
-from pandera.extensions import CheckType
 
 from core.transformation.utils import POSTCODE_REGEX
+from core.validation.pathfinders.schema_validation.consts import PFErrors, PFRegex
 
 
-def _should_fail_check_because_element_is_nan(element) -> Literal[True] | None:
+def _should_fail_check_because_element_is_nan(element: Any) -> Literal[True] | None:
     """Detect nan values in pandera checks which should return false to bypass type errors.
 
     When writing element-wise pandera checks, pandera will pass through any null/nan values rather than skipping over
@@ -49,87 +32,104 @@ def _should_fail_check_because_element_is_nan(element) -> Literal[True] | None:
     return None
 
 
-@pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def is_datetime(element):
-    try:
-        pd.to_datetime(element)
-        return True
-    except ValueError:
-        return False
-
-
-@pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def is_int(element):
-    coerced = pd.to_numeric(element, errors="coerce")
-    return pd.notnull(coerced) and (isinstance(coerced, float) or coerced.astype(float).is_integer())
-
-
-@pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def is_float(element):
-    coerced = pd.to_numeric(element, errors="coerce")
-    return pd.notnull(coerced)
-
-
-@pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def not_in_future(element: Any):
-    """Checks that a datetime is not in the future.
-
-    :param element: an element to check
-    :return: True if passes the check, else False
-    """
-    if _should_fail_check_because_element_is_nan(element):
-        return False
-
-    # If it's not come through here as a datetime, it's probably some other native data type like an int or string,
-    # which will fail datetime coercion later in the pipeline. We throw a TypeError here as these are ignored by
-    # some custom logic we have, see tables.validate:TableValidator.IGNORED_FAILURES)
-    if not isinstance(element, datetime):
-        raise TypeError("Value must be a datetime")
-    return element <= datetime.now().date()
-
-
-@pa.extensions.register_check_method(statistics=["max_words"], check_type=CheckType.ELEMENT_WISE)
-def max_word_count(element: Any, *, max_words):
-    """Checks that a string split up by whitespace characters is less than or equal to "max_words" elements long.
-
-    :param element: an element to check
-    :param max_words: the maximum allowed length of the string split up by whitespace
-    :return: True if passes the check, else False
-    """
-    if _should_fail_check_because_element_is_nan(element):
-        return False
-
-    # If it's not come through here as a string, it's probably some other native data type like an int, float, or
-    # datetime. Which won't be more than 100 words.
-    if not isinstance(element, str):
-        raise TypeError("Value must be a string")
-    return len(element.split()) <= max_words
-
-
-@pa.extensions.register_check_method(check_type=CheckType.ELEMENT_WISE)
-def postcode_list(element: Any):
-    """Checks that a string can be split on commas and each element matches a basic UK postcode regex.
-
-    :param element: an element to check
-    :return: True if passes the check, else False
-    """
-    if _should_fail_check_because_element_is_nan(element):
-        return False
-
-    # If we've been passed anything that's not a string (eg an int or datetime), we already know it's not going to
-    # have a postcode format, so we can fail. We don't raise a TypeError here, because our table validation ignores
-    # TypeErrors raised from these pandera checks, which would lead to not reporting the cell as an invalid postcode.
-    if not isinstance(element, str):
-        return False
-
-    postcodes = element.split(",")
-    for postcode in postcodes:
-        postcode = postcode.strip()
-        if not re.match(POSTCODE_REGEX, postcode):
+def datetime_check():
+    def is_datetime(element: Any):
+        try:
+            pd.to_datetime(element)
+            return True
+        except ValueError:
             return False
-    return True
+
+    return pa.Check(is_datetime, element_wise=True, error=PFErrors.IS_DATETIME)
 
 
-@pa.extensions.register_check_method(check_type=CheckType.VECTORIZED)
-def exactly_five_rows(df):
-    return df.shape[0] == 5
+def int_check():
+    def is_int(element: Any):
+        coerced = pd.to_numeric(element, errors="coerce")
+        return pd.notnull(coerced) and (isinstance(coerced, float) or coerced.astype(float).is_integer())
+
+    return pa.Check(is_int, element_wise=True, error=PFErrors.IS_INT)
+
+
+def float_check():
+    def is_float(element: Any):
+        coerced = pd.to_numeric(element, errors="coerce")
+        return pd.notnull(coerced)
+
+    return pa.Check(is_float, element_wise=True, error=PFErrors.IS_FLOAT)
+
+
+def max_word_count_check(max_words: int):
+    def max_word_count(element: Any):
+        if _should_fail_check_because_element_is_nan(element):
+            return False
+        if not isinstance(element, str):
+            raise TypeError("Value must be a string")
+        return len(element.split()) <= max_words
+
+    return pa.Check(max_word_count, element_wise=True, error=PFErrors.LTE_X_WORDS.format(max_words=max_words))
+
+
+def not_in_future_check():
+    def not_in_future(element: Any):
+        if _should_fail_check_because_element_is_nan(element):
+            return False
+        if not isinstance(element, datetime):
+            raise TypeError("Value must be a datetime")
+        return element <= datetime.now().date()
+
+    return pa.Check(not_in_future, element_wise=True, error=PFErrors.FUTURE_DATE)
+
+
+def postcode_list_check():
+    def postcode_list(element: Any):
+        if _should_fail_check_because_element_is_nan(element):
+            return False
+        if not isinstance(element, str):
+            return False
+        postcodes = element.split(",")
+        for postcode in postcodes:
+            postcode = postcode.strip()
+            if not re.match(POSTCODE_REGEX, postcode):
+                return False
+        return True
+
+    return pa.Check(postcode_list, element_wise=True, error=PFErrors.INVALID_POSTCODE_LIST)
+
+
+def exactly_x_rows_check(num_rows: int):
+    def exactly_x_rows(df: pd.DataFrame):
+        return df.shape[0] == num_rows
+
+    return pa.Check(exactly_x_rows, error=PFErrors.EXACTLY_X_ROWS.format(num_rows=num_rows))
+
+
+def email_regex_check():
+    return pa.Check.str_matches(PFRegex.BASIC_EMAIL, error=PFErrors.EMAIL)
+
+
+def phone_regex_check():
+    return pa.Check.str_matches(PFRegex.BASIC_TELEPHONE, error=PFErrors.PHONE_NUMBER)
+
+
+def greater_than_check(num: int):
+    return pa.Check.greater_than(num, error=PFErrors.GREATER_THAN.format(num=num))
+
+
+def greater_than_or_equal_to_check(num: int):
+    return pa.Check.greater_than_or_equal_to(num, error=PFErrors.GREATER_THAN_OR_EQUAL_TO.format(num=num))
+
+
+def less_than_check(num: int):
+    return pa.Check.less_than(num, error=PFErrors.LESS_THAN.format(num=num))
+
+
+def less_than_or_equal_to_check(num: int):
+    return pa.Check.less_than_or_equal_to(num, error=PFErrors.LESS_THAN_OR_EQUAL_TO.format(num=num))
+
+
+def is_in_check(allowed_values: list):
+    def is_in(element: Any):
+        return element in allowed_values
+
+    return pa.Check(is_in, element_wise=True, error=PFErrors.ISIN)

--- a/core/validation/pathfinders/schema_validation/consts.py
+++ b/core/validation/pathfinders/schema_validation/consts.py
@@ -1,0 +1,57 @@
+class PFErrors:
+    """
+    Error messages for the Pathfinder round 1 template.
+    """
+
+    IS_INT = "Value must be a whole number."
+    IS_FLOAT = (
+        "You entered text instead of a number. Remove any names of measurements and only use numbers, for example, '9'."
+    )
+    IS_DATETIME = "You entered text instead of a date. Date must be in numbers."
+    ISIN = (
+        "You’ve entered your own content instead of selecting from the dropdown list provided. Select an "
+        "option from the dropdown list."
+    )
+    LTE_X_WORDS = "Enter no more than {max_words} words."
+    GREATER_THAN = "Amount must be more than {num}."
+    GREATER_THAN_OR_EQUAL_TO = "Amount must be equal to or more than {num}."
+    LESS_THAN = "Amount must be less than {num}."
+    LESS_THAN_OR_EQUAL_TO = "Amount must be equal to or less than {num}."
+    EMAIL = "Enter a valid email address, for example, 'name.example@gmail.com'."
+    FUTURE_DATE = "You must not enter a date in the future."
+    INVALID_POSTCODE_LIST = (
+        "Enter a valid postcode or list of postcodes separated by commas, for example, 'EX12 3AM, PL45 E67'."
+    )
+    EXACTLY_X_ROWS = "You must enter exactly {num_rows} rows and no fewer."
+    PROJECT_NOT_ALLOWED = "Project name '{project_name}' is not allowed for this organisation."
+    STANDARD_OUTPUT_NOT_ALLOWED = (
+        "Standard output value '{output}' is not allowed for intervention theme '{intervention_theme}'."
+    )
+    STANDARD_OUTCOME_NOT_ALLOWED = (
+        "Standard outcome value '{outcome}' is not allowed for intervention theme '{intervention_theme}'."
+    )
+    BESPOKE_OUTPUT_NOT_ALLOWED = "Bespoke output value '{output}' is not allowed for this organisation."
+    BESPOKE_OUTCOME_NOT_ALLOWED = "Bespoke outcome value '{outcome}' is not allowed for this organisation."
+    UOM_NOT_ALLOWED = "Unit of measurement '{unit_of_measurement}' is not allowed for this output or outcome."
+    CREDIBLE_PLAN_YES = "If you have selected 'Yes' for 'Credible Plan', you must answer Q2, Q3 and Q4."
+    CREDIBLE_PLAN_NO = "If you have selected 'No' for 'Credible Plan', Q2, Q3 and Q4 must be left blank."
+    CURRENT_UNDERSPEND = "Current underspend must be filled in if the reporting period is not Q4."
+    INTERVENTION_THEME_NOT_ALLOWED = "Intervention theme '{intervention_theme}' is not allowed."
+    ACTUAL_REPORTING_PERIOD = (
+        "Reporting period must not be in the future if 'Actual, forecast or cancelled' is 'Actual'."
+    )
+    FORECAST_REPORTING_PERIOD = (
+        "Reporting period must be in the future if 'Actual, forecast or cancelled' is 'Forecast'."
+    )
+    PHONE_NUMBER = (
+        "Enter a valid UK telephone number starting with an apostrophe, for example, '01632 960 001, "
+        "'07700 900 982 or '+44 808 157 0192"
+    )
+
+
+class PFRegex:
+    BASIC_EMAIL = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"  # will catch most common errors
+    BASIC_TELEPHONE = (
+        r"^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}"
+        r"\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?$"
+    )

--- a/tests/test_full_pf_pipeline.py
+++ b/tests/test_full_pf_pipeline.py
@@ -5,6 +5,7 @@ import pytest
 
 from core.table_extraction import TableExtractor, TableProcessor
 from core.table_extraction.table import Table
+from core.validation.pathfinders.schema_validation import checks
 from core.validation.pathfinders.schema_validation.exceptions import TableValidationError, TableValidationErrors
 from core.validation.pathfinders.schema_validation.validate import TableValidator
 
@@ -13,16 +14,6 @@ resources = Path(__file__).parent / "resources" / "pathfinders"
 
 @pytest.fixture
 def config():
-    int_error = (
-        "You entered text instead of a number. Remove any units of measurement and only use numbers, for example, 9."
-    )
-    datetime_error = (
-        "You entered text instead of a date. Check the cell is formatted as a date, for example, Dec-22 or Jun-23"
-    )
-    isin_error = (
-        "You’ve entered your own content, instead of selecting from the dropdown list provided. Select an option from "
-        "the dropdown list."
-    )
     return {
         "extract": {
             "id_tag": "TESTE2EID1",
@@ -33,9 +24,9 @@ def config():
             "schema_config": {
                 "columns": {
                     "StringColumn": pa.Column(),
-                    "IntColumn": pa.Column(checks=[pa.Check.is_int(error=int_error)]),
-                    "DatetimeColumn": pa.Column(checks=[pa.Check.is_datetime(error=datetime_error)]),
-                    "DropdownColumn": pa.Column(checks=[pa.Check.isin(["Yes", "No"], error=isin_error)]),
+                    "IntColumn": pa.Column(checks=[checks.int_check()]),
+                    "DatetimeColumn": pa.Column(checks=[checks.datetime_check()]),
+                    "DropdownColumn": pa.Column(checks=[checks.is_in_check(["Yes", "No"])]),
                     "UniqueColumn": pa.Column(unique=True, report_duplicates="exclude_first"),
                 },
                 "unique": ["StringColumn", "IntColumn"],
@@ -70,14 +61,10 @@ def test_pipeline_failure(config):
     assert errors_by_cell["A3"].message == "You entered duplicate data. Remove or replace the duplicate data."
     assert errors_by_cell["B6"].message == "You entered duplicate data. Remove or replace the duplicate data."
     assert errors_by_cell["A4"].message == "The cell is blank but is required."
-    assert errors_by_cell["B5"].message == (
-        "You entered text instead of a number. Remove any units of measurement " "and only use numbers, for example, 9."
-    )
-    assert errors_by_cell["C4"].message == (
-        "You entered text instead of a date. Check the cell is formatted as a " "date, for example, Dec-22 or Jun-23"
-    )
+    assert errors_by_cell["B5"].message == "Value must be a whole number."
+    assert errors_by_cell["C4"].message == ("You entered text instead of a date. Date must be in numbers.")
     assert errors_by_cell["D4"].message == (
-        "You’ve entered your own content, instead of selecting from the dropdown list provided. Select an option from "
+        "You’ve entered your own content instead of selecting from the dropdown list provided. Select an option from "
         "the dropdown list."
     )
     assert errors_by_cell["E5"].message == "You entered duplicate data. Remove or replace the duplicate data."

--- a/tests/validation_tests/pathfinders/schema_validation_tests/test_checks.py
+++ b/tests/validation_tests/pathfinders/schema_validation_tests/test_checks.py
@@ -1,10 +1,18 @@
-import re
-from functools import partial
-
+import pandas as pd
+import pandera as pa
 import pytest
 
-from core.table_extraction.config.pf_r1_config import PFRegex
-from core.validation.pathfinders.schema_validation.checks import max_word_count, not_in_future, postcode_list
+from core.validation.pathfinders.schema_validation import checks
+
+
+@pytest.fixture(scope="module")
+def postcode_list_check_schema() -> pa.DataFrameSchema:
+    return pa.DataFrameSchema(columns={"postcode": pa.Column(str, checks.postcode_list_check())})
+
+
+@pytest.fixture(scope="module")
+def phone_regex_check_schema() -> pa.DataFrameSchema:
+    return pa.DataFrameSchema(columns={"phone_number": pa.Column(str, checks.phone_regex_check())})
 
 
 @pytest.mark.parametrize(
@@ -24,35 +32,50 @@ from core.validation.pathfinders.schema_validation.checks import max_word_count,
         "EC1A 1BB",
     ],
 )
-def test_postcode_list_valid_postcodes(postcode):
-    assert postcode_list(postcode)
+def test_postcode_list_valid_postcodes(postcode: str, postcode_list_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"postcode": [postcode]})
+    postcode_list_check_schema.validate(df)
 
 
-def test_postcode_list_valid_postcode_list():
-    assert postcode_list("SW1A1AA, EC1A 1BB, M1 1AE")
+def test_postcode_list_valid_postcode_list(postcode_list_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"postcode": ["SW1A1AA, EC1A 1BB, M1 1AE"]})
+    postcode_list_check_schema.validate(df)
 
 
 @pytest.mark.parametrize("postcode", ["SW1A 1", "sw1a 1aa", "SW!A 1AA", "InvalidPostcode"])
-def test_postcode_list_invalid_postcodes(postcode):
-    assert not postcode_list(postcode)
+def test_postcode_list_invalid_postcodes(postcode, postcode_list_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"postcode": [postcode]})
+    with pytest.raises(pa.errors.SchemaError):
+        postcode_list_check_schema.validate(df)
 
 
-def test_postcode_list_invalid_postcode_list():
-    assert not postcode_list("SW1A1AA, InvalidPostcode, M1 1AE")
+def test_postcode_list_invalid_postcode_list(postcode_list_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"postcode": ["SW1A1AA, InvalidPostcode, M1 1AE"]})
+    with pytest.raises(pa.errors.SchemaError):
+        postcode_list_check_schema.validate(df)
 
 
-def test_postcode_list_empty_input():
-    assert not postcode_list("")
+def test_postcode_list_empty_input(postcode_list_check_schema):
+    df = pd.DataFrame({"postcode": [""]})
+    with pytest.raises(pa.errors.SchemaError):
+        postcode_list_check_schema.validate(df)
 
 
 @pytest.mark.parametrize("invalid_input", [123, ["SW1A1AA", "EC1A 1BB"]])
-def test_postcode_list_non_string_input(invalid_input):
-    assert postcode_list(invalid_input) is False
+def test_postcode_list_non_string_input(invalid_input: any, postcode_list_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"postcode": [invalid_input]})
+    with pytest.raises(pa.errors.SchemaError):
+        postcode_list_check_schema.validate(df)
 
 
-@pytest.mark.parametrize("partial_func", [not_in_future, partial(max_word_count, max_words=100), postcode_list])
-def test_checks_return_false_on_nan(partial_func):
-    assert partial_func(float("nan")) is False
+@pytest.mark.parametrize(
+    "check_func", [checks.not_in_future_check(), checks.max_word_count_check(100), checks.postcode_list_check()]
+)
+def test_checks_return_false_on_nan(check_func: callable):
+    schema = pa.DataFrameSchema(columns={"col": pa.Column(str, check_func)})
+    df = pd.DataFrame({"col": [float("nan")]})
+    with pytest.raises(pa.errors.SchemaError):
+        schema.validate(df)
 
 
 @pytest.mark.parametrize(
@@ -65,8 +88,9 @@ def test_checks_return_false_on_nan(partial_func):
         "+441709382121",
     ],
 )
-def test_is_phone_number(number):
-    assert re.match(PFRegex.BASIC_TELEPHONE, number)
+def test_is_phone_number(number: int, phone_regex_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"phone_number": [number]})
+    phone_regex_check_schema.validate(df)
 
 
 @pytest.mark.parametrize(
@@ -79,5 +103,7 @@ def test_is_phone_number(number):
         "0",
     ],
 )
-def test_is_not_phone_number(number):
-    assert not re.match(PFRegex.BASIC_TELEPHONE, number)
+def test_is_not_phone_number(number: int, phone_regex_check_schema: pa.DataFrameSchema):
+    df = pd.DataFrame({"phone_number": [number]})
+    with pytest.raises(pa.errors.SchemaError):
+        phone_regex_check_schema.validate(df)


### PR DESCRIPTION
### Ticket
[Pathfinders - use direct Check instantiation instead of using pandera.register_check_method](https://dluhcdigital.atlassian.net/browse/SMD-503)

### Change summary
Currently we register custom Pandera check functions (used in schema validation for Pathfinders) through Pandera's `register_check_method` decorator. The problem is that we cannot specify an error message that should be raised if the check fails, and that means that every time we instantiate a check in our code, we have to remember to pass the error message that corresponds to the check as a separate argument, which is error-prone and verbose. For example, we add a float datatype check to the validation schema using `pa.Check.is_float(error=PFErrors.IS_FLOAT)`.

As check functions are very much tied to error messages in the real world, for the sake of a consistent user experience, it makes sense to tie them together formally in the backend, instead of simply by convention. Thus, this change is to remove the practice of registering check functions via a decorator and handing over the process of actually instantiating these checks to Pandera, and instead instantiate checks in our own application code, facilitating the passing of error messages as arguments. As we also need to support arguments, we cannot instantiate them directly in the `checks.py` module and instead need to offer wrapper functions or closures. What we end up with is the ability to add a float datatype check to the validation schema using `checks.float_check()`.

To facilitate this tying together of check functions and error messages for all checks used during Pandera schema validation for Pathfinders, checks that do not use custom logic have also been assigned closures in the `checks.py` module (e.g., the email regex check, which uses Pandera's built-in `str_matches` check function).

As checks are now tied to error messages, tests had to be updated to reflect this and ensure that the real error messages (from `PFErrors`) were being verified against.

Finally, the check function `exactly_five_rows` was replaced by the more generic `exactly_x_rows`, slightly out of scope but definitely the right thing to do.