### PR TITLE
FPASF-461: Update deployment workflows

### DIFF
--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -1,0 +1,55 @@
+name: Deploy post-award services to AWS
+run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.copilot_environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
+on:
+  workflow_call:
+    inputs:
+        copilot_environment:
+            description: "Copilot environment to deploy to"
+            type: string
+            required: true
+        github_sha:
+            description: "Github SHA of the commit being deployed"
+            type: string
+            required: true
+        deployment:
+            description: "Service or job to be deployed"
+            type: string
+            required: true
+        command:
+            description: "Command to run for deployment"
+            type: string
+            required: true
+        IMAGE_LOCATION:
+            description: "Location of the image to deploy"
+            type: string
+            required: true
+
+jobs:
+  copilot_deploy:
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.copilot_environment || 'test' }}
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+
+      - name: Setup Copilot
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
+        with:
+          copilot_environment: ${{ inputs.copilot_environment || 'test' }}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+
+      - name: Inject env specific values into manifest
+        run: |
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ inputs.deployment }}/manifest.yml
+          yq -i '.image.location = "${{ inputs.IMAGE_LOCATION }}"' copilot/${{ inputs.deployment }}/manifest.yml
+
+      - name: Run database migrations
+        if: ${{ inputs.deployment == 'post-award' }}
+        run: scripts/migration-task-script.py ${{ inputs.copilot_environment || 'test' }} ${{ inputs.IMAGE_LOCATION }}
+
+      - name: Copilot deploy ${{ inputs.deployment }}
+        run: |
+          copilot ${{ inputs.command }} deploy --name ${{ inputs.deployment }}

--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -1,4 +1,4 @@
-name: Deploy post-award services to AWS
+name: Reusable workflow for AWS Copilot deployment
 run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.copilot_environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
 on:
   workflow_call:

--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow for AWS Copilot deployment
+name: Reusable workflow for post-award AWS Copilot deployment
 run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.copilot_environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
 on:
   workflow_call:
@@ -7,25 +7,22 @@ on:
             description: "Copilot environment to deploy to"
             type: string
             required: true
-        github_sha:
-            description: "Github SHA of the commit being deployed"
-            type: string
-            required: true
-        deployment:
-            description: "Service or job to be deployed"
-            type: string
-            required: true
-        command:
-            description: "Command to run for deployment"
-            type: string
-            required: true
-        IMAGE_LOCATION:
+        image_location:
             description: "Location of the image to deploy"
             type: string
             required: true
 
 jobs:
   copilot_deploy:
+    strategy:
+      matrix:
+        include:
+          - deployment: post-award
+            command: svc
+          - deployment: post-award-celery
+            command: svc
+          - deployment: download-report
+            command: job
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
@@ -43,13 +40,13 @@ jobs:
 
       - name: Inject env specific values into manifest
         run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ inputs.deployment }}/manifest.yml
-          yq -i '.image.location = "${{ inputs.IMAGE_LOCATION }}"' copilot/${{ inputs.deployment }}/manifest.yml
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
+          yq -i '.image.location = "${{ inputs.image_location }}"' copilot/${{ matrix.deployment }}/manifest.yml
 
       - name: Run database migrations
-        if: ${{ inputs.deployment == 'post-award' }}
-        run: scripts/migration-task-script.py ${{ inputs.copilot_environment || 'test' }} ${{ inputs.IMAGE_LOCATION }}
+        if: ${{ matrix.deployment == 'post-award' }}
+        run: scripts/migration-task-script.py ${{ inputs.copilot_environment || 'test' }} ${{ inputs.image_location }}
 
-      - name: Copilot deploy ${{ inputs.deployment }}
+      - name: Copilot deploy ${{ matrix.deployment }}
         run: |
-          copilot ${{ inputs.command }} deploy --name ${{ inputs.deployment }}
+          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}

--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -1,9 +1,6 @@
-name: Deploy post-award services to AWS
+name: Deploy post-award branch to AWS
 run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
         environment:
@@ -13,7 +10,7 @@ on:
           options:
           - dev
           - test
-          - prod
+          # - prod # This is our production environment and only /main branch can deploy to it
 
 concurrency:
   group: deploy-${{ inputs.environment || 'test' }}
@@ -41,32 +38,11 @@ jobs:
             command: svc
           - deployment: download-report
             command: job
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read  # This is required for actions/checkout
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || 'test' }}
-    env:
+    uses: ./.github/workflows/aws_copilot_deployment.yml
+    with:
+      copilot_environment: ${{ inputs.environment || 'test' }}
+      github_sha: ${{ github.sha }}
+      deployment: ${{ matrix.deployment }}
+      command: ${{ matrix.command }}
       IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Copilot
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
-        with:
-          copilot_environment: ${{ inputs.environment || 'test' }}
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-
-      - name: Inject env specific values into manifest
-        run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-          yq -i '.image.location = "${{ env.IMAGE_LOCATION }}"' copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Run database migrations
-        if: ${{ matrix.deployment == 'post-award' }}
-        run: scripts/migration-task-script.py ${{ inputs.environment || 'test' }} ${{ env.IMAGE_LOCATION }}
-
-      - name: Copilot deploy ${{ matrix.deployment }}
-        run: |
-          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}
+    secrets: inherit

--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -10,11 +10,6 @@ on:
           options:
           - dev
           - test
-          # - prod # This is our production environment and only /main branch can deploy to it
-
-concurrency:
-  group: deploy-${{ inputs.environment || 'test' }}
-  cancel-in-progress: false
 
 jobs:
   paketo_build:
@@ -29,20 +24,11 @@ jobs:
 
   copilot_deploy:
     needs: [ paketo_build ]
-    strategy:
-      matrix:
-        include:
-          - deployment: post-award
-            command: svc
-          - deployment: post-award-celery
-            command: svc
-          - deployment: download-report
-            command: job
+    concurrency:
+      group: deploy-${{ inputs.environment || 'test' }}
+      cancel-in-progress: false
     uses: ./.github/workflows/aws_copilot_deployment.yml
     with:
       copilot_environment: ${{ inputs.environment || 'test' }}
-      github_sha: ${{ github.sha }}
-      deployment: ${{ matrix.deployment }}
-      command: ${{ matrix.command }}
-      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -20,27 +20,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tag_version:
-    runs-on: ubuntu-latest
-    outputs:
-      version_to_tag: ${{ steps.tagging.outputs.tag_value }}
-    steps:
-      - id: tagging
-        run: |
-          echo "tag_value=$(echo '${{ github.ref }}' | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_OUTPUT
   paketo_build:
     permissions:
       packages: write
-    needs: [ tag_version ]
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
     with:
       assets_required: true
-      version_to_build: ${{ needs.tag_version.outputs.version_to_tag }}
+      version_to_build:  ${{ github.sha }}
       owner: ${{ github.repository_owner }}
       application: ${{ github.event.repository.name }}
 
   copilot_deploy:
-    needs: [ tag_version, paketo_build ]
+    needs: [ paketo_build ]
     strategy:
       matrix:
         include:
@@ -56,25 +47,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'test' }}
     env:
-      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name == 'main' && 'latest' || needs.tag_version.outputs.version_to_tag }}
+      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v4
 
-      - name: Get current date
-        id: currentdatetime
-        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Setup Copilot
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: POST_AWARD_DATA_STORE_${{ steps.currentdatetime.outputs.datetime }}  # fixme: remove data_store reference?
-          aws-region: eu-west-2
-
-      - name: Install AWS Copilot CLI
-        run: |
-          curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
+          copilot_environment: ${{ inputs.environment || 'test' }}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
 
       - name: Inject env specific values into manifest
         run: |

--- a/.github/workflows/deployment_cd_test_prod.yml
+++ b/.github/workflows/deployment_cd_test_prod.yml
@@ -1,0 +1,72 @@
+name: Deploy post-award services to AWS
+run-name: Deploy branch ${{ github.ref_name }} to test and prod environments (${{ format('SHA:{0}', github.sha) }})
+on:
+  push:
+    branches:
+      - main
+
+env:
+  ENVIRONMENT: test
+
+concurrency:
+      group: deploy-test-prod
+      cancel-in-progress: false
+
+jobs:
+  paketo_build:
+    permissions:
+      packages: write
+    concurrency: build-${{ github.sha }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
+    with:
+      assets_required: true
+      version_to_build: ${{ github.sha }}
+      owner: ${{ github.repository_owner }}
+      application: ${{ github.event.repository.name }}
+
+  copilot_test_deploy:
+    needs: [ paketo_build ]
+    # concurrency:
+    #   group: deploy-$ENVIRONMENT
+    #   cancel-in-progress: false
+    strategy:
+      matrix:
+        include:
+          - deployment: post-award
+            command: svc
+          - deployment: post-award-celery
+            command: svc
+          - deployment: download-report
+            command: job
+    uses: ./.github/workflows/aws_copilot_deployment.yml
+    with:
+      copilot_environment: $ENVIRONMENT
+      github_sha: ${{ github.sha }}
+      deployment: ${{ matrix.deployment }}
+      command: ${{ matrix.command }}
+      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+    secrets: inherit
+
+  copilot_prod_deploy:
+    if: github.ref_name == 'main'
+    needs: [ paketo_build, copilot_test_deploy ]
+    # concurrency:
+    #   group: deploy-prod
+    #   cancel-in-progress: false
+    strategy:
+      matrix:
+        include:
+          - deployment: post-award
+            command: svc
+          - deployment: post-award-celery
+            command: svc
+          - deployment: download-report
+            command: job
+    uses: ./.github/workflows/aws_copilot_deployment.yml
+    with:
+      copilot_environment: prod
+      github_sha: ${{ github.sha }}
+      deployment: ${{ matrix.deployment }}
+      command: ${{ matrix.command }}
+      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/deployment_cd_test_prod.yml
+++ b/.github/workflows/deployment_cd_test_prod.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: deploy-test
-  cancel-in-progress: false
-
 jobs:
   paketo_build:
     permissions:
@@ -23,41 +19,23 @@ jobs:
 
   copilot_test_deploy:
     needs: [ paketo_build ]
-    strategy:
-      matrix:
-        include:
-          - deployment: post-award
-            command: svc
-          - deployment: post-award-celery
-            command: svc
-          - deployment: download-report
-            command: job
+    concurrency:
+      group: deploy-test
+      cancel-in-progress: false
     uses: ./.github/workflows/aws_copilot_deployment.yml
     with:
       copilot_environment: test
-      github_sha: ${{ github.sha }}
-      deployment: ${{ matrix.deployment }}
-      command: ${{ matrix.command }}
-      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
     secrets: inherit
 
   copilot_prod_deploy:
-    if: github.ref_name == 'main'
+    if: ${{ github.ref_name == 'main' }}
     needs: [ paketo_build, copilot_test_deploy ]
-    strategy:
-      matrix:
-        include:
-          - deployment: post-award
-            command: svc
-          - deployment: post-award-celery
-            command: svc
-          - deployment: download-report
-            command: job
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
     uses: ./.github/workflows/aws_copilot_deployment.yml
     with:
       copilot_environment: prod
-      github_sha: ${{ github.sha }}
-      deployment: ${{ matrix.deployment }}
-      command: ${{ matrix.command }}
-      IMAGE_LOCATION: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+      image_location: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/deployment_cd_test_prod.yml
+++ b/.github/workflows/deployment_cd_test_prod.yml
@@ -1,16 +1,13 @@
-name: Deploy post-award services to AWS
-run-name: Deploy branch ${{ github.ref_name }} to test and prod environments (${{ format('SHA:{0}', github.sha) }})
+name: Deployment pipeline for post-award services
+run-name: Deploy branch ${{ github.ref_name }} to test and prod (${{ format('SHA:{0}', github.sha) }})
 on:
   push:
     branches:
       - main
 
-env:
-  ENVIRONMENT: test
-
 concurrency:
-      group: deploy-test-prod
-      cancel-in-progress: false
+  group: deploy-test
+  cancel-in-progress: false
 
 jobs:
   paketo_build:
@@ -26,9 +23,6 @@ jobs:
 
   copilot_test_deploy:
     needs: [ paketo_build ]
-    # concurrency:
-    #   group: deploy-$ENVIRONMENT
-    #   cancel-in-progress: false
     strategy:
       matrix:
         include:
@@ -40,7 +34,7 @@ jobs:
             command: job
     uses: ./.github/workflows/aws_copilot_deployment.yml
     with:
-      copilot_environment: $ENVIRONMENT
+      copilot_environment: test
       github_sha: ${{ github.sha }}
       deployment: ${{ matrix.deployment }}
       command: ${{ matrix.command }}
@@ -50,9 +44,6 @@ jobs:
   copilot_prod_deploy:
     if: github.ref_name == 'main'
     needs: [ paketo_build, copilot_test_deploy ]
-    # concurrency:
-    #   group: deploy-prod
-    #   cancel-in-progress: false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
### Change description
Implements a single pipeline that builds, tags (using the commit SHA rather than the branch name or `latest`), pushes and deploys to the `test` environment when PRs are merged into `main` and then just deploys the same image to production (`prod`) after approval. 

Also updates the old manual branch deployment workflow to make use of the new reusable workflow for consistency and also (for now) removes the ability to deploy to prod from this workflow to avoid clashes.

Testing still needed on how this all works in practice, which we can't do until this gets merged in and we can observe the behaviour 😬, but testing of the reusable workflow has been done with the manual deploy to `dev`.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
