### PR TITLE
Initial playwright setup - test find flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip-compile requirements-dev.in
 * Pre-commit hooks can either be installed using pip `pip install pre-commit` or homebrew (for Mac users)`brew install pre-commit`
 * From your checkout directory run `pre-commit install` to set up the git hook scripts
 
-## Run App or Unit Tests Locally
+## Run App Locally
 
 Local Docker stack must be up-to-date and running with `docker compose up` in order to use the app/tests locally:
 https://github.com/communitiesuk/funding-service-design-post-award-docker-runner
@@ -88,6 +88,23 @@ To run the app locally:
 `flask run`
 
 App should be available at `http://localhost:8080`
+
+## Running the tests
+
+We use `pytest` to run all of our tests. We have a selection of unit, integration, and end-to-end (browser) tests. By default,
+the unit and integration tests will run with a basic invocation of `pytest.`
+
+### End-to-end (browser) tests
+
+As a one-off setup step, run `playwright install` to download and configure the browsers needed for these tests.
+
+To run the end-to-end (browser) tests, use `pytest --e2e`. This will, by default, run the browser tests headless - i.
+e. you won't see a browser appear. To display the browser so you can visually inspect the test journey, use `pytest
+--e2e --headed --slowmo 1000`. `--headed` displays the browser, and `--slowmo 1000` makes Playwright insert 1 second
+pauses between various steps so that you can follow what the test is doing more easily.
+
+The e2e test for find currently requires a `test`-scoped API key for GOV.UK Notify to retrieve the email send during
+the test.  Pass an environment variable called `E2E_NOTIFY_FIND_API_KEY` to allow this test to pass.
 
 ## Updating database migrations
 
@@ -194,7 +211,6 @@ On the deployed environments we use [Paketo buildpacks](https://paketo.io) rathe
 
 As it is deployed as a Backend Service on AWS the service is not publicly accessible.
 We have written a script to allow you to tunnel from your local machine to the environment
-
 * You will need to be granted AWS access with aws-vault setup as a pre-requisite (ask another developer how to gain access and set these up)
 * Use AWS vault to exec into the account for the environment you would like to access
 * Run: `./scripts/ssm-conn.sh 9999`

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -16,7 +16,7 @@ class UnitTestConfig(DefaultConfig):
     AWS_S3_BUCKET_SUCCESSFUL_FILES = "data-store-successful-files-unit-tests"
     AWS_S3_BUCKET_FIND_DOWNLOAD_FILES = "data-store-find-download-files-unit-tests"
     AWS_CONFIG = Config(retries={"max_attempts": 1, "mode": "standard"})
-    FIND_SERVICE_BASE_URL = "http://localhost:4002"
+    FIND_SERVICE_BASE_URL = "http://find-monitoring-data.levellingup.gov.localhost:4001"
     WTF_CSRF_ENABLED = False
 
     # RSA 256 KEYS

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
-env = FLASK_ENV=unit_test
+env =
+  FLASK_ENV=unit_test
+  D:E2E_NOTIFY_FIND_API_KEY=set-me-in-your-environment
+markers =
+  e2e: run e2e (browser) tests using playwright
 testpaths =
 	tests
 filterwarnings =

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,6 +11,7 @@ pytest-cov==4.1.0
 pytest-env
 pytest-mock
 requests-mock==1.11.0
+pytest-playwright
 
 #-----------------------------------
 #   Code Quality

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,13 +32,11 @@ blinker==1.8.2
     # via
     #   -r requirements.txt
     #   sentry-sdk
-boto3==1.34.143
-    # via
-    #   -r requirements.txt
-    #   flipper-client
+boto3==1.34.151
+    # via -r requirements.txt
 boto3-stubs==1.34.133
     # via types-boto3
-botocore==1.34.143
+botocore==1.34.151
     # via
     #   -r requirements.txt
     #   boto3
@@ -47,10 +45,6 @@ botocore-stubs==1.34.132
     # via boto3-stubs
 build==1.2.1
     # via pip-tools
-cachetools==5.3.3
-    # via
-    #   -r requirements.txt
-    #   flipper-client
 celery[redis]==5.4.0
     # via -r requirements.txt
 certifi==2024.7.4
@@ -164,11 +158,7 @@ flask-wtf==1.1.1
     # via
     #   -r requirements.txt
     #   govuk-frontend-wtf
-flipper-client==1.3.2
-    # via
-    #   -r requirements.txt
-    #   funding-service-design-utils
-funding-service-design-utils==4.0.2
+funding-service-design-utils==5.0.1
     # via -r requirements.txt
 govuk-frontend-jinja==2.7.0
     # via
@@ -176,6 +166,8 @@ govuk-frontend-jinja==2.7.0
     #   govuk-frontend-wtf
 govuk-frontend-wtf==2.5.0
     # via -r requirements.txt
+greenlet==3.0.3
+    # via playwright
 gunicorn==20.1.0
     # via
     #   -r requirements.txt
@@ -275,6 +267,8 @@ pip-tools==6.13.0
     # via -r requirements-dev.in
 platformdirs==4.2.0
     # via virtualenv
+playwright==1.45.1
+    # via pytest-playwright
 pluggy==1.0.0
     # via pytest
 pre-commit==3.6.1
@@ -295,10 +289,8 @@ pydantic==1.10.14
     #   pandera
 pydot==1.4.2
     # via -r requirements-dev.in
-pyee==6.0.0
-    # via
-    #   -r requirements.txt
-    #   flipper-client
+pyee==11.1.0
+    # via playwright
 pygments==2.18.0
     # via
     #   -r requirements.txt
@@ -318,19 +310,21 @@ pyproject-hooks==1.1.0
 pytest==7.3.1
     # via
     #   -r requirements-dev.in
+    #   pytest-base-url
     #   pytest-cov
     #   pytest-env
     #   pytest-mock
+    #   pytest-playwright
+pytest-base-url==2.1.0
+    # via pytest-playwright
 pytest-cov==4.1.0
     # via -r requirements-dev.in
 pytest-env==0.8.1
     # via -r requirements-dev.in
 pytest-mock==3.10.0
     # via -r requirements-dev.in
-python-consul==1.1.0
-    # via
-    #   -r requirements.txt
-    #   flipper-client
+pytest-playwright==0.5.1
+    # via -r requirements-dev.in
 python-dateutil==2.8.2
     # via
     #   -r requirements.txt
@@ -345,6 +339,8 @@ python-json-logger==2.0.7
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
+python-slugify==8.0.4
+    # via pytest-playwright
 pytz==2023.3
     # via
     #   -r requirements.txt
@@ -361,13 +357,12 @@ redis==4.5.4
     #   -r requirements.txt
     #   celery
     #   flask-redis
-    #   flipper-client
 requests==2.32.3
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
     #   notifications-python-client
-    #   python-consul
+    #   pytest-base-url
     #   requests-mock
 requests-mock==1.11.0
     # via -r requirements-dev.in
@@ -388,10 +383,8 @@ sentry-sdk[flask]==2.10.0
 six==1.16.0
     # via
     #   -r requirements.txt
-    #   python-consul
     #   python-dateutil
     #   requests-mock
-    #   thrift
 soupsieve==2.5
     # via
     #   -r requirements.txt
@@ -409,10 +402,8 @@ sqlalchemy-utils==0.41.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-thrift==0.20.0
-    # via
-    #   -r requirements.txt
-    #   flipper-client
+text-unidecode==1.3
+    # via python-slugify
 typeguard==4.0.0
     # via
     #   -r requirements.txt
@@ -480,6 +471,7 @@ typing-extensions==4.6.0
     #   boto3-stubs
     #   mypy
     #   pydantic
+    #   pyee
     #   sqlalchemy
     #   sqlalchemy-stubs
     #   typing-inspect

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #-----------------------------------
 #   Utils
 #-----------------------------------
-funding-service-design-utils>=4,<5
+funding-service-design-utils==5.0.1
 email_validator==2.0.0.post2
 
 #-----------------------------------
@@ -10,6 +10,11 @@ email_validator==2.0.0.post2
 Flask==2.2.5
 flask-talisman==1.0.0
 flask-WTF==1.1.1
+
+#-----------------------------------
+#   AWS
+#-----------------------------------
+boto3
 
 #-----------------------------------
 #   Excel Ingestion and Output

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,14 +18,12 @@ billiard==4.2.0
     # via celery
 blinker==1.8.2
     # via sentry-sdk
-boto3==1.34.143
-    # via flipper-client
-botocore==1.34.143
+boto3==1.34.151
+    # via -r requirements.in
+botocore==1.34.151
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
-    # via flipper-client
 celery[redis]==5.4.0
     # via -r requirements.in
 certifi==2024.7.4
@@ -96,9 +94,7 @@ flask-wtf==1.1.1
     # via
     #   -r requirements.in
     #   govuk-frontend-wtf
-flipper-client==1.3.2
-    # via funding-service-design-utils
-funding-service-design-utils==4.0.2
+funding-service-design-utils==5.0.1
     # via -r requirements.in
 govuk-frontend-jinja==2.7.0
     # via
@@ -174,8 +170,6 @@ pycparser==2.22
     # via cffi
 pydantic==1.10.14
     # via pandera
-pyee==6.0.0
-    # via flipper-client
 pygments==2.18.0
     # via rich
 pyjwt[crypto]==2.6.0
@@ -184,8 +178,6 @@ pyjwt[crypto]==2.6.0
     #   notifications-python-client
 pyparsing==3.0.9
     # via packaging
-python-consul==1.1.0
-    # via flipper-client
 python-dateutil==2.8.2
     # via
     #   botocore
@@ -206,12 +198,10 @@ redis==4.5.4
     # via
     #   celery
     #   flask-redis
-    #   flipper-client
 requests==2.32.3
     # via
     #   funding-service-design-utils
     #   notifications-python-client
-    #   python-consul
 rich==12.6.0
     # via funding-service-design-utils
 s3transfer==0.10.2
@@ -221,10 +211,7 @@ sentry-sdk[flask]==2.10.0
     #   -r requirements.in
     #   funding-service-design-utils
 six==1.16.0
-    # via
-    #   python-consul
-    #   python-dateutil
-    #   thrift
+    # via python-dateutil
 soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.9
@@ -236,8 +223,6 @@ sqlalchemy==2.0.9
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via funding-service-design-utils
-thrift==0.20.0
-    # via flipper-client
 typeguard==4.0.0
     # via pandera
 typing-extensions==4.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,25 @@ from submit.main.fund import TOWNS_FUND_APP_CONFIG
 from tests.resources.pathfinders.extracted_data import get_extracted_data
 
 
+def pytest_addoption(parser):
+    parser.addoption("--e2e", action="store_true", default=False, help="run e2e (browser) tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    skip_e2e = pytest.mark.skip(reason="only running non-e2e tests")
+    skip_non_e2e = pytest.mark.skip(reason="only running e2e tests")
+
+    e2e_run = config.getoption("--e2e")
+    if e2e_run:
+        for item in items:
+            if "e2e" not in item.keywords:
+                item.add_marker(skip_non_e2e)
+    else:
+        for item in items:
+            if "e2e" in item.keywords:
+                item.add_marker(skip_e2e)
+
+
 @pytest.fixture(scope="session")
 def test_session() -> Generator[FlaskClient, None, None]:
     """

--- a/tests/e2e_tests/helpers.py
+++ b/tests/e2e_tests/helpers.py
@@ -1,0 +1,65 @@
+import os
+import re
+import secrets
+import time
+
+import requests
+from notifications_python_client import NotificationsAPIClient
+from playwright._impl._errors import Error as PlaywrightError
+from playwright.sync_api import Page
+
+
+def login_via_magic_link(page: Page, test_name: str, email_domain: str = "levellingup.gov.test"):
+    response = requests.get("http://authenticator.levellingup.gov.localhost:4004/magic-links")
+    magic_links_before = set(response.json())
+
+    page.goto(
+        "http://authenticator.levellingup.gov.localhost:4004/service/magic-links/new"
+        "?fund=post-award-e2e-tests&round=r1w1"
+    )
+
+    # Help disambiguate tests running around the same time by injecting a random token into the email, so that
+    # when we lookup the email it should be unique. We avoid a UUID so as to keep the emails 'short enough'.
+    token = secrets.token_urlsafe(8)
+    email_address = f"fsd-e2e-tests+{test_name}-{token}@{email_domain}".lower()
+    page.get_by_role("textbox", name="email").fill(email_address)
+    page.get_by_role("button", name="Continue").click()
+
+    response = requests.get("http://authenticator.levellingup.gov.localhost:4004/magic-links")
+    magic_links_after = set(response.json())
+
+    new_magic_links = magic_links_after - magic_links_before
+    for magic_link in new_magic_links:
+        if magic_link.startswith("link:"):
+            break
+    else:
+        raise KeyError("Could not generate/retrieve a new magic link via authenticator")
+
+    magic_link_id = magic_link.split(":")[1]
+    try:
+        page.goto(f"http://authenticator.levellingup.gov.localhost:4004/magic-links/{magic_link_id}")
+    except PlaywrightError:
+        # FIXME: Authenticator gets into a weird redirect loop locally... We just ignore that error.
+        pass
+
+    return email_address
+
+
+def lookup_find_download_link_for_user_in_govuk_notify(email_address: str, retries: int = 30, delay: int = 1) -> str:
+    client = NotificationsAPIClient(os.getenv("E2E_NOTIFY_FIND_API_KEY"))
+
+    while retries >= 0:
+        emails = client.get_all_notifications(template_type="email", status="delivered")["notifications"]
+        for email in emails:
+            if email["email_address"] == email_address:
+                return re.findall(
+                    r"\[Visit the data download page to download your file\]"
+                    r"\(\s*([^\)]+?)\s*\)\s+"
+                    r"This link will stop working after 7 days.",
+                    email["body"],
+                )[0]
+
+        time.sleep(delay)
+        retries -= 1
+
+    raise LookupError("Could not find a corresponding find download link in GOV.UK Notify")

--- a/tests/e2e_tests/pages/__init__.py
+++ b/tests/e2e_tests/pages/__init__.py
@@ -1,0 +1,6 @@
+from playwright.sync_api import Page
+
+
+class BasePage:
+    def __init__(self, page: Page):
+        self.page = page

--- a/tests/e2e_tests/pages/find.py
+++ b/tests/e2e_tests/pages/find.py
@@ -1,0 +1,83 @@
+import tempfile
+from typing import Literal
+
+from tests.e2e_tests.pages import BasePage
+
+
+class FindRequestDataPage(BasePage):
+    def navigate(self):
+        self.page.goto("http://find-monitoring-data.levellingup.gov.localhost:4001/download")
+
+    def reveal_funds(self):
+        if self.page.get_by_label("Filter by fund , Show this section").is_visible():
+            self.page.get_by_label("Filter by fund , Show this section").click()
+
+    def reveal_regions(self):
+        if self.page.get_by_label("Filter by region , Show this section").is_visible():
+            self.page.get_by_label("Filter by region , Show this section").click()
+
+    def reveal_organisations(self):
+        if self.page.get_by_label("Filter by funded organisation , Show this section").is_visible():
+            self.page.get_by_label("Filter by funded organisation , Show this section").click()
+
+    def reveal_outcomes(self):
+        if self.page.get_by_label("Filter by outcomes , Show this section").is_visible():
+            self.page.get_by_label("Filter by outcomes , Show this section").click()
+
+    def reveal_returns_period(self):
+        if self.page.get_by_label("Filter by returns period , Show this section").is_visible():
+            self.page.get_by_label("Filter by returns period , Show this section").click()
+
+    def filter_funds(self, *funds: str):
+        self.reveal_funds()
+
+        for fund in funds:
+            self.page.get_by_label(fund).check()
+
+    def filter_regions(self, *regions: str):
+        self.reveal_regions()
+
+        for region in regions:
+            self.page.get_by_label(region).check()
+
+    def filter_organisations(self, *organisations: str):
+        self.reveal_organisations()
+
+        for organisation in organisations:
+            self.page.get_by_label(organisation).check()
+
+    def filter_outcomes(self, *outcomes: str):
+        self.reveal_outcomes()
+
+        for outcome in outcomes:
+            self.page.get_by_label(outcome).check()
+
+    def filter_returns_period(
+        self, from_quarter: Literal[1, 2, 3, 4], from_year: str, to_quarter: Literal[1, 2, 3, 4], to_year: str
+    ):
+        self.reveal_returns_period()
+
+        self.page.locator("#from-quarter").select_option(str(from_quarter))
+        self.page.locator("#from-year").select_option(from_year)
+
+        self.page.locator("#to-quarter").select_option(str(to_quarter))
+        self.page.locator("#to-year").select_option(to_year)
+
+    def select_file_format(self, file_format: Literal["XLSX (Microsoft Excel)", "JSON"]):
+        self.page.get_by_text(file_format).click()
+
+    def request_data(self):
+        request_data_button = self.page.get_by_role("button", name="Confirm and request data")
+        request_data_button.click()
+
+
+class DownloadDataPage(BasePage):
+    def download_file(self) -> str:
+        with self.page.expect_download() as download_info:
+            self.page.get_by_role("button", name="Download your data").click()
+
+        download = download_info.value
+        tempdir = tempfile.gettempdir()
+        download_filename = tempdir + "/" + download_info.value.suggested_filename
+        download.save_as(download_filename)
+        return download_filename

--- a/tests/e2e_tests/test_find.py
+++ b/tests/e2e_tests/test_find.py
@@ -1,0 +1,37 @@
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_tests.helpers import login_via_magic_link, lookup_find_download_link_for_user_in_govuk_notify
+from tests.e2e_tests.pages.find import DownloadDataPage, FindRequestDataPage
+
+pytestmark = pytest.mark.e2e
+
+
+def test_find_download(page: Page):
+    email_address = login_via_magic_link(page, "test_find_download", email_domain="communities.gov.uk")
+
+    request_data_page = FindRequestDataPage(page)
+    request_data_page.navigate()
+
+    request_data_page.filter_funds("High Street Fund")
+    request_data_page.filter_regions("North West")
+    request_data_page.filter_organisations("Bolton Council")
+    request_data_page.filter_outcomes("Health & Wellbeing", "Transport")
+    request_data_page.filter_returns_period(from_quarter=2, from_year="2023/2024", to_quarter=3, to_year="2023/2024")
+
+    request_data_page.select_file_format("XLSX (Microsoft Excel)")
+
+    request_data_page.request_data()
+
+    expect(page.get_by_role("heading", name="Request received")).to_be_visible()
+
+    download_file_url = lookup_find_download_link_for_user_in_govuk_notify(email_address)
+    page.goto(download_file_url)
+
+    download_page = DownloadDataPage(page)
+    filename = download_page.download_file()
+    assert filename.endswith(".xlsx")
+
+    with open(filename, "rb") as f:
+        download_data = f.read()
+        assert len(download_data)

--- a/tests/e2e_tests/test_find.py
+++ b/tests/e2e_tests/test_find.py
@@ -14,10 +14,10 @@ def test_find_download(page: Page):
     request_data_page.navigate()
 
     request_data_page.filter_funds("High Street Fund")
-    request_data_page.filter_regions("North West")
-    request_data_page.filter_organisations("Bolton Council")
-    request_data_page.filter_outcomes("Health & Wellbeing", "Transport")
-    request_data_page.filter_returns_period(from_quarter=2, from_year="2023/2024", to_quarter=3, to_year="2023/2024")
+    request_data_page.filter_regions("London")
+    request_data_page.filter_organisations("A District Council From Hogwarts")
+    request_data_page.filter_outcomes("Economy", "Transport")
+    request_data_page.filter_returns_period(from_quarter=2, from_year="2022/2023", to_quarter=3, to_year="2022/2023")
 
     request_data_page.select_file_format("XLSX (Microsoft Excel)")
 

--- a/tests/integration_tests/test_async_download.py
+++ b/tests/integration_tests/test_async_download.py
@@ -36,7 +36,7 @@ def test_trigger_async_download_endpoint(mocker, seeded_test_client, find_test_c
         mocker.call(
             email_address="dev@levellingup.test",
             download_url=mock.ANY,
-            find_service_url="http://localhost:4002/download",
+            find_service_url="http://find-monitoring-data.levellingup.gov.localhost:4001/download",
         )
     ]
 


### PR DESCRIPTION
Adds a browser test using Playwright that walks through the main user journey for a find user.

This involves:

* selecting some filters
* select a download file format
* clicking download
* clicking the link in the email that is received later
* downloading the final report on the page

We need to do some incredibly funky stuff around authentication to get a valid user session (in a way that could feasibly work against dev and test environments, too). We (ab)use authenticator's magic links flow to create a link as if we're an assessor of a new "post-award-e2e-tests" fund (which we inject into the local mock data for authenticator in a PR on that repo). When we use the magic link, it sets a cookie on the .levellingup.gov.localhost that is valid for Find, so we become effectively logged in.

---

At the moment I haven't added this to CI/CD, and it isn't able to run against dev/test environments. These will need to come in future development. But you are able to run the tests on your laptop against your own running services. This should make it possible to develop these tests out as we build the new features/journeys we're planning.

---

## Show the thing

**Note**: the errors at the start are from the authentication flow, and are "correct" (insofar as they do the auth correctly), but they definitely _look_ weird because we have to jump through some weird rabbit-holes to get an authenticated session.

![2024-07-31 10 40 49](https://github.com/user-attachments/assets/b58eba2f-f77b-461b-9875-fde550c817a1)
