### PR TITLE
Celery logging

### DIFF
--- a/core/celery.py
+++ b/core/celery.py
@@ -1,0 +1,84 @@
+import time
+from contextlib import contextmanager
+from os import getpid
+
+from celery import Task
+
+
+def make_task(app):
+    class FSDTask(Task):
+        abstract = True
+        start = None
+
+        @property
+        def queue_name(self):
+            delivery_info = self.request.delivery_info or {}
+            return delivery_info.get("routing_key", "none")
+
+        @contextmanager
+        def app_context(self):
+            with app.app_context():
+                yield
+
+        def on_success(self, retval, task_id, args, kwargs):
+            with self.app_context():
+                elapsed_time = time.monotonic() - self.start
+
+                app.logger.info(
+                    "Celery task %s (task_id: %s, queue: %s) took %.4f",
+                    self.name,
+                    self.request.id,
+                    self.queue_name,
+                    elapsed_time,
+                    extra={
+                        "task_id": self.request.id,
+                        "celery_task": self.name,
+                        "queue_name": self.queue_name,
+                        "time_taken": elapsed_time,
+                        # avoid name collision with LogRecord's own `process` attribute
+                        "process_": getpid(),
+                    },
+                )
+
+        def on_failure(self, exc, task_id, args, kwargs, einfo):
+            with self.app_context():
+                elapsed_time = time.monotonic() - self.start
+
+                app.logger.exception(
+                    "Celery task %s (task_id: %s, queue: %s) failed after %.4f",
+                    self.name,
+                    self.request.id,
+                    self.queue_name,
+                    elapsed_time,
+                    extra={
+                        "task_id": self.request.id,
+                        "celery_task": self.name,
+                        "queue_name": self.queue_name,
+                        "time_taken": elapsed_time,
+                        # avoid name collision with LogRecord's own `process` attribute
+                        "process_": getpid(),
+                    },
+                )
+
+        def __call__(self, *args, **kwargs):
+            # ensure task has flask context to access config, logger, etc
+            with self.app_context():
+                self.start = time.monotonic()
+
+                app.logger.info(
+                    "Celery task %s (task_id: %s, queue: %s) starting",
+                    self.name,
+                    self.request.id,
+                    self.queue_name,
+                    extra={
+                        "task_id": self.request.id,
+                        "celery_task": self.name,
+                        "queue_name": self.queue_name,
+                        # avoid name collision with LogRecord's own `process` attribute
+                        "process_": getpid(),
+                    },
+                )
+
+                return super().__call__(*args, **kwargs)
+
+    return FSDTask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -152,7 +152,7 @@ flipper-client==1.3.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==3.0.1
+funding-service-design-utils==3.0.2
     # via -r requirements.txt
 gunicorn==20.1.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ flask-sqlalchemy==3.0.3
     #   funding-service-design-utils
 flipper-client==1.3.1
     # via funding-service-design-utils
-funding-service-design-utils==3.0.1
+funding-service-design-utils==3.0.2
     # via -r requirements.in
 gunicorn==20.1.0
     # via funding-service-design-utils


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-104

### Change description
Updates fsd_utils to pull in the [new utils changes](https://github.com/communitiesuk/funding-service-design-utils/pull/148) that change how logging is configured behind-the-scenes (to use dictConfig rather than imperatively configuring the loggers).

This means that we can grab the default logging config and use that to configure the celery workers, too, giving us consistent logging via the Flask app logger.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")