### PR TITLE
Bump fsd-utils/sentry SDK for queue monitoring

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -152,7 +152,7 @@ flipper-client==1.3.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.19
+funding-service-design-utils==3.0.1
     # via -r requirements.txt
 gunicorn==20.1.0
     # via
@@ -396,7 +396,7 @@ semver==2.13.0
     # via
     #   -r requirements.txt
     #   prance
-sentry-sdk[flask]==1.45.0
+sentry-sdk[flask]==2.7.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,8 @@
 #-----------------------------------
 #   Utils
 #-----------------------------------
-funding-service-design-utils<=2.1.0
+funding-service-design-utils
+
 
 #-----------------------------------
 #   Flask Version

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ flask-sqlalchemy==3.0.3
     #   funding-service-design-utils
 flipper-client==1.3.1
     # via funding-service-design-utils
-funding-service-design-utils==2.0.19
+funding-service-design-utils==3.0.1
     # via -r requirements.in
 gunicorn==20.1.0
     # via funding-service-design-utils
@@ -183,7 +183,6 @@ pyjwt[crypto]==2.6.0
     # via
     #   funding-service-design-utils
     #   notifications-python-client
-    #   pyjwt
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.19.3
@@ -232,7 +231,7 @@ s3transfer==0.6.0
     # via boto3
 semver==2.13.0
     # via prance
-sentry-sdk[flask]==1.45.0
+sentry-sdk[flask]==2.7.1
     # via
     #   -r requirements.in
     #   funding-service-design-utils


### PR DESCRIPTION
### Change description
Pull in latest fsd_utils, so that we can use the latest version of sentry, which has queue monitoring features.