### PR TITLE
BAU: Update Bastion Security Group config

### DIFF
--- a/copilot/data-store/addons/data-store-cluster.yml
+++ b/copilot/data-store/addons/data-store-cluster.yml
@@ -63,7 +63,7 @@ Resources:
           IpProtocol: tcp
           Description: !Sub 'From the Bastion Security Group.'
           SourceSecurityGroupId:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref datastoreclusterAuroraSecret, ":SecretString:bastionSecurityGroup}}" ]]
+            "{{resolve:secretsmanager:bastionSecurityGroup:SecretString:bastionSecurityGroup}}"
       VpcId:
         Fn::ImportValue:
           !Sub '${App}-${Env}-VpcId'


### PR DESCRIPTION
### Change description
Update copilot manifest to point to new `bastionSecurityGroup` secret in AWS.

This moves the secret to an environment level and decouples from the other data-store secrets, avoiding a cyclical reference to the key in the manifest before it's been created if re-creating the application from scratch.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
