### PR TITLE
Write a lockfile for the head migration

### DIFF
--- a/db/migrations/.current-alembic-head
+++ b/db/migrations/.current-alembic-head
@@ -1,0 +1,1 @@
+036_nullable_reporting_round

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,5 +1,6 @@
 import logging
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
 from alembic.script import ScriptDirectory
@@ -120,6 +121,14 @@ def run_migrations_online():
 
         with context.begin_transaction():
             context.run_migrations()
+
+    # if we're running on the main db (as opposed to the test db)
+    if connectable.url.database == "data_store":
+        with open(Path(__file__).parent / ".current-alembic-head", "w") as f:
+            # write the current head to `.current-alembic-head`. This will prevent conflicting migrations
+            # being merged at the same time and breaking the build.
+            head = context.get_head_revision()
+            f.write(head + "\n")
 
 
 if context.is_offline_mode():


### PR DESCRIPTION
### Change description
This will provide a clear conflict in git if there are PRs with overlapping migrations, ensuring that they are linearised before merge.

This will allow us to potentially disable the setting that forces PRs to be up-to-date before merging, which becomes a pain point with larger teams and repositories.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
