### PR TITLE
Prevent downloads from failing on empty strings

### DIFF
--- a/core/controllers/async_download.py
+++ b/core/controllers/async_download.py
@@ -28,7 +28,6 @@ def trigger_async_download(body: dict) -> None:
     - rp_end: the end of the reporting period
     - outcome_categories: a list of outcome category to filter the download by
     """
-
     email_address = body["email_address"]
     file_format = body["file_format"]
     funds = body.get("funds", None)

--- a/core/db/queries.py
+++ b/core/db/queries.py
@@ -95,6 +95,14 @@ def download_data_base_query(
     :param outcome_categories: (optional) List of additional outcome_categories
     :return: SQLAlchemy query (to extend as required).
     """
+
+    # Swagger's UI can send lists of blank values (ie `['']`) through to these values; we should remove any
+    # empty values so that filters don't break.
+    fund_type_ids = list(filter(lambda fund_type_id: fund_type_id, fund_type_ids or []))
+    outcome_categories = list(filter(lambda outcome_category: outcome_category, outcome_categories or []))
+    organisation_uuids = list(filter(lambda org_id: org_id, organisation_uuids or []))
+    itl1_regions = list(filter(lambda region: region, itl1_regions or []))
+
     submission_period_condition = set_submission_period_condition(min_rp_start, max_rp_end)
     fund_type_condition = ents.Fund.fund_code.in_(fund_type_ids) if fund_type_ids else True
     organisation_name_condition = ents.Organisation.id.in_(organisation_uuids) if organisation_uuids else True

--- a/tests/db_tests/test_queries.py
+++ b/tests/db_tests/test_queries.py
@@ -329,6 +329,20 @@ def test_project_if_no_outcomes(seeded_test_client_rollback, additional_test_dat
     assert list(test_df["project_name"])
 
 
+def test_download_data_base_query_removes_empty_strings_from_filter_lists(
+    seeded_test_client_rollback, additional_test_data
+):
+    # This should not throw an error.
+    download_data_base_query(
+        min_rp_start=None,
+        max_rp_end=None,
+        organisation_uuids=[""],
+        fund_type_ids=[""],
+        itl1_regions=[""],
+        outcome_categories=[""],
+    ).count()
+
+
 def test_transaction_retry_wrapper_wrapper_max_retries(mocker, test_session, caplog):
     """
     Test the behavior of 'transaction_retry_wrapper' in case of IntegrityError.


### PR DESCRIPTION
### Change description
When using the swagger UI to hit `trigger_async_download`, if the `send empty values` checkbox is filled, then the API request sent for the `organisation` (for example) field will be: `['']`.

This is treated as 'truthy' for the query, so would end up running some SQL like `WHERE organisation_id = ''::uuid`.

SQL can't convert an empty string to a UUID, and so throws an error.

Let's fix this by filtering out any empty string values first.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
