### PR TITLE
Upgrade pip-tools

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -35,7 +35,7 @@ types-PyYAML
 types-requests
 types-setuptools
 types-WTForms
-pip-tools==6.13.0
+pip-tools
 
 
 pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -167,10 +167,7 @@ govuk-frontend-jinja==2.7.0
 govuk-frontend-wtf==2.5.0
     # via -r requirements.txt
 greenlet==3.0.3
-    # via
-    #   -r requirements.txt
-    #   playwright
-    #   sqlalchemy
+    # via playwright
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -267,7 +264,7 @@ pandas-stubs==2.0.1.230501
     # via -r requirements-dev.in
 pandera==0.17.2
     # via -r requirements.txt
-pip-tools==6.13.0
+pip-tools==7.4.1
     # via -r requirements-dev.in
 platformdirs==4.2.0
     # via virtualenv
@@ -310,7 +307,9 @@ pyparsing==3.0.9
     #   packaging
     #   pydot
 pyproject-hooks==1.1.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pytest==7.3.1
     # via
     #   -r requirements-dev.in


### PR DESCRIPTION
Fixes an issue with `pip sync`:

```
sam:~/work/dluhc/funding/funding-service-design-post-award-data-store [bump-pip-tools]$ pip-sync requirements-dev.txt
Traceback (most recent call last):
  File "/Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/bin/pip-sync", line 5, in <module>
    from piptools.scripts.sync import cli
  File "/Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/piptools/scripts/sync.py", line 16, in <module>
    from .. import sync
  File "/Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/piptools/sync.py", line 11, in <module>
    from pip._internal.commands.freeze import DEV_PKGS
ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze' (/Users/sam/work/dluhc/funding/funding-service-design-post-award-data-store/venv/lib/python3.11/site-packages/pip/_internal/commands/freeze.py)
```