### PR TITLE
BAU: Limit branch deployments to dev

### DIFF
--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -9,7 +9,6 @@ on:
           required: true
           options:
           - dev
-          - test
 
 jobs:
   paketo_build:


### PR DESCRIPTION
### Change description
Limit branch deployments to dev. (We want to keep test running `main`.)

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Post merge action should only be able to deploy to dev


### Screenshots of UI changes (if applicable)
