### PR TITLE
SMD-653 - Dependency injection for Pathfinders

### DIFF
--- a/core/validation/pathfinders/cross_table_validation/ct_validate_r1.py
+++ b/core/validation/pathfinders/cross_table_validation/ct_validate_r1.py
@@ -17,7 +17,7 @@ from core.transformation.pathfinders.consts import PF_REPORTING_PERIOD_TO_DATES_
 from core.validation.pathfinders.schema_validation.consts import PFErrors
 
 
-def cross_table_validation(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:
+def cross_table_validate(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:
     """
     Perform cross-table validation checks on the input DataFrames extracted from the original Excel file. These are
     checks that require data from multiple tables to be compared against each other.

--- a/tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r1.py
+++ b/tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r1.py
@@ -10,12 +10,12 @@ from core.validation.pathfinders.cross_table_validation.ct_validate_r1 import (
     _check_intervention_themes_in_pfcs,
     _check_projects,
     _check_standard_outcomes,
-    cross_table_validation,
+    cross_table_validate,
 )
 
 
 def test_cross_table_validation_passes(mock_df_dict):
-    error_messages = cross_table_validation(mock_df_dict)
+    error_messages = cross_table_validate(mock_df_dict)
     assert error_messages == []
 
 
@@ -26,7 +26,7 @@ def test_cross_table_validation_fails(mock_df_dict):
     mock_df_dict["Bespoke outputs"]["Output"][0] = "Invalid Bespoke Output"
     mock_df_dict["Total underspend"]["Total underspend"][0] = pd.NA
     mock_df_dict["Outputs"]["Unit of measurement"][0] = "Invalid Unit of Measurement"
-    error_messages = cross_table_validation(mock_df_dict)
+    error_messages = cross_table_validate(mock_df_dict)
     assert error_messages == [
         Message(
             sheet="Progress",


### PR DESCRIPTION
### Ticket
[Pathfinders - replace hard-coded dependencies with dependency injection](https://dluhcdigital.atlassian.net/browse/SMD-653)

### Change summary
Currently we have an IngestDependencies class that is used by Pathfinders but only for initial validation schema and table to load function mapping, as the other dependencies don't map directly between Towns Fund and Pathfinders. For the dependencies that Towns Fund has but not Pathfinders, we specify None in the constructor for the IngestDependencies object when doing a Pathfinders run, while for the dependencies that Pathfinders has but not Towns Fund, we hard-code them in the main 'ingest' pipeline flow.

This change is to break apart IngestDependencies into three classes - a base IngestDependencies, containing shared dependencies; and then specific child classes for Towns Fund and Pathfinders, containing fund-specific dependencies. This allows us to share the same dependency factory method but to return IngestDependency objects specific to funds. We can then leverage this change to replace the hard-coding of Pathfinders-specific dependencies with dependency injection, similar to what Towns Fund enjoys now, which will help when we move to Pathfinders round 2.