### PR TITLE
Use a shorter redis group name

### DIFF
--- a/copilot/data-store/addons/data-store-redis.yml
+++ b/copilot/data-store/addons/data-store-redis.yml
@@ -53,7 +53,7 @@ Resources:
   DataStoreRedisReplicationGroup:
     Type: AWS::ElastiCache::ReplicationGroup
     Properties:
-      ReplicationGroupId: !Sub 'funding-service-data-store-redis-${Env}'
+      ReplicationGroupId: !Sub 'data-store-redis-${Env}'
       ReplicationGroupDescription: !Sub '${Env} Funding Service Data Store Redis'
       AutomaticFailoverEnabled: true
       AtRestEncryptionEnabled: true


### PR DESCRIPTION
When deploying this infrastructure change to production, AWS CloudFormation was unable to create the cluster because the replication group ID ('funding-service-data-store-redis-production') was too long; there is a hard limit of 40 characters on the replication group name. Which we didn't know/factor in beforehand. This deployed find on dev and test environments because those envs have shorter names (...dev and test), which coincidentally stayed under the limit.

I've manually applied these changes to dev and test environments already to get everything consistent there, which involved:

* deleting the data-store-celery services, as they rely on the existing (badly-named) redis rep. group.
* renaming all of the resources in the redis coplit manifest with a '2' suffix to make them unique
* deploying these to both envs, which switches everything to the 2 version.
* removing the '2' suffixes from the manifest and updating the redis replication group name to be shorter (remove the 'funding-service-') prefix.
* deploying that to both envs.
* re-creating the data-store-celery service