### PR TITLE
Migrate DB before code deployments

### DIFF
--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -13,8 +13,34 @@ on:
             required: true
 
 jobs:
+  migrate:
+    name: Migrate DB in ${{ inputs.copilot_environment || 'test' }}
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.copilot_environment || 'test' }}
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+
+      - name: Setup Copilot
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
+        with:
+          copilot_environment: ${{ inputs.copilot_environment || 'test' }}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+
+      - name: Inject env specific values into manifest
+        run: |
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/post-award/manifest.yml
+          yq -i '.image.location = "${{ inputs.image_location }}"' copilot/post-award/manifest.yml
+
+      - name: Run database migrations
+        run: scripts/migration-task-script.py ${{ inputs.copilot_environment || 'test' }} ${{ inputs.image_location }}
+
   deploy:
     name: ${{ matrix.deployment }}
+    needs: [ migrate ]
     strategy:
       matrix:
         include:
@@ -43,10 +69,6 @@ jobs:
         run: |
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
           yq -i '.image.location = "${{ inputs.image_location }}"' copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Run database migrations
-        if: ${{ matrix.deployment == 'post-award' }}
-        run: scripts/migration-task-script.py ${{ inputs.copilot_environment || 'test' }} ${{ inputs.image_location }}
 
       - name: Copilot deploy ${{ matrix.deployment }}
         run: |

--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   paketo_build:
+    name: Build post-award image
     permissions:
       packages: write
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main

--- a/.github/workflows/deployment_cd_test_prod.yml
+++ b/.github/workflows/deployment_cd_test_prod.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   paketo_build:
+    name: Build post-award image
     permissions:
       packages: write
     concurrency: build-${{ github.sha }}


### PR DESCRIPTION
Our current deployment pipeline runs three jobs in parallel:

1. Migrate DB and deploy post-award service
2. Deploy post-award-celery service
3. Deploy download-report job

If the DB migration fails, we still deploy post-award-celery and the
download-report job. These might be relying on model changes from a DB
migration, so it is logically incorrect to be deploying these if the
migration fails. It also leaves us in an inconsistent place - post-award
service is on the old code, post-award-celery/download-report are on the
new code.

We should run the DB migrations before deploying any of the code
changes. If these succeed, we can run all three deployments. If they
fail, we shouldn't run any.