### PR TITLE
Allow e2e tests to target dev+test environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ pauses between various steps so that you can follow what the test is doing more 
 The e2e test for find currently requires a `test`-scoped API key for GOV.UK Notify to retrieve the email send during
 the test.  Pass an environment variable called `E2E_NOTIFY_FIND_API_KEY` to allow this test to pass.
 
+If you want to run the end-to-end tests against our deployed dev/test environments, you can do this by adding the
+`--e2e-env` flag to the pytest command with a value of either `dev` or `test`.
+
 ## Updating database migrations
 
 Whenever you make changes to database models, please run:

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -61,4 +61,4 @@ class UnitTestConfig(DefaultConfig):
     CELERY["task_always_eager"] = True
 
     E2E_NOTIFY_FIND_API_KEY = os.environ.get("E2E_NOTIFY_FIND_API_KEY")
-    E2E_DEVTEST_BASIC_AUTH = os.environ.get("E2E_DEVTEST_BASIC_AUTH")
+    E2E_DEVTEST_BASIC_AUTH = os.environ.get("E2E_DEVTEST_BASIC_AUTH")  # Format: "username:password"

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -1,3 +1,5 @@
+import os
+
 from botocore.config import Config
 from fsd_utils import configclass
 
@@ -57,3 +59,6 @@ class UnitTestConfig(DefaultConfig):
     # Which is overkill for now. 28/06/2024.
     CELERY = DefaultConfig.CELERY
     CELERY["task_always_eager"] = True
+
+    E2E_NOTIFY_FIND_API_KEY = os.environ.get("E2E_NOTIFY_FIND_API_KEY")
+    E2E_DEVTEST_BASIC_AUTH = os.environ.get("E2E_DEVTEST_BASIC_AUTH")

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 env =
   FLASK_ENV=unit_test
   D:E2E_NOTIFY_FIND_API_KEY=set-me-in-your-environment
+  D:E2E_DEVTEST_BASIC_AUTH=set-me-in-your-environment
 markers =
   e2e: run e2e (browser) tests using playwright
 testpaths =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,6 @@
 [pytest]
 env =
   FLASK_ENV=unit_test
-  D:E2E_NOTIFY_FIND_API_KEY=set-me-in-your-environment
-  D:E2E_DEVTEST_BASIC_AUTH=set-me-in-your-environment
 markers =
   e2e: run e2e (browser) tests using playwright
 testpaths =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,13 @@ from tests.resources.pathfinders.extracted_data import get_extracted_data
 def pytest_addoption(parser):
     parser.addoption("--e2e", action="store_true", default=False, help="run e2e (browser) tests")
     parser.addoption(
+        "--e2e-env",
+        action="store",
+        default="local",
+        help="choose the environment that e2e tests will target",
+        choices=("local", "dev", "test"),
+    )
+    parser.addoption(
         "--viewport",
         default="1920x1080",
         type=str,

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -1,3 +1,6 @@
+import dataclasses
+import os
+
 import pytest
 from playwright.sync_api import Page
 
@@ -6,3 +9,56 @@ from playwright.sync_api import Page
 def _viewport(request, page: Page):
     width, height = request.config.getoption("viewport").split("x")
     page.set_viewport_size({"width": int(width), "height": int(height)})
+
+
+@dataclasses.dataclass
+class FundingServiceDomains:
+    authenticator: str
+    find: str
+    submit: str
+
+
+@pytest.fixture()
+def domains(request) -> FundingServiceDomains:
+    e2e_env = request.config.getoption("e2e_env")
+    devtest_basic_auth = os.environ.get("E2E_DEVTEST_BASIC_AUTH", "")
+
+    if e2e_env == "local":
+        return FundingServiceDomains(
+            authenticator="http://authenticator.levellingup.gov.localhost:4004",
+            find="http://find-monitoring-data.levellingup.gov.localhost:4001",
+            submit="http://submit-monitoring-data.levellingup.gov.localhost:4001",
+        )
+    elif e2e_env in {"dev", "test"}:
+        return FundingServiceDomains(
+            authenticator=f"https://{devtest_basic_auth}@authenticator.{e2e_env}.access-funding.test.levellingup.gov.uk",
+            find=f"https://{devtest_basic_auth}@find-monitoring-data.{e2e_env}.access-funding.test.levellingup.gov.uk",
+            submit=f"https://{devtest_basic_auth}@submit-monitoring-data.{e2e_env}.access-funding.test.levellingup.gov.uk",
+        )
+    else:
+        raise ValueError(f"not configured for {e2e_env}")
+
+
+@dataclasses.dataclass
+class TestFundConfig:
+    short_name: str
+    round: str
+
+
+@pytest.fixture()
+def authenticator_fund_config(request):
+    e2e_env = request.config.getoption("e2e_env")
+
+    if e2e_env == "local":
+        return TestFundConfig(
+            short_name="post-award-e2e-tests",
+            round="r1w1",
+        )
+    elif e2e_env in {"dev", "test"}:
+        # A fairly arbitrary choice of fund/round that exists on those environments currently
+        return TestFundConfig(
+            short_name="HSRA",
+            round="R1",
+        )
+    else:
+        raise ValueError(f"not configured for {e2e_env}")

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -26,15 +26,21 @@ def domains(request) -> FundingServiceDomains:
 
     if e2e_env == "local":
         return FundingServiceDomains(
-            authenticator="http://authenticator.levellingup.gov.localhost:4004",
-            find="http://find-monitoring-data.levellingup.gov.localhost:4001",
-            submit="http://submit-monitoring-data.levellingup.gov.localhost:4001",
+            authenticator=f"http://{Config.AUTHENTICATOR_HOST}.levellingup.gov.localhost:4004",
+            find=f"http://{Config.FIND_HOST}",
+            submit=f"http://{Config.SUBMIT_HOST}",
         )
-    elif e2e_env in {"dev", "test"}:
+    elif e2e_env == "dev":
         return FundingServiceDomains(
-            authenticator=f"https://{devtest_basic_auth}@authenticator.{e2e_env}.access-funding.test.levellingup.gov.uk",
-            find=f"https://{devtest_basic_auth}@find-monitoring-data.{e2e_env}.access-funding.test.levellingup.gov.uk",
-            submit=f"https://{devtest_basic_auth}@submit-monitoring-data.{e2e_env}.access-funding.test.levellingup.gov.uk",
+            authenticator=f"https://{devtest_basic_auth}@authenticator.dev.access-funding.test.levellingup.gov.uk",
+            find=f"https://{devtest_basic_auth}@find-monitoring-data.dev.access-funding.test.levellingup.gov.uk",
+            submit=f"https://{devtest_basic_auth}@submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk",
+        )
+    elif e2e_env == "test":
+        return FundingServiceDomains(
+            authenticator=f"https://{devtest_basic_auth}@authenticator.test.access-funding.test.levellingup.gov.uk",
+            find=f"https://{devtest_basic_auth}@find-monitoring-data.test.access-funding.test.levellingup.gov.uk",
+            submit=f"https://{devtest_basic_auth}@submit-monitoring-data.test.access-funding.test.levellingup.gov.uk",
         )
     else:
         raise ValueError(f"not configured for {e2e_env}")

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -24,6 +24,9 @@ def domains(request) -> FundingServiceDomains:
     e2e_env = request.config.getoption("e2e_env")
     devtest_basic_auth = Config.E2E_DEVTEST_BASIC_AUTH
 
+    if e2e_env in {"dev", "test"} and not devtest_basic_auth:
+        raise ValueError("E2E_DEVTEST_BASIC_AUTH is not set to `username:password` for accessing dev/test environments")
+
     if e2e_env == "local":
         return FundingServiceDomains(
             authenticator=f"http://{Config.AUTHENTICATOR_HOST}.levellingup.gov.localhost:4004",

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -1,8 +1,9 @@
 import dataclasses
-import os
 
 import pytest
 from playwright.sync_api import Page
+
+from config import Config
 
 
 @pytest.fixture(autouse=True)
@@ -21,7 +22,7 @@ class FundingServiceDomains:
 @pytest.fixture()
 def domains(request) -> FundingServiceDomains:
     e2e_env = request.config.getoption("e2e_env")
-    devtest_basic_auth = os.environ.get("E2E_DEVTEST_BASIC_AUTH", "")
+    devtest_basic_auth = Config.E2E_DEVTEST_BASIC_AUTH
 
     if e2e_env == "local":
         return FundingServiceDomains(

--- a/tests/e2e_tests/helpers.py
+++ b/tests/e2e_tests/helpers.py
@@ -8,15 +8,22 @@ from notifications_python_client import NotificationsAPIClient
 from playwright._impl._errors import Error as PlaywrightError
 from playwright.sync_api import Page
 
+from tests.e2e_tests.conftest import FundingServiceDomains, TestFundConfig
 
-def login_via_magic_link(page: Page, test_name: str, email_domain: str = "levellingup.gov.test"):
-    response = requests.get("http://authenticator.levellingup.gov.localhost:4004/magic-links")
+
+def login_via_magic_link(
+    page: Page,
+    test_name: str,
+    domains: FundingServiceDomains,
+    fund_config: TestFundConfig,
+    email_domain: str = "levellingup.gov.test",
+):
+    response = requests.get(f"{domains.authenticator}/magic-links")
+
     magic_links_before = set(response.json())
 
-    page.goto(
-        "http://authenticator.levellingup.gov.localhost:4004/service/magic-links/new"
-        "?fund=post-award-e2e-tests&round=r1w1"
-    )
+    url = f"{domains.authenticator}/service/magic-links/new?fund={fund_config.short_name}&round={fund_config.round}"
+    page.goto(url)
 
     # Help disambiguate tests running around the same time by injecting a random token into the email, so that
     # when we lookup the email it should be unique. We avoid a UUID so as to keep the emails 'short enough'.
@@ -25,7 +32,7 @@ def login_via_magic_link(page: Page, test_name: str, email_domain: str = "levell
     page.get_by_role("textbox", name="email").fill(email_address)
     page.get_by_role("button", name="Continue").click()
 
-    response = requests.get("http://authenticator.levellingup.gov.localhost:4004/magic-links")
+    response = requests.get(f"{domains.authenticator}/magic-links")
     magic_links_after = set(response.json())
 
     new_magic_links = magic_links_after - magic_links_before
@@ -37,7 +44,8 @@ def login_via_magic_link(page: Page, test_name: str, email_domain: str = "levell
 
     magic_link_id = magic_link.split(":")[1]
     try:
-        page.goto(f"http://authenticator.levellingup.gov.localhost:4004/magic-links/{magic_link_id}")
+        page.goto(f"{domains.authenticator}/magic-links/{magic_link_id}")
+
     except PlaywrightError:
         # FIXME: Authenticator gets into a weird redirect loop locally... We just ignore that error.
         pass

--- a/tests/e2e_tests/helpers.py
+++ b/tests/e2e_tests/helpers.py
@@ -1,4 +1,3 @@
-import os
 import re
 import secrets
 import time
@@ -8,6 +7,7 @@ from notifications_python_client import NotificationsAPIClient
 from playwright._impl._errors import Error as PlaywrightError
 from playwright.sync_api import Page
 
+from config import Config
 from tests.e2e_tests.conftest import FundingServiceDomains, TestFundConfig
 
 
@@ -54,7 +54,7 @@ def login_via_magic_link(
 
 
 def lookup_find_download_link_for_user_in_govuk_notify(email_address: str, retries: int = 30, delay: int = 1) -> str:
-    client = NotificationsAPIClient(os.getenv("E2E_NOTIFY_FIND_API_KEY"))
+    client = NotificationsAPIClient(Config.E2E_NOTIFY_FIND_API_KEY)
 
     while retries >= 0:
         emails = client.get_all_notifications(template_type="email", status="delivered")["notifications"]

--- a/tests/e2e_tests/pages/__init__.py
+++ b/tests/e2e_tests/pages/__init__.py
@@ -2,5 +2,6 @@ from playwright.sync_api import Page
 
 
 class BasePage:
-    def __init__(self, page: Page):
+    def __init__(self, page: Page, domain: str | None = None):
         self.page = page
+        self.domain = domain

--- a/tests/e2e_tests/pages/find.py
+++ b/tests/e2e_tests/pages/find.py
@@ -6,7 +6,7 @@ from tests.e2e_tests.pages import BasePage
 
 class FindRequestDataPage(BasePage):
     def navigate(self):
-        self.page.goto("http://find-monitoring-data.levellingup.gov.localhost:4001/download")
+        self.page.goto(f"{self.domain}/download")
 
     def reveal_funds(self):
         if self.page.get_by_label("Filter by fund , Show this section").is_visible():

--- a/tests/e2e_tests/test_find.py
+++ b/tests/e2e_tests/test_find.py
@@ -7,10 +7,16 @@ from tests.e2e_tests.pages.find import DownloadDataPage, FindRequestDataPage
 pytestmark = pytest.mark.e2e
 
 
-def test_find_download(page: Page):
-    email_address = login_via_magic_link(page, "test_find_download", email_domain="communities.gov.uk")
+def test_find_download(domains, authenticator_fund_config, page: Page):
+    email_address = login_via_magic_link(
+        page,
+        "test_find_download",
+        email_domain="communities.gov.uk",
+        domains=domains,
+        fund_config=authenticator_fund_config,
+    )
 
-    request_data_page = FindRequestDataPage(page)
+    request_data_page = FindRequestDataPage(page, domain=domains.find)
     request_data_page.navigate()
 
     request_data_page.filter_funds("High Street Fund")


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-471

### Change description
This adds the '--e2e-env' option to our e2e tests so that they can target the deployed dev and test environments.

By default these will still just run against the local domains, but this is a step towards us being able to run these tests in CI.

For now, the find test remains broken in dev+test envs because we are hardcoding our filter choices, and these are not reliably present in each environment. This will be fixed later, but getting this in now should unblock another developer's work on playwright tests.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- `pytest --e2e --headed --slowmo 1000  --e2e-env dev`


### Screenshots of UI changes (if applicable)
