### PR TITLE
Allow healthcheck in maintenance mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,9 +143,13 @@ def create_app(config_class=Config) -> Flask:
 
     @flask_app.before_request
     def maintenance_page() -> str | None:
-        if (not request.endpoint or not request.endpoint.endswith(".static")) and current_app.config[
-            "MAINTENANCE_MODE"
-        ]:
+        is_static_asset = request.endpoint and request.endpoint.endswith(".static")
+        is_healthcheck = request.endpoint and request.endpoint == "any_host_healthcheck"
+        if is_static_asset or is_healthcheck:
+            return None
+
+        is_in_maintenance_mode = current_app.config["MAINTENANCE_MODE"]
+        if is_in_maintenance_mode:
             return render_template(
                 "common/maintenance-mode.html", maintenance_ends_from=current_app.config["MAINTENANCE_ENDS_FROM"]
             )

--- a/tests/common_tests/test_maintenance_mode.py
+++ b/tests/common_tests/test_maintenance_mode.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_find_maintenance_mode(unauthenticated_find_test_client):
     unauthenticated_find_test_client.application.config["MAINTENANCE_MODE"] = False
     response = unauthenticated_find_test_client.get("/login")
@@ -24,3 +27,22 @@ def test_submit_maintenance_mode(unauthenticated_submit_test_client):
     assert response.status_code == 200
     assert "Submit monitoring and evaluation data" in response.text
     assert "Sorry, the service is unavailable" in response.text
+
+
+@pytest.mark.parametrize(
+    "test_client", ("unauthenticated_find_test_client", "unauthenticated_submit_test_client"), indirect=True
+)
+def test_maintenance_mode_healthcheck_available(test_client):
+    test_client.application.config["MAINTENANCE_MODE"] = True
+    response = test_client.get("/healthcheck")
+    assert response.status_code == 200
+    assert response.json["checks"][0]["check_flask_running"] == "OK"
+
+
+@pytest.mark.parametrize(
+    "test_client", ("unauthenticated_find_test_client", "unauthenticated_submit_test_client"), indirect=True
+)
+def test_maintenance_mode_static_assets_available(test_client):
+    test_client.application.config["MAINTENANCE_MODE"] = True
+    response = test_client.get("/static/govuk-frontend/govuk-frontend-4.7.0.min.css")
+    assert response.status_code == 200


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-451

### Change description
Allows hitting `/healthcheck` in maintenance mode

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")