### PR TITLE
Remove post-award log group from find download report

### DIFF
--- a/copilot/download-report/manifest.yml
+++ b/copilot/download-report/manifest.yml
@@ -26,7 +26,7 @@ memory: 512    # Amount of memory in MiB used by the task.
 #
 variables:                    # Pass environment variables as key value pairs.
   # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
-  SENTRY_DSN: https://e63d6f45b69f46b9a381f1f042db363e@o1432034.ingest.sentry.io/4505358184415232
+  SENTRY_DSN: https://6a2623e302e641ba88eabe6675a70ddf@o1432034.ingest.sentry.io/4505390859747328
   FLASK_ENV:  ${COPILOT_ENVIRONMENT_NAME}
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.

--- a/find/scripts/extract_download_logs.py
+++ b/find/scripts/extract_download_logs.py
@@ -105,14 +105,8 @@ def main(args):
 
     cloudwatch_logs_client = client("logs", region_name="eu-west-2")
 
-    # TODO: Remove the query on the data-frontend once it's historical enough that we don't need this report to
-    #       hit it any more. See FPASF-409
-    OLD_ENVIRONMENT = "production" if ENVIRONMENT == "prod" else ENVIRONMENT
     query_id = cloudwatch_logs_client.start_query(
-        logGroupNames=[
-            f"/copilot/post-award-{OLD_ENVIRONMENT}-data-frontend",
-            f"/copilot/pre-award-{ENVIRONMENT}-post-award",
-        ],
+        logGroupName=f"/copilot/pre-award-{ENVIRONMENT}-post-award",
         queryString="""fields @timestamp, @message
     | sort @timestamp asc
     | limit 10000


### PR DESCRIPTION
### Change description
All of the logs from pre-monolith times have now been scraped and sent to our performance analyst, so we no longer need to (try to) touch this log group. Goodbye.

(Also, when the job ran in the context of the `pre-award` cluster it couldn't even read from a service's log group in the `post-award` cluster. But fortunately we still had the scheduled job running in the old world, so the report was still pulled down successfully there).

--

Also updates the sentry DSN for the download report to go into the "data-store" project.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
