### PR TITLE
Translate prod->production for download report

### DIFF
--- a/find/scripts/extract_download_logs.py
+++ b/find/scripts/extract_download_logs.py
@@ -107,9 +107,10 @@ def main(args):
 
     # TODO: Remove the query on the data-frontend once it's historical enough that we don't need this report to
     #       hit it any more. See FPASF-409
+    OLD_ENVIRONMENT = "production" if ENVIRONMENT == "prod" else ENVIRONMENT
     query_id = cloudwatch_logs_client.start_query(
         logGroupNames=[
-            f"/copilot/post-award-{ENVIRONMENT}-data-frontend",
+            f"/copilot/post-award-{OLD_ENVIRONMENT}-data-frontend",
             f"/copilot/pre-award-{ENVIRONMENT}-post-award",
         ],
         queryString="""fields @timestamp, @message


### PR DESCRIPTION
### Change description
The environment names for prod(uction) after different between pre-award and post-award. This was missed in the monolith migration.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
