### PR TITLE
Stop reading `reporting_round` from submission table

### DIFF
--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -140,6 +140,7 @@ def ingest(body: dict, excel_file: FileStorage) -> tuple[dict, int]:
     clean_data(transformed_data)
     if do_load:
         populate_db(
+            reporting_round=reporting_round,
             transformed_data=transformed_data,
             mappings=INGEST_MAPPINGS,
             excel_file=excel_file,
@@ -396,6 +397,7 @@ def get_metadata(transformed_data: dict[str, pd.DataFrame]) -> dict:
 
 @transaction_retry_wrapper(max_retries=5, sleep_duration=0.6, error_type=exc.IntegrityError)
 def populate_db(
+    reporting_round: int,
     transformed_data: dict[str, pd.DataFrame],
     mappings: tuple[DataMapping],
     excel_file: FileStorage,
@@ -417,7 +419,6 @@ def populate_db(
     :param submitting_user_email: The email address of the submitting user.
     :return: None
     """
-    reporting_round = int(transformed_data["Submission_Ref"]["Reporting Round"].iloc[0])
     programme_id = transformed_data["Programme_Ref"]["Programme ID"].iloc[0]
     fund_id = transformed_data["Programme_Ref"]["FundType_ID"].iloc[0]
     programme_exists_previous_round = get_programme_by_id_and_previous_round(programme_id, reporting_round)
@@ -432,7 +433,9 @@ def populate_db(
     for mapping in mappings:
         if load_function := load_mapping.get(mapping.table):
             additional_kwargs = dict(
-                submission_id=submission_id, programme_exists_previous_round=programme_exists_previous_round
+                submission_id=submission_id,
+                programme_exists_previous_round=programme_exists_previous_round,
+                reporting_round=reporting_round,
             )  # some load functions also expect additional key word args
             load_function(transformed_data, mapping, **additional_kwargs)
 

--- a/core/controllers/ingest.py
+++ b/core/controllers/ingest.py
@@ -397,6 +397,7 @@ def get_metadata(transformed_data: dict[str, pd.DataFrame]) -> dict:
 
 @transaction_retry_wrapper(max_retries=5, sleep_duration=0.6, error_type=exc.IntegrityError)
 def populate_db(
+    *,
     reporting_round: int,
     transformed_data: dict[str, pd.DataFrame],
     mappings: tuple[DataMapping],

--- a/core/controllers/load_functions.py
+++ b/core/controllers/load_functions.py
@@ -89,19 +89,20 @@ def load_outputs_outcomes_ref(transformed_data: dict[str, pd.DataFrame], mapping
     db.session.add_all(models)
 
 
-def load_programme_junction(transformed_data: dict[str, pd.DataFrame], mapping: DataMapping, submission_id, **kwargs):
+def load_programme_junction(
+    transformed_data: dict[str, pd.DataFrame], mapping: DataMapping, submission_id, reporting_round: int, **kwargs
+):
     """
     Load data into the programme junction table.
 
-    ProgrammeJunction consists of two values: 'Programme ID' and 'Submission ID'.
-    As these are both foreign keys the DataFrame is instantiated during load.
+    ProgrammeJunction consists of three values: 'Programme ID', 'Submission ID', and 'Reporting Round'.
+    As the first two are foreign keys the DataFrame is instantiated during load.
 
     :param transformed_data: a dictionary of DataFrames of table data to be inserted into the db.
     :param mapping: the mapping of the relevant DataFrame to its attributes as they appear in the db.
     :param submission_id: the ID of the submission associated with the data.
     """
     programme_id = transformed_data["Programme_Ref"]["Programme ID"].iloc[0]
-    reporting_round = int(transformed_data["Submission_Ref"]["Reporting Round"].iloc[0])
     programme_junction_df = pd.DataFrame(
         {"Submission ID": [submission_id], "Programme ID": [programme_id], "Reporting Round": [reporting_round]}
     )
@@ -181,7 +182,7 @@ def get_or_generate_submission_id(
             (
                 programme_submission
                 for programme_submission in programme_exists_same_round.in_round_programmes
-                if programme_submission.submission.reporting_round == reporting_round
+                if programme_submission.reporting_round == reporting_round
             ),
             None,
         )

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -634,7 +634,7 @@ def submission_metadata_query(base_query: Query) -> Query:
         ents.Programme.programme_id,
         ents.Submission.reporting_period_start,
         ents.Submission.reporting_period_end,
-        ents.Submission.reporting_round,
+        ents.ProgrammeJunction.reporting_round,
     ).distinct()
 
 
@@ -694,9 +694,7 @@ def get_programme_by_id_and_round(programme_id: str, reporting_round: int) -> en
     """
     programme_exists_same_round = (
         ents.Programme.query.join(ents.ProgrammeJunction)
-        .join(ents.Submission)
-        .filter(ents.Programme.programme_id == programme_id)
-        .filter(ents.Submission.reporting_round == reporting_round)
+        .filter(ents.Programme.programme_id == programme_id, ents.ProgrammeJunction.reporting_round == reporting_round)
         .first()
     )
     return programme_exists_same_round
@@ -713,9 +711,7 @@ def get_programme_by_id_and_previous_round(programme_id: str, reporting_round: i
     """
     programme_exists_previous_round = (
         ents.Programme.query.join(ents.ProgrammeJunction)
-        .join(ents.Submission)
-        .filter(ents.Programme.programme_id == programme_id)
-        .filter(ents.Submission.reporting_round <= reporting_round)
+        .filter(ents.Programme.programme_id == programme_id, ents.ProgrammeJunction.reporting_round <= reporting_round)
         .first()
     )
     return programme_exists_previous_round
@@ -755,7 +751,7 @@ def get_latest_submission_by_round_and_fund(reporting_round: int, fund_id: str) 
         ents.Submission.query.join(ents.ProgrammeJunction)
         .join(ents.Programme)
         .join(ents.Fund)
-        .filter(ents.Submission.reporting_round == reporting_round)
+        .filter(ents.ProgrammeJunction.reporting_round == reporting_round)
         .filter(ents.Fund.fund_code.in_(fund_types))
         .order_by(desc(func.cast(func.substr(ents.Submission.submission_id, id_character_offset[fund_id]), Integer)))
         .first()

--- a/tests/integration_tests/test_ingest_component_towns_fund.py
+++ b/tests/integration_tests/test_ingest_component_towns_fund.py
@@ -933,7 +933,7 @@ def test_ingest_same_programme_different_rounds(
         .join(ProgrammeJunction)
         .join(Submission)
         .filter(Project.project_id == "HS-WRC-01")
-        .filter(Submission.reporting_round == 3)
+        .filter(ProgrammeJunction.reporting_round == 3)
         .first()
     )
     r4_proj_1_child = (
@@ -941,7 +941,7 @@ def test_ingest_same_programme_different_rounds(
         .join(ProgrammeJunction)
         .join(Submission)
         .filter(Project.project_id == "HS-WRC-01")
-        .filter(Submission.reporting_round == 4)
+        .filter(ProgrammeJunction.reporting_round == 4)
         .first()
     )
 

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -192,7 +192,11 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
 
     # ingest with r3 data
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
 
     # make sure the old R1 project that referenced this programme still exists
@@ -242,7 +246,11 @@ def test_same_programme_drops_children(
 
     # ingest with r3 data
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
 
     submissions_after = db.session.query(Submission).all()
@@ -693,7 +701,11 @@ def test_get_or_generate_submission_id_already_existing_programme_same_round(
 ):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     # now re-populate with the same data such that condition 'if programme_exists_same_round' is True
     programme = get_programme_by_id_and_round("FHSF001", 3)
@@ -707,7 +719,11 @@ def test_get_or_generate_submission_id_not_existing_programme_same_round(
 ):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     submission_id, submission_to_del = get_or_generate_submission_id(None, 3, fund_id="HS")
     assert submission_id == "S-R03-2"
@@ -717,7 +733,11 @@ def test_get_or_generate_submission_id_not_existing_programme_same_round(
 def test_delete_existing_submission(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
 
     programme_projects = (
@@ -748,7 +768,11 @@ def test_delete_existing_submission(test_client_reset, mock_r3_data_dict, mock_e
 def test_load_programme_ref_upsert(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     # add new round of identical data
     mock_r3_data_dict["Submission_Ref"]["Reporting Round"].iloc[0] = 4
@@ -767,7 +791,11 @@ def test_load_organisation_ref_upsert(
 ):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     # change Geography field to test if upsert correct
     mock_r3_data_dict["Organisation_Ref"]["Geography"].iloc[0] = "new geography"
@@ -782,7 +810,11 @@ def test_load_organisation_ref_upsert(
 def test_load_outputs_outcomes_ref(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     new_row = {"Outcome_Category": "new cat", "Outcome_Name": "new outcome"}
     mock_r3_data_dict["Outcome_Ref"] = mock_r3_data_dict["Outcome_Ref"].append(new_row, ignore_index=True)
@@ -795,7 +827,11 @@ def test_load_outputs_outcomes_ref(test_client_reset, mock_r3_data_dict, mock_ex
 def test_load_submission_level_data(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
     populate_db(
-        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+        reporting_round=3,
+        transformed_data=mock_r3_data_dict,
+        mappings=INGEST_MAPPINGS,
+        excel_file=mock_excel_file,
+        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
     new_row = {
         "Answer": "new answer",

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -191,10 +191,12 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     db.session.commit()  # end the session
 
     # ingest with r3 data
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
 
     # make sure the old R1 project that referenced this programme still exists
-    round_1_project = Project.query.join(ProgrammeJunction).filter(Submission.reporting_round == 1).first()
+    round_1_project = Project.query.join(ProgrammeJunction).filter(ProgrammeJunction.reporting_round == 1).first()
 
     # old R1 data not changed, FK to parent programme still the same
     assert round_1_project.id == init_proj_id  # details not changed
@@ -239,7 +241,9 @@ def test_same_programme_drops_children(
     db.session.commit()
 
     # ingest with r3 data
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
 
     submissions_after = db.session.query(Submission).all()
     submission_ids_after = [row.submission_id for row in submissions_after]
@@ -311,11 +315,11 @@ def populate_test_data(test_client_function):
         reporting_round=1,
     )
     db.session.add_all((sub_1, sub_2, sub_3))
-    read_sub = Submission.query.first()
-    read_sub_latest = Submission.query.filter(Submission.submission_id == "S-R03-4").first()  # The latest submission
-    read_sub_old = Submission.query.filter(
-        Submission.reporting_round == 1
-    ).first()  # replicate a submission from a previous round
+    read_sub = Submission.query.filter_by(submission_id="S-R03-3").one()
+    # The latest submission
+    read_sub_latest = Submission.query.filter_by(submission_id="S-R03-4").one()
+    # replicate a submission from a previous round
+    read_sub_old = Submission.query.filter_by(submission_id="S-R01-99").one()
 
     organisation = Organisation(
         organisation_name="Some new Org",
@@ -688,7 +692,9 @@ def test_get_or_generate_submission_id_already_existing_programme_same_round(
     test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload
 ):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     # now re-populate with the same data such that condition 'if programme_exists_same_round' is True
     programme = get_programme_by_id_and_round("FHSF001", 3)
     submission_id, submission_to_del = get_or_generate_submission_id(programme, 3, fund_id="HS")
@@ -700,7 +706,9 @@ def test_get_or_generate_submission_id_not_existing_programme_same_round(
     test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload
 ):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     submission_id, submission_to_del = get_or_generate_submission_id(None, 3, fund_id="HS")
     assert submission_id == "S-R03-2"
     assert submission_to_del is None
@@ -708,13 +716,15 @@ def test_get_or_generate_submission_id_not_existing_programme_same_round(
 
 def test_delete_existing_submission(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
 
     programme_projects = (
         Programme.query.join(ProgrammeJunction)
         .join(Submission)
         .filter(Programme.programme_id == "FHSF001")
-        .filter(Submission.reporting_round == 3)
+        .filter(ProgrammeJunction.reporting_round == 3)
         .first()
     )
 
@@ -727,7 +737,7 @@ def test_delete_existing_submission(test_client_reset, mock_r3_data_dict, mock_e
         Programme.query.join(ProgrammeJunction)
         .join(Submission)
         .filter(Programme.programme_id == "FHSF001")
-        .filter(Submission.reporting_round == 3)
+        .filter(ProgrammeJunction.reporting_round == 3)
         .first()
     )
 
@@ -737,13 +747,15 @@ def test_delete_existing_submission(test_client_reset, mock_r3_data_dict, mock_e
 
 def test_load_programme_ref_upsert(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     # add new round of identical data
     mock_r3_data_dict["Submission_Ref"]["Reporting Round"].iloc[0] = 4
     # ensure programme name has changed to test if upsert correct
     mock_r3_data_dict["Programme_Ref"]["Programme Name"].iloc[0] = "new name"
     programme = get_programme_by_id_and_previous_round("FHSF001", 3)
-    load_programme_ref(mock_r3_data_dict, INGEST_MAPPINGS[2], programme)
+    load_programme_ref(mock_r3_data_dict, INGEST_MAPPINGS[2], programme, reporting_round=4)
     db.session.commit()
     programme = Programme.query.filter(Programme.programme_id == "FHSF001").first()
 
@@ -754,10 +766,12 @@ def test_load_organisation_ref_upsert(
     test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload
 ):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     # change Geography field to test if upsert correct
     mock_r3_data_dict["Organisation_Ref"]["Geography"].iloc[0] = "new geography"
-    load_organisation_ref(mock_r3_data_dict, INGEST_MAPPINGS[1])
+    load_organisation_ref(mock_r3_data_dict, INGEST_MAPPINGS[1], reporting_round=3)
     db.session.commit()
     organisation = Organisation.query.filter(
         Organisation.organisation_name == "A District Council From Hogwarts"
@@ -767,10 +781,12 @@ def test_load_organisation_ref_upsert(
 
 def test_load_outputs_outcomes_ref(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     new_row = {"Outcome_Category": "new cat", "Outcome_Name": "new outcome"}
     mock_r3_data_dict["Outcome_Ref"] = mock_r3_data_dict["Outcome_Ref"].append(new_row, ignore_index=True)
-    load_outputs_outcomes_ref(mock_r3_data_dict, INGEST_MAPPINGS[14])
+    load_outputs_outcomes_ref(mock_r3_data_dict, INGEST_MAPPINGS[14], reporting_round=3)
     db.session.commit()
     outcome = OutcomeDim.query.filter(OutcomeDim.outcome_name == "new outcome").first()
     assert outcome
@@ -778,7 +794,9 @@ def test_load_outputs_outcomes_ref(test_client_reset, mock_r3_data_dict, mock_ex
 
 def test_load_submission_level_data(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):
     # add mock_r3 data to database
-    populate_db(mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund"))
+    populate_db(
+        3, mock_r3_data_dict, INGEST_MAPPINGS, mock_excel_file, get_table_to_load_function_mapping("Towns Fund")
+    )
     new_row = {
         "Answer": "new answer",
         "Indicator": "new indicator",
@@ -786,7 +804,7 @@ def test_load_submission_level_data(test_client_reset, mock_r3_data_dict, mock_e
         "Programme ID": "FHSF001",
     }
     mock_r3_data_dict["Place Details"] = pd.DataFrame(new_row, index=[0])
-    load_submission_level_data(mock_r3_data_dict, INGEST_MAPPINGS[5], "S-R03-1")
+    load_submission_level_data(mock_r3_data_dict, INGEST_MAPPINGS[5], "S-R03-1", reporting_round=3)
     db.session.commit()
     place = PlaceDetail.query.filter(PlaceDetail.data_blob["question"].astext == "new question").first()
     assert place


### PR DESCRIPTION
### Change description
Now that we have the `reporting_round` tracked on the
`programme_junction` table, lets switch all reads from
`submission.reporting_round` over to
`programme_junction.reporting_round`.

As well as changing DB reads, we also stop reading the `Submission_Ref`
dataframe that eventually populates the `submission` table. Instead, we
rely on the `reporting_round` variable passed into `ingest`, and we
cascade this through to `populate_db` so that it can avoid checking the
`Submission_Ref` data frame. This is because we'll shortly stop writing
`submission.reporting_round`, and remove it from the data frame, so
we're just preparing for that.


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")