### PR TITLE
Fix deprecation warnings and turn them into errors in the future

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 env = FLASK_ENV=unit_test
 testpaths =
 	tests
+filterwarnings =
+  error

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ testpaths =
 	tests
 filterwarnings =
   error
+  ignore:Conditional Formatting extension is not supported and will be removed:UserWarning
+  ignore:Data Validation extension is not supported and will be removed:UserWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -138,7 +138,7 @@ flask==2.2.5
     #   govuk-frontend-wtf
     #   sentry-sdk
     #   types-flask-migrate
-flask-assets==2.0
+flask-assets==2.1.0
     # via -r requirements.txt
 flask-babel==2.0.0
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -54,7 +54,7 @@ wtforms==3.0.1  # Pin this specific version until we bump to GOV.UK Frontend v5.
 #-----------------------------------
 #   frontend assets
 #-----------------------------------
-flask-assets==2.0
+flask-assets~=2.0
 cssmin==0.2.0
 jsmin==3.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ flask==2.2.5
     #   funding-service-design-utils
     #   govuk-frontend-wtf
     #   sentry-sdk
-flask-assets==2.0
+flask-assets==2.1.0
     # via -r requirements.in
 flask-babel==2.0.0
     # via funding-service-design-utils

--- a/tests/data_store_tests/transformation_tests/test_transformation_utils.py
+++ b/tests/data_store_tests/transformation_tests/test_transformation_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from pandas import NaT, Timestamp
 from pandas.testing import assert_frame_equal
 
@@ -82,6 +83,7 @@ def test_financial_conversion():
     assert list(test_df.columns) == ["test_data", "Start_Date", "End_Date"]
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")  # From the `0` date.
 def test_excel_datetime_conversion():
     """Check util function converts columns of DataFrame from Excel datetime format."""
     test_df = pd.DataFrame(

--- a/tests/find_tests/test_routes.py
+++ b/tests/find_tests/test_routes.py
@@ -33,7 +33,7 @@ def test_download_get(mocker, find_test_client):
     response = find_test_client.get("/download")
     assert response.status_code == 200
 
-    page = BeautifulSoup(response.text)
+    page = BeautifulSoup(response.text, "html.parser")
     assert page.select_one(".govuk-back-link") is None
 
 
@@ -126,7 +126,7 @@ def test_back_link(find_test_client, url):
     response = find_test_client.get(url)
     assert response.status_code == 200
 
-    page = BeautifulSoup(response.text)
+    page = BeautifulSoup(response.text, "html.parser")
     back_links = page.select(".govuk-back-link")
     assert len(back_links) == 1
     assert back_links[0].text.strip() == "Back"
@@ -168,7 +168,7 @@ def test_download_file_exist(find_test_client):
         )
 
     assert response.status_code == 200
-    page = BeautifulSoup(response.text)
+    page = BeautifulSoup(response.text, "html.parser")
     download_button = page.select_one("button#download")
     assert download_button is not None
 
@@ -180,7 +180,7 @@ def test_file_not_found(find_test_client):
         )
 
     assert response.status_code == 200
-    page = BeautifulSoup(response.text)
+    page = BeautifulSoup(response.text, "html.parser")
     download_button = page.select_one("button#download")
     assert download_button is None
     assert b"Your link to download data has expired" in response.data

--- a/tests/submit_tests/test_routes.py
+++ b/tests/submit_tests/test_routes.py
@@ -19,7 +19,7 @@ def test_index_page(submit_test_client):
 def test_select_fund_page_with_tf_role(submit_test_client, mocker):
     mocker.patch.object(TOWNS_FUND_APP_CONFIG, "active", True)
     response = submit_test_client.get("/dashboard")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert '<a class="govuk-heading-m govuk-link--no-visited-state" href="/upload/TF/5" id="TF"> Towns Fund</a>' in str(
         page_html
@@ -33,7 +33,7 @@ def test_select_fund_page_with_tf_role(submit_test_client, mocker):
 def test_select_fund_page_with_pf_role(submit_test_client, mocked_pf_auth):
     response = submit_test_client.get("/dashboard")
     assert response.status_code == 200
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert (
         '<a class="govuk-heading-m govuk-link--no-visited-state" href="/upload/TF/5" id="TF"> Towns Fund</a>'
         not in page_html
@@ -47,7 +47,7 @@ def test_select_fund_page_with_pf_role(submit_test_client, mocked_pf_auth):
 def test_select_fund_page_with_tf_and_pf_roles(submit_test_client, mocked_pf_and_tf_auth, monkeypatch):
     monkeypatch.setattr(TOWNS_FUND_APP_CONFIG, "active", True)
     response = submit_test_client.get("/dashboard")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert '<a class="govuk-heading-m govuk-link--no-visited-state" href="/upload/TF/5" id="TF"> Towns Fund</a>' in str(
         page_html
@@ -61,7 +61,7 @@ def test_select_fund_page_with_tf_and_pf_roles(submit_test_client, mocked_pf_and
 def test_inactive_fund_not_accessible_on_dashboard(submit_test_client, mocked_pf_and_tf_auth, monkeypatch):
     monkeypatch.setattr(TOWNS_FUND_APP_CONFIG, "active", False)
     response = submit_test_client.get("/dashboard")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "Towns Fund" not in str(page_html)
 
@@ -77,7 +77,7 @@ def test_inactive_fund_not_accessible_on_route(submit_test_client, mocked_pf_and
 def test_towns_fund_role(submit_test_client, mocked_auth, monkeypatch):
     monkeypatch.setattr(TOWNS_FUND_APP_CONFIG, "active", True)
     response = submit_test_client.get(f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     # Assert the Towns Fund view is displayed
     assert "Towns Fund" in str(page_html)
@@ -85,7 +85,7 @@ def test_towns_fund_role(submit_test_client, mocked_auth, monkeypatch):
 
 def test_pathfinders_role(submit_test_client, mocked_pf_auth):
     response = submit_test_client.get("/upload/PF/1")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     # Assert the Pathfinders view is displayed instead of Towns Fund
     assert "Pathfinders" in str(page_html)
@@ -94,7 +94,7 @@ def test_pathfinders_role(submit_test_client, mocked_pf_auth):
 def test_upload_page(submit_test_client, mocker):
     mocker.patch.object(TOWNS_FUND_APP_CONFIG, "active", True)
     response = submit_test_client.get(f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}")
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "Upload your data return" in str(page_html)
     assert "When you upload your return, we’ll check it for missing data and formatting errors." in str(page_html)
@@ -113,7 +113,7 @@ def test_upload_xlsx_successful(submit_test_client, example_pre_ingest_data_file
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_pre_ingest_data_file}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "Return submitted" in str(page_html)
     assert "We’ll do this using the email you’ve provided." in str(page_html)
@@ -175,7 +175,7 @@ def test_upload_xlsx_prevalidation_errors(example_pre_ingest_data_file, submit_t
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_pre_ingest_data_file}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "The selected file must be an Excel file" in str(page_html)
 
@@ -213,7 +213,7 @@ def test_upload_xlsx_validation_errors(example_pre_ingest_data_file, submit_test
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_pre_ingest_data_file}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "There are errors in your return" in str(page_html)
     assert "Project admin" in str(page_html)
@@ -233,7 +233,7 @@ def test_upload_ingest_generic_bad_request(example_pre_ingest_data_file, submit_
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_pre_ingest_data_file}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 500
     assert "Sorry, there is a problem with the service" in str(page_html)
     assert "Try again later." in str(page_html)
@@ -256,7 +256,7 @@ def test_upload_xlsx_uncaught_validation_error(example_pre_ingest_data_file, sub
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_pre_ingest_data_file}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
 
     assert response.status_code == 500
     assert "Sorry, there is a problem with the service" in str(page_html)
@@ -271,7 +271,7 @@ def test_upload_wrong_format(submit_test_client, example_ingest_wrong_format, mo
     response = submit_test_client.post(
         f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": example_ingest_wrong_format}
     )
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "The selected file must be an XLSX" in str(page_html)
 
@@ -279,7 +279,7 @@ def test_upload_wrong_format(submit_test_client, example_ingest_wrong_format, mo
 def test_upload_no_file(submit_test_client, example_ingest_wrong_format, mocker):
     mocker.patch.object(TOWNS_FUND_APP_CONFIG, "active", True)
     response = submit_test_client.post(f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}", data={"ingest_spreadsheet": None})
-    page_html = BeautifulSoup(response.data)
+    page_html = BeautifulSoup(response.data, "html.parser")
     assert response.status_code == 200
     assert "Select your returns template" in str(page_html)
 


### PR DESCRIPTION
### Change description
Turn warnings into errors so that we always deal with them

At the moment, warnings emitted during the test run are reported at the
end. But we've basically just been ignoring these and not doing anything
about them.

We can instead tell pytest to report them as errors, which will result
in failed test runs. This will force us to deal with warnings emitted by
our (or our dependencies') code. These can be things like
DeprecationWarnings, which can be early warning signs for our
dependencies changing how things are done and that we need to make
changes in our code.

Or they can be telling us that we're using some library incorrectly or
imprecisely, and should probably do something different.

To make sure that we're staying on top of our code, we should have a
rule that all warnings are addressed. This can either be through us
fixing/changing something in our code, or by explicitly ignoring the
warning (to say "we acknowledge this and accept it").

### Before
<details><summary>Pytest warnings summary</summary>
<p>

```
========================================================== warnings summary ===========================================================
venv/lib/python3.11/site-packages/flask_assets.py:8
venv/lib/python3.11/site-packages/flask_assets.py:8
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/flask_assets.py:8: DeprecationWarning: '_request_ctx_stack' is deprecated and will be removed in Flask 2.3.
    from flask import _request_ctx_stack, current_app

venv/lib/python3.11/site-packages/flask_assets.py:317: 11 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/flask_assets.py:317: DeprecationWarning: '_request_ctx_stack' is deprecated and will be removed in Flask 2.3. Use 'g' to store data, or 'request_ctx' to access the current context.
    ctx = _request_ctx_stack.top

venv/lib/python3.11/site-packages/flask_assets.py:322: 22 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/flask_assets.py:322: DeprecationWarning: '_app_ctx_stack' is deprecated and will be removed in Flask 2.3.
    from flask import _app_ctx_stack

venv/lib/python3.11/site-packages/flask_assets.py:323: 11 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/flask_assets.py:323: DeprecationWarning: '_app_ctx_stack' is deprecated and will be removed in Flask 2.3. Use 'g' to store data, or 'app_ctx' to access the current context.
    app_ctx = _app_ctx_stack.top

tests/common_tests/test_maintenance_mode.py: 12 warnings
tests/find_tests/test_routes.py: 30 warnings
tests/submit_tests/test_routes.py: 56 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/flask_assets.py:273: DeprecationWarning: '_request_ctx_stack' is deprecated and will be removed in Flask 2.3. Use 'g' to store data, or 'request_ctx' to access the current context.
    if not _request_ctx_stack.top:

tests/data_store_tests/controller_tests/test_admin_tasks.py: 36 warnings
tests/data_store_tests/controller_tests/test_ingest_functions.py: 9 warnings
tests/integration_tests/test_ingest_component_all_funds.py: 27 warnings
tests/integration_tests/test_ingest_component_towns_fund.py: 171 warnings
tests/integration_tests/test_ingest_metrics.py: 18 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/openpyxl/worksheet/_reader.py:329: UserWarning: Conditional Formatting extension is not supported and will be removed
    warn(msg)

tests/data_store_tests/controller_tests/test_admin_tasks.py: 35 warnings
tests/data_store_tests/controller_tests/test_ingest_functions.py: 7 warnings
tests/integration_tests/test_ingest_component_all_funds.py: 42 warnings
tests/integration_tests/test_ingest_component_pathfinders.py: 63 warnings
tests/integration_tests/test_ingest_component_towns_fund.py: 133 warnings
tests/integration_tests/test_ingest_db_transactions.py: 14 warnings
tests/integration_tests/test_ingest_metrics.py: 21 warnings
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/openpyxl/worksheet/_reader.py:329: UserWarning: Data Validation extension is not supported and will be removed
    warn(msg)

tests/data_store_tests/transformation_tests/test_transformation_utils.py::test_excel_datetime_conversion
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/pandas/core/tools/datetimes.py:557: RuntimeWarning: invalid value encountered in cast
    arr, tz_parsed = tslib.array_with_unit_to_datetime(arg, unit, errors=errors)

tests/find_tests/test_routes.py::test_download_get
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py:36: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 36 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page = BeautifulSoup(response.text)

tests/find_tests/test_routes.py::test_back_link[/help]
tests/find_tests/test_routes.py::test_back_link[/data-glossary]
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py:129: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 129 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page = BeautifulSoup(response.text)

tests/find_tests/test_routes.py::test_download_file_exist
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py:171: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 171 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page = BeautifulSoup(response.text)

tests/find_tests/test_routes.py::test_file_not_found
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py:183: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 183 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/find_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page = BeautifulSoup(response.text)

tests/submit_tests/test_routes.py::test_select_fund_page_with_tf_role
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:22: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 22 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_select_fund_page_with_pf_role
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:36: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 36 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_select_fund_page_with_tf_and_pf_roles
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:50: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 50 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_inactive_fund_not_accessible_on_dashboard
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:64: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 64 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_towns_fund_role
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:80: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 80 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_pathfinders_role
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:88: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 88 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_page
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:97: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 97 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_xlsx_successful
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:116: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 116 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_xlsx_prevalidation_errors
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:178: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 178 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_xlsx_validation_errors
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:216: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 216 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_ingest_generic_bad_request
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:236: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 236 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_xlsx_uncaught_validation_error
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:259: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 259 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_wrong_format
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:274: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 274 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

tests/submit_tests/test_routes.py::test_upload_no_file
  /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py:282: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

  The code that caused this warning is on line 282 of the file /Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/tests/submit_tests/test_routes.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.

    page_html = BeautifulSoup(response.data)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 618 passed, 1 skipped, 3 xfailed, 740 warnings in 51.81s =======================================
```

</p>
</details> 

### After
```
============================================= 618 passed, 1 skipped, 3 xfailed in 54.24s ==============================================
```