### PR TITLE
Remove submission.reporting_round

### DIFF
--- a/core/db/entities.py
+++ b/core/db/entities.py
@@ -604,7 +604,6 @@ class Submission(BaseModel):
     ingest_date = sqla.Column(sqla.DateTime(), nullable=False, default=datetime.now())
     reporting_period_start = sqla.Column(sqla.DateTime(), nullable=False)
     reporting_period_end = sqla.Column(sqla.DateTime(), nullable=False)
-    reporting_round = sqla.Column(sqla.Integer(), nullable=True)
     submission_filename = sqla.Column(sqla.String(), nullable=True)
     data_blob = sqla.Column(JSONB, nullable=True)
     submitting_account_id = sqla.Column(sqla.String())

--- a/core/serialisation/data_serialiser.py
+++ b/core/serialisation/data_serialiser.py
@@ -45,6 +45,7 @@ from core.db.entities import (
     PrivateInvestment,
     Programme,
     ProgrammeFundingManagement,
+    ProgrammeJunction,
     ProgrammeProgress,
     Project,
     ProjectProgress,
@@ -522,4 +523,4 @@ class SubmissionSchema(SQLAlchemySchema):
     programme_id = auto_field(model=Programme, data_key="ProgrammeID")
     reporting_period_start = fields.Raw(data_key="ReportingPeriodStart")
     reporting_period_end = fields.Raw(data_key="ReportingPeriodEnd")
-    reporting_round = auto_field(data_key="ReportingRound")
+    reporting_round = auto_field(model=ProgrammeJunction, data_key="ReportingRound")

--- a/tests/controller_tests/test_filters.py
+++ b/tests/controller_tests/test_filters.py
@@ -225,28 +225,24 @@ def test_get_reporting_period_range(seeded_test_client_rollback):
         submission_date=datetime(2023, 5, 1),
         reporting_period_start=datetime(2023, 4, 1),
         reporting_period_end=datetime(2023, 4, 30),
-        reporting_round=1,
     )
     sub2 = Submission(
         submission_id="2",
         submission_date=datetime(2024, 5, 5),
         reporting_period_start=datetime(2024, 5, 1),
         reporting_period_end=datetime(2024, 5, 31),
-        reporting_round=2,
     )
     sub3 = Submission(
         submission_id="3",
         submission_date=datetime(2025, 6, 1),
         reporting_period_start=datetime(2025, 6, 1),
         reporting_period_end=datetime(2025, 6, 30),
-        reporting_round=1,
     )
     sub4 = Submission(
         submission_id="4",
         submission_date=datetime(2021, 6, 5),
         reporting_period_start=datetime(2021, 6, 1),
         reporting_period_end=datetime(2021, 6, 30),
-        reporting_round=2,
     )
     submissions = [sub1, sub2, sub3, sub4]
     db.session.add_all(submissions)

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -564,7 +564,6 @@ def test_save_submission_file_name_and_user_metadata(seeded_test_client_rollback
         submission_date=datetime(2024, 5, 1),
         reporting_period_start=datetime(2024, 4, 1),
         reporting_period_end=datetime(2024, 4, 30),
-        reporting_round=1,
     )
     db.session.add(new_sub)
 

--- a/tests/resources/submission_dim.csv
+++ b/tests/resources/submission_dim.csv
@@ -1,2 +1,2 @@
-id,submission_id,ingest_date,submission_date,reporting_period_start,reporting_period_end,reporting_round,submission_filename
-97386631-d515-481b-8a79-46cc1317ea54,S-R03-1,03/12/1955,12/03/1945,02/01/2023,02/12/2023,3,test_submission.xlsx
+id,submission_id,ingest_date,submission_date,reporting_period_start,reporting_period_end,submission_filename
+97386631-d515-481b-8a79-46cc1317ea54,S-R03-1,03/12/1955,12/03/1945,02/01/2023,02/12/2023,test_submission.xlsx


### PR DESCRIPTION
### Change description
Removes the `submission.reporting_round` column from the code. The DB column itself will be dropped in a followup PR (https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/596) because migrations run before code deployment. If we drop the column, the code can still refer to the column when making queries (SQLAlchemy selects each column individually rather than using *). So any reads on the submission table may try to read from the `reporting_round` column, which the migration will remove. That would raise errors.

Also updates a few unit tests and fixtures to remove `reporting_round` entries that were missed previously.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
