### PR TITLE
Fix env name for download report

### DIFF
--- a/copilot/download-report/manifest.yml
+++ b/copilot/download-report/manifest.yml
@@ -34,7 +34,7 @@ secrets:                      # Pass secrets from AWS Systems Manager (SSM) Para
 
 # Set email for production
 environments:
-  production:
+  prod:
     secrets:
       NOTIFY_API_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_NOTIFY_API_KEY
       NOTIFY_SEND_EMAIL: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_NOTIFY_SEND_EMAIL


### PR DESCRIPTION
### Change description
The env name in the manifest is wrong, so `NOTIFY_SEND_EMAIL` isn't being injected correctly

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
