### PR TITLE
Exclude some files from built container images

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,6 +1,14 @@
 [ _ ]
 schema-version = "0.2"
 
+[io.buildpacks]
+exclude = [
+    ".flaskenv",
+    ".git",
+    ".github",
+    ".vscode",
+]
+
 [[ io.buildpacks.build.env ]]
   name = "BP_CPYTHON_VERSION"
   value = "3.11.*" # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable


### PR DESCRIPTION
### Change description
We had a gnarly problem recently (well, it's been around for a while now) that has made manual use of `flask` CLI commands on deployed environments have the wrong AWS credentials.

When our code is running in AWS, the container gets all of its permissions from its IAM task role. These are collected automatically by boto3 by talking to an ECS metadata endpoint on the container. However, boto3 will first look in the environment for any access keys. We don't provide credentials by environment variable, so normally this is fine.

However, when you specifically use the `flask` command, it will read a `.flaskenv` file and fill in any missing environment variables from that file. In this file we set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_ENDPOINT_OVERRIDE. As these aren't in the environment by default, Flask loads them from the file. These have stub values which are expected to only be used in local development. We shouldn't be including these files in our built container images that are meant to deploy on AWS, so this patch excludes them.

This problem has existed for a long time, theoretically, but only surfaces when you specifically use a `flask` command. Previously, when we've used ECS exec to get onto a container and run some manual task, we've used `python` as an entrypoint. This doesn't load `.flaskenv` - so the problem has been mostly hidden until now.