### PR TITLE
Make submission.reporting_round nullable

### DIFF
--- a/core/controllers/mappings.py
+++ b/core/controllers/mappings.py
@@ -146,7 +146,6 @@ INGEST_MAPPINGS = (
             "Submission Date": "submission_date",
             "Reporting Period Start": "reporting_period_start",
             "Reporting Period End": "reporting_period_end",
-            "Reporting Round": "reporting_round",
             "Sign Off Name": "sign_off_name",
             "Sign Off Role": "sign_off_role",
             "Sign Off Date": "sign_off_date",

--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -604,7 +604,7 @@ class Submission(BaseModel):
     ingest_date = sqla.Column(sqla.DateTime(), nullable=False, default=datetime.now())
     reporting_period_start = sqla.Column(sqla.DateTime(), nullable=False)
     reporting_period_end = sqla.Column(sqla.DateTime(), nullable=False)
-    reporting_round = sqla.Column(sqla.Integer(), nullable=False)
+    reporting_round = sqla.Column(sqla.Integer(), nullable=True)
     submission_filename = sqla.Column(sqla.String(), nullable=True)
     data_blob = sqla.Column(JSONB, nullable=True)
     submitting_account_id = sqla.Column(sqla.String())

--- a/core/transformation/pathfinders/pf_transform_r1.py
+++ b/core/transformation/pathfinders/pf_transform_r1.py
@@ -51,7 +51,6 @@ def _submission_ref(
         ingest_date             - assigned on DB insert as current date
         reporting_period_start  - from "Reporting Period Start" in the transformed DF
         reporting_period_end    - from "Reporting Period End" in the transformed DF
-        reporting_round         - from "Reporting Round" in the transformed DF
         submission_filename     - assigned during load_data
         data_blob               - includes "Sign Off Name", "Sign Off Role" and "Sign Off Date" from the transformed DF
     """
@@ -63,7 +62,6 @@ def _submission_ref(
             "Submission Date": [datetime.now()],
             "Reporting Period Start": [PF_REPORTING_ROUND_TO_DATES[reporting_round]["start"]],
             "Reporting Period End": [PF_REPORTING_ROUND_TO_DATES[reporting_round]["end"]],
-            "Reporting Round": [reporting_round],
             "Sign Off Name": [signatory_name],
             "Sign Off Role": [signatory_role],
             "Sign Off Date": [signature_date],

--- a/core/transformation/towns_fund/common.py
+++ b/core/transformation/towns_fund/common.py
@@ -25,7 +25,6 @@ def get_submission_details(reporting_round: int) -> pd.DataFrame:
         "Submission Date": datetime.now(),
         "Reporting Period Start": start_date,
         "Reporting Period End": end_date,
-        "Reporting Round": reporting_round,
     }
 
     df_submission = pd.DataFrame(current_period, index=[0])

--- a/core/validation/towns_fund/schema_validation/schemas.py
+++ b/core/validation/towns_fund/schema_validation/schemas.py
@@ -10,9 +10,8 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
                 "Submission Date": datetime,
                 "Reporting Period Start": datetime,
                 "Reporting Period End": datetime,
-                "Reporting Round": int,
             },
-            "non-nullable": ["Reporting Period Start", "Reporting Period End", "Reporting Round"],
+            "non-nullable": ["Reporting Period Start", "Reporting Period End"],
         },
         "Organisation_Ref": {
             "columns": {
@@ -357,9 +356,8 @@ TF_ROUND_3_VAL_SCHEMA = parse_schema(
                 "Submission Date": datetime,
                 "Reporting Period Start": datetime,
                 "Reporting Period End": datetime,
-                "Reporting Round": int,
             },
-            "non-nullable": ["Reporting Period Start", "Reporting Period End", "Reporting Round"],
+            "non-nullable": ["Reporting Period Start", "Reporting Period End"],
         },
         "Organisation_Ref": {
             "columns": {

--- a/db/migrations/versions/036_nullable_reporting_round.py
+++ b/db/migrations/versions/036_nullable_reporting_round.py
@@ -1,0 +1,26 @@
+"""nullable reporting_round
+
+Revision ID: 036_nullable_reporting_round
+Revises: 035_drop_geospatial_data_blob
+Create Date: 2024-05-14 09:01:17.945873
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "036_nullable_reporting_round"
+down_revision = "035_drop_geospatial_data_blob"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("submission_dim", schema=None) as batch_op:
+        batch_op.alter_column("reporting_round", existing_type=sa.INTEGER(), nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table("submission_dim", schema=None) as batch_op:
+        batch_op.alter_column("reporting_round", existing_type=sa.INTEGER(), nullable=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,6 @@ def additional_test_data() -> dict[str, Any]:
     """
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID",
-        reporting_round=1,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -249,7 +248,7 @@ def additional_test_data() -> dict[str, Any]:
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=1,
     )
     db.session.add(programme_junction)
     db.session.flush()
@@ -440,7 +439,6 @@ def towns_fund_bolton_round_1_test_data(test_client_reset):
     """
     submission = Submission(
         submission_id="S-R01-1",
-        reporting_round=1,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -462,7 +460,7 @@ def towns_fund_bolton_round_1_test_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=1,
     )
     db.session.add(programme_junction)
     db.session.commit()
@@ -473,7 +471,6 @@ def pathfinders_round_1_submission_data(test_client_reset):
     """Pre-populates Submission table with an already existing PF submission."""
     submission = Submission(
         submission_id="S-PF-R01-1",
-        reporting_round=1,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -495,7 +492,7 @@ def pathfinders_round_1_submission_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=1,
     )
     db.session.add(programme_junction)
     db.session.commit()
@@ -506,7 +503,6 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
     """Pre-populates Submission table with an already existing TD submission."""
     submission = Submission(
         submission_id="S-R03-1",
-        reporting_round=3,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -528,7 +524,7 @@ def towns_fund_td_round_3_submission_data(test_client_reset):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=3,
     )
     db.session.add(programme_junction)
     db.session.commit()

--- a/tests/db_tests/test_constraints.py
+++ b/tests/db_tests/test_constraints.py
@@ -141,7 +141,6 @@ def test_project_geospatial_association_pk_constraint(seeded_test_client_rollbac
     geospatial_2 = GeospatialDim.query.filter_by(postcode_prefix="SW").one()
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID",
-        reporting_round=1,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -170,7 +169,7 @@ def test_project_geospatial_association_pk_constraint(seeded_test_client_rollbac
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=1,
     )
     db.session.add(programme_junction)
     db.session.flush()
@@ -268,7 +267,6 @@ class TestConstraintOnStartAndEndDates:
             submission_id="TEST",
             reporting_period_start=datetime.now(),
             reporting_period_end=datetime.now() - timedelta(seconds=1),
-            reporting_round=1,
         )
         db.session.add(s)
 

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -427,7 +427,6 @@ def test_get_project_id_fk(seeded_test_client, additional_test_data):
 def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback, additional_test_data):
     submission_2 = Submission(
         submission_id="S-R03-2",
-        reporting_round=3,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -445,7 +444,7 @@ def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback,
     programme_junction_2 = ProgrammeJunction(
         programme_id=programme_2.id,
         submission_id=submission_2.id,
-        reporting_round=submission_2.reporting_round,
+        reporting_round=3,
     )
 
     db.session.add(programme_junction_2)

--- a/tests/integration_tests/mock_tf_r3_transformed_data/Submission_Ref.csv
+++ b/tests/integration_tests/mock_tf_r3_transformed_data/Submission_Ref.csv
@@ -1,2 +1,2 @@
-Submission Date,Reporting Period Start,Reporting Period End,Reporting Round
-1945-03-12,2023-02-01,2023-02-12,3
+Submission Date,Reporting Period Start,Reporting Period End
+1945-03-12,2023-02-01,2023-02-12

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -139,7 +139,6 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     db.session.add(sub)
     read_sub = Submission.query.first()
@@ -161,7 +160,7 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     prog_junction = ProgrammeJunction(
         programme_id=read_prog.id,
         submission_id=read_sub.id,
-        reporting_round=read_sub.reporting_round,
+        reporting_round=1,
     )
     db.session.add(prog_junction)
     read_prog_junction = ProgrammeJunction.query.first()
@@ -305,7 +304,6 @@ def populate_test_data(test_client_function):
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=3,
         submission_filename="fake_name_drop_me",
     )
     sub_2 = Submission(
@@ -313,14 +311,12 @@ def populate_test_data(test_client_function):
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=3,
     )
     sub_3 = Submission(
         submission_id="S-R01-99",
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     db.session.add_all((sub_1, sub_2, sub_3))
     read_sub = Submission.query.filter_by(submission_id="S-R03-3").one()
@@ -357,17 +353,17 @@ def populate_test_data(test_client_function):
     prog_junction_latest_persists = ProgrammeJunction(
         programme_id=read_prog_persists.id,
         submission_id=read_sub_latest.id,
-        reporting_round=read_sub_latest.reporting_round,
+        reporting_round=3,
     )
     prog_junction_updated = ProgrammeJunction(
         submission_id=read_sub.id,
         programme_id=read_prog_updated.id,
-        reporting_round=read_sub.reporting_round,
+        reporting_round=3,
     )
     prog_junction_old_updated = ProgrammeJunction(
         submission_id=read_sub_old.id,
         programme_id=read_prog_updated.id,
-        reporting_round=read_sub_old.reporting_round,
+        reporting_round=1,
     )
     db.session.add_all((prog_junction_latest_persists, prog_junction_updated, prog_junction_old_updated))
     read_prog_junction_latest_persists = ProgrammeJunction.query.filter(
@@ -478,21 +474,18 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     sub2 = Submission(
         submission_id="S-R01-2",
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     sub3 = Submission(
         submission_id="S-R01-3",
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     db.session.add_all((sub3, sub1, sub2))
     db.session.flush()
@@ -522,17 +515,17 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
     pj1 = ProgrammeJunction(
         programme_id=prog1.id,
         submission_id=sub1.id,
-        reporting_round=sub1.reporting_round,
+        reporting_round=1,
     )
     pj2 = ProgrammeJunction(
         programme_id=prog2.id,
         submission_id=sub2.id,
-        reporting_round=sub2.reporting_round,
+        reporting_round=1,
     )
     pj3 = ProgrammeJunction(
         programme_id=prog3.id,
         submission_id=sub3.id,
-        reporting_round=sub3.reporting_round,
+        reporting_round=1,
     )
     db.session.add_all((pj1, pj2, pj3))
 
@@ -549,21 +542,18 @@ def test_next_submission_id_more_digits(test_client_rollback):
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     sub2 = Submission(
         submission_id="S-R01-4",
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     sub3 = Submission(
         submission_id="S-R01-99",
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     db.session.add_all((sub3, sub1, sub2))
     db.session.flush()
@@ -602,17 +592,17 @@ def test_next_submission_id_more_digits(test_client_rollback):
     pj1 = ProgrammeJunction(
         programme_id=prog1.id,
         submission_id=sub1.id,
-        reporting_round=sub1.reporting_round,
+        reporting_round=1,
     )
     pj2 = ProgrammeJunction(
         programme_id=prog2.id,
         submission_id=sub2.id,
-        reporting_round=sub2.reporting_round,
+        reporting_round=1,
     )
     pj3 = ProgrammeJunction(
         programme_id=prog3.id,
         submission_id=sub3.id,
-        reporting_round=sub3.reporting_round,
+        reporting_round=1,
     )
     db.session.add_all((pj1, pj2, pj3))
 
@@ -638,7 +628,6 @@ def test_next_submission_numpy_type(test_client_rollback):
         submission_id="S-R01-3",
         reporting_period_start=datetime.now(),
         reporting_period_end=datetime.now(),
-        reporting_round=1,
     )
     prog = Programme(
         programme_id="HS-ROW",
@@ -651,7 +640,7 @@ def test_next_submission_numpy_type(test_client_rollback):
     pj = ProgrammeJunction(
         programme_id=prog.id,
         submission_id=sub.id,
-        reporting_round=sub.reporting_round,
+        reporting_round=1,
     )
     db.session.add(pj)
     sub_id = next_submission_id(reporting_round=np.int64(1), fund_id="HS")
@@ -774,9 +763,6 @@ def test_load_programme_ref_upsert(test_client_reset, mock_r3_data_dict, mock_ex
         excel_file=mock_excel_file,
         load_mapping=get_table_to_load_function_mapping("Towns Fund"),
     )
-    # add new round of identical data
-    mock_r3_data_dict["Submission_Ref"].loc[0, "Reporting Round"] = 4
-    mock_r3_data_dict["Submission_Ref"].loc[0, "Reporting Round"] = 4
     # ensure programme name has changed to test if upsert correct
     mock_r3_data_dict["Programme_Ref"]["Programme Name"].iloc[0] = "new name"
     programme = get_programme_by_id_and_previous_round("FHSF001", 3)

--- a/tests/serialisation_tests/conftest.py
+++ b/tests/serialisation_tests/conftest.py
@@ -19,9 +19,9 @@ from core.db.entities import (
 @pytest.fixture
 def non_transport_outcome_data(seeded_test_client):
     """Inserts a tree of data with no links to a transport outcome to assert against."""
+    reporting_round = 1
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID-OUTCOME-TEST",
-        reporting_round=1,
         reporting_period_start=datetime(2019, 10, 10),
         reporting_period_end=datetime(2021, 10, 10),
     )
@@ -41,7 +41,7 @@ def non_transport_outcome_data(seeded_test_client):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme_no_transport_outcome_or_transport_child_projects.id,
-        reporting_round=submission.reporting_round,
+        reporting_round=reporting_round,
     )
     db.session.add(programme_junction)
     db.session.flush()

--- a/tests/transformation_tests/pathfinders/test_pf_transform_r1.py
+++ b/tests/transformation_tests/pathfinders/test_pf_transform_r1.py
@@ -16,7 +16,6 @@ def test__submission_ref(mock_df_dict: dict[str, pd.DataFrame]):
     assert isinstance(row["Submission Date"], pd.Timestamp)
     assert row["Reporting Period Start"] == datetime.datetime(2024, 1, 1)
     assert row["Reporting Period End"] == datetime.datetime(2024, 3, 31)
-    assert row["Reporting Round"] == 1
     assert row["Sign Off Name"] == "Graham Bell"
     assert row["Sign Off Role"] == "Project Manager"
     assert row["Sign Off Date"] == pd.Timestamp("2024-03-05").isoformat()

--- a/tests/transformation_tests/towns_fund/test_common.py
+++ b/tests/transformation_tests/towns_fund/test_common.py
@@ -39,5 +39,3 @@ def test_submission_extract():
         Timestamp("2025-09-30 00:00:00"),
         Timestamp("2026-03-31 00:00:00"),
     ]
-
-    assert test_output["Reporting Round"] == [1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
### Change description
Now that we're storing this information on
`programme_junction.reporting_round`, and we're no longer reading from `submission.reporting_round`, we can start to phase out writes to that table.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
