### PR TITLE
Add exception for missing postcode data

### DIFF
--- a/data_store/controllers/load_functions.py
+++ b/data_store/controllers/load_functions.py
@@ -5,7 +5,6 @@ as well as helper functions for loading.
 """
 
 import pandas as pd
-from flask import abort
 
 from data_store.const import SUBMISSION_ID_FORMAT
 from data_store.controllers.mappings import DataMapping
@@ -15,6 +14,7 @@ from data_store.db.queries import (
     get_latest_submission_by_round_and_fund,
     get_organisation_exists,
 )
+from data_store.exceptions import MissingGeospatialException
 from data_store.util import get_postcode_prefix_set
 
 
@@ -325,8 +325,6 @@ def add_project_geospatial_relationship(project_models: list[db.Model]) -> list[
 
     if failing_postcode_prefixes:
         sorted_failing_postcode_prefixes = sorted(list(failing_postcode_prefixes))
-        return abort(
-            500, f"Postcode prefixes not found in geospatial table: {', '.join(sorted_failing_postcode_prefixes)}"
-        )
+        raise MissingGeospatialException(sorted_failing_postcode_prefixes)
 
     return project_models

--- a/data_store/exceptions.py
+++ b/data_store/exceptions.py
@@ -20,3 +20,9 @@ class InitialValidationError(RuntimeError):
 
     def __init__(self, error_messages: list[str]):
         self.error_messages = error_messages
+
+
+class MissingGeospatialException(Exception):
+    def __init__(self, missing_postcode_prefixes: list[str]):
+        self.description = f"Postcode prefixes not found in geospatial table: {', '.join(missing_postcode_prefixes)}"
+        self.missing_postcode_prefixes = missing_postcode_prefixes

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -850,8 +850,7 @@ def test_add_project_geospatial_relationship(test_client_reset):
 
     with pytest.raises(Exception) as error:
         add_project_geospatial_relationship([project4])
-    assert error.typename == "InternalServerError"
-    assert error.value.code == 500
+    assert error.typename == "MissingGeospatialException"
     assert error.value.description == "Postcode prefixes not found in geospatial table: XY, Y, ZB"
 
 


### PR DESCRIPTION
### Change description
`add_project_geospatial_relationship` is in our `data_store` module, which should need no concept of HTTP requests. This function, however, uses flask's `abort` call in situations where an error has happened. Instead, we should just raise an exception, which will bubble up to the relevant view and then be handled by flask as a 500. (Or it could be caught and handled appropriately)

https://dluhcdigital.atlassian.net/browse/FPASF-288