### PR TITLE
Switch copilot deployment order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,10 +73,10 @@ jobs:
       - name: Run database migrations
         run: scripts/migration-task-script.py ${{ inputs.environment || 'test' }} ${{ env.IMAGE_LOCATION }}
 
-      - name: Copilot deploy Data Store celery worker
-        run: |
-          copilot svc deploy --name data-store-celery
-
       - name: Copilot deploy Data Store API
         run: |
           copilot svc deploy --name data-store
+
+      - name: Copilot deploy Data Store celery worker
+        run: |
+          copilot svc deploy --name data-store-celery


### PR DESCRIPTION
The celery deploy is stuck at 'review in progress'. I think data-store actually needs to go first (at least for the first run), so that it can update data-store addons and export values for the data-store-celery workload to use.

_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
