### PR TITLE
SMD-732: Improve TF validation

### DIFF
--- a/core/messaging/__init__.py
+++ b/core/messaging/__init__.py
@@ -127,6 +127,7 @@ class SharedMessages:
         "You entered {wrong_type} instead of a date. Check the cell is formatted as a date, "
         "for example, Dec-22 or Jun-23"
     )
+    GENERIC_WRONG_TYPE = "You entered {wrong_type} instead of {expected_type}. Check the data is correct."
     WRONG_TYPE_CURRENCY = (
         "You entered text instead of a number. Check the cell is formatted as currency and only enter numbers. "
         "For example, £5,588.13 or £238,062.50"

--- a/core/messaging/tf_messaging.py
+++ b/core/messaging/tf_messaging.py
@@ -107,6 +107,7 @@ class TFMessenger(MessengerBase):
         "Private Sector Funding Secured": ("Private Sector Funding Secured", "Private Sector Investment"),
         "Spend for Reporting Period": ("Financial Year 2022/21 - Financial Year 2025/26", "Project Funding Profiles"),
         "Amount": ("Financial Year 2022/21 - Financial Year 2025/26", "Project Outputs"),
+        "Response": ("All Columns", "Funding Questions"),
     }
 
     # mapping of user submitted column names per table to its original excel column letter index
@@ -294,8 +295,16 @@ class TFMessenger(MessengerBase):
         sheet = self.INTERNAL_TABLE_TO_FORM_SHEET[validation_failure.table]
         _, section = self.INTERNAL_COLUMN_TO_FORM_COLUMN_AND_SECTION[validation_failure.column]
         actual_type = self.INTERNAL_TYPE_TO_MESSAGE_FORMAT[validation_failure.actual_type]
+        expected_type = self.INTERNAL_TYPE_TO_MESSAGE_FORMAT[validation_failure.expected_type]
+
+        column = validation_failure.column
+        if section == "Funding Questions":
+            column = validation_failure.failed_row["Indicator"]
+
         cell_index = self._construct_cell_index(
-            table=validation_failure.table, column=validation_failure.column, row_index=validation_failure.row_index
+            table=validation_failure.table,
+            column=column,
+            row_index=validation_failure.row_index,
         )
 
         if sheet == "Outcomes":
@@ -307,6 +316,9 @@ class TFMessenger(MessengerBase):
 
         if validation_failure.expected_type == datetime:
             message = self.msgs.WRONG_TYPE_DATE.format(wrong_type=actual_type)
+        elif validation_failure.expected_type not in [int, float]:
+            # not a currency related type error
+            message = self.msgs.GENERIC_WRONG_TYPE.format(wrong_type=actual_type, expected_type=expected_type)
         elif sheet == "PSI":
             message = self.msgs.WRONG_TYPE_CURRENCY
         elif sheet == "Funding Profiles":

--- a/tests/messaging_tests/test_tf_messaging.py
+++ b/tests/messaging_tests/test_tf_messaging.py
@@ -326,6 +326,62 @@ def test_wrong_type_messages():
         )
     )
 
+    message = test_messeger._wrong_type_failure_message(
+        WrongTypeFailure(
+            table="Project Details",
+            column="Single or Multiple Locations",
+            expected_type=str,
+            actual_type=datetime,
+            row_index=100,
+            failed_row=None,
+        )
+    )
+
+    assert message.description.startswith("You entered a date instead of text.")
+
+
+def test_funding_questions_wrong_type_messages():
+    test_messenger = TFMessenger()
+
+    failures = [
+        WrongTypeFailure(
+            table="Funding Questions",
+            column="Response",
+            expected_type=str,
+            actual_type=datetime,
+            row_index=18,
+            failed_row=pd.Series({"Indicator": "TD 5% CDEL Pre-Payment\n(Towns Fund FAQs p.46 - 49)"}),
+        ),
+        WrongTypeFailure(
+            table="Funding Questions",
+            column="Response",
+            expected_type=str,
+            actual_type=datetime,
+            row_index=18,
+            failed_row=pd.Series({"Indicator": "TD RDEL Capacity Funding"}),
+        ),
+        WrongTypeFailure(
+            table="Funding Questions",
+            column="Response",
+            expected_type=str,
+            actual_type=datetime,
+            row_index=18,
+            failed_row=pd.Series({"Indicator": "TD Accelerated Funding"}),
+        ),
+    ]
+
+    output = failures_to_messages(failures, test_messenger)
+
+    assert isinstance(output, list)
+    assert len(output) == 1
+    assert output[0] == Message(
+        "Funding Profiles",
+        "Funding Questions",
+        ("E18", "F18", "I18"),
+        "You entered a date instead of text. Check the data is correct.",
+        "WrongTypeFailure",
+    )
+
 
 def test_enum_failure_with_footfall_geography_indicator_wrong():
     test_messeger = TFMessenger()


### PR DESCRIPTION
Return user friendly error for cells that are expected to be str but datetime is provided.

Add generic message for type mismatch, however to not break existing currency validation, we ignore numbers.

Especially for Funding Question section. Where the `Response` column must be mapped to a particular `Question` sheet column.

_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines


### How to test
_Are tests passing? Alternatively ask me for a sheet that reproduces the error._


### Screenshots
![image](https://github.com/communitiesuk/funding-service-design-post-award-data-store/assets/6387619/3a832055-efc3-412d-9bd9-f06f00205e8c)


