### PR TITLE
Force file to download rather than open in the browser

### DIFF
--- a/core/controllers/async_download.py
+++ b/core/controllers/async_download.py
@@ -147,7 +147,11 @@ def get_presigned_url(filename: str):
 
     url = _S3_CLIENT.generate_presigned_url(
         "get_object",
-        Params={"Bucket": Config.AWS_S3_BUCKET_FIND_DATA_FILES, "Key": filename},
+        Params={
+            "Bucket": Config.AWS_S3_BUCKET_FIND_DATA_FILES,
+            "Key": filename,
+            "ResponseContentDisposition": f'attachment; filename="{filename}"',
+        },
         ExpiresIn=1600,
     )
     return {"presigned_url": url}

--- a/tests/integration_tests/test_async_download.py
+++ b/tests/integration_tests/test_async_download.py
@@ -101,6 +101,7 @@ def test_download_file_presigned_url(test_session, test_buckets):
     assert response.status_code == 200
     presigned_url = response.json["presigned_url"]
     assert filename in presigned_url
+    assert "content-disposition=attachment" in presigned_url
 
 
 def test_download_file_failed_presigned_url(test_session, test_buckets):


### PR DESCRIPTION
### Change description
Force presigned URLs for find download files to actually download, as otherwise the browser may choose to open them in the browser (eg in web excel).

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
