### PR TITLE
Add basic flask-admin views

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -1,0 +1,33 @@
+from admin.actions import ReingestAdminView, RetrieveFailedSubmissionAdminView, RetrieveSubmissionAdminView
+from admin.entities import (
+    FundAdminView,
+    GeospatialAdminView,
+    OrganisationAdminView,
+    OutcomeDimAdminView,
+    OutputDimAdminView,
+    ReportingRoundAdminView,
+    SubmissionAdminView,
+)
+
+
+def register_admin_views(flask_admin, db):
+    flask_admin.add_view(FundAdminView(db.session, category="Reference data"))
+    flask_admin.add_view(GeospatialAdminView(db.session, category="Reference data"))
+    flask_admin.add_view(OrganisationAdminView(db.session, category="Reference data"))
+    flask_admin.add_view(OutcomeDimAdminView(db.session, category="Reference data"))
+    flask_admin.add_view(OutputDimAdminView(db.session, category="Reference data"))
+
+    flask_admin.add_view(SubmissionAdminView(db.session, category="Reporting data"))
+    flask_admin.add_view(ReportingRoundAdminView(db.session, category="Reporting data"))
+
+    flask_admin.add_view(ReingestAdminView(name="Reingest", endpoint="reingest", category="Admin actions"))
+    flask_admin.add_view(
+        RetrieveSubmissionAdminView(
+            name="Retrieve Submission", endpoint="retrieve_submission", category="Admin actions"
+        ),
+    )
+    flask_admin.add_view(
+        RetrieveFailedSubmissionAdminView(
+            name="Retrieve Failed Submission", endpoint="retrieve_failed_submission", category="Admin actions"
+        )
+    )

--- a/admin/actions.py
+++ b/admin/actions.py
@@ -1,0 +1,131 @@
+from io import BytesIO
+
+import requests
+from flask import current_app, flash, g, redirect, request, url_for
+from flask_admin import BaseView, expose
+from flask_admin.helpers import flash_errors
+from sqlalchemy.exc import NoResultFound
+from werkzeug.datastructures import FileStorage
+
+from admin.base import AdminAuthorizationMixin
+from admin.forms import ReingestAdminForm, RetrieveFailedSubmissionAdminForm, RetrieveSubmissionAdminForm
+from data_store.controllers.failed_submission import get_failed_submission
+from data_store.controllers.ingest import ingest
+from data_store.controllers.retrieve_submission_file import retrieve_submission_file
+from data_store.db import db
+from data_store.db.entities import Submission
+
+
+class BaseAdminView(AdminAuthorizationMixin, BaseView):
+    pass
+
+
+class ReingestAdminView(BaseAdminView):
+    @expose("/", methods=["GET", "POST"])
+    def index(self):
+        form = ReingestAdminForm(request.form)
+
+        if form.is_submitted():
+            if form.validate():
+                try:
+                    submission = Submission.query.filter_by(submission_id=form.submission_id.data).one()
+                except NoResultFound as e:
+                    flash(str(e), "error")
+                    return self.render("admin/reingest.html", form=form)
+
+                try:
+                    presigned_url = retrieve_submission_file(submission.submission_id)
+                except (LookupError, FileNotFoundError) as e:
+                    flash(str(e), "error")
+                    return self.render("admin/reingest.html", form=form)
+
+                file_response = requests.get(presigned_url)
+                file_storage = FileStorage(
+                    BytesIO(file_response.content),
+                    file_response.headers["x-amz-meta-filename"],
+                    file_response.headers["x-amz-meta-filename"],
+                    file_response.headers["content-type"],
+                    int(file_response.headers["content-length"]),
+                )
+                fund_name = (
+                    "Pathfinders"
+                    if submission.programme_junction.programme_ref.fund.fund_code == "PF"
+                    else "Towns Fund"
+                )
+                reporting_round = submission.programme_junction.reporting_round
+                account_id, user_email = submission.submitting_account_id, submission.submitting_user_email
+                db.session.close()  # ingest (specifically `populate_db`) wants to start a new clean session/transaction
+
+                response_data, status_code = ingest(
+                    dict(
+                        fund_name=fund_name,
+                        reporting_round=reporting_round,
+                        auth=None,  # Don't run any auth checks because we're admins
+                        do_load=True,
+                        submitting_account_id=account_id,
+                        submitting_user_email=user_email,
+                    ),
+                    file_storage,
+                )
+                if status_code == 200:
+                    current_app.logger.warning(
+                        "Submission ID %s reingested by %s", form.submission_id.data, g.user.email
+                    )
+                    flash(f"Successfully re-ingested submission {submission.submission_id}", "success")
+                else:
+                    flash(f"Issues re-ingesting submission {submission.submission_id}: {response_data}", "error")
+
+                return redirect(url_for("reingest.index"))
+
+            flash_errors(form, "%(error)s")
+
+        return self.render("admin/reingest.html", form=form)
+
+
+class RetrieveSubmissionAdminView(BaseAdminView):
+    @expose("/", methods=["GET", "POST"])
+    def index(self):
+        form = RetrieveSubmissionAdminForm(request.form)
+
+        if form.is_submitted():
+            if form.validate():
+                submission_id = form.submission_id.data
+                try:
+                    Submission.query.filter_by(submission_id=submission_id).one()
+                except NoResultFound as e:
+                    flash(str(e), "error")
+                    return self.render("admin/retrieve_submission.html", form=form)
+
+                try:
+                    presigned_url = retrieve_submission_file(submission_id)
+                except (LookupError, FileNotFoundError) as e:
+                    flash(str(e), "error")
+                    return self.render("admin/retrieve_submission.html", form=form)
+
+                current_app.logger.warning("Submission ID %s downloaded by %s", form.submission_id.data, g.user.email)
+                return redirect(presigned_url)
+
+            flash_errors(form, "%(error)s")
+
+        return self.render("admin/retrieve_submission.html", form=form)
+
+
+class RetrieveFailedSubmissionAdminView(BaseAdminView):
+    @expose("/", methods=["GET", "POST"])
+    def index(self):
+        form = RetrieveFailedSubmissionAdminForm(request.form)
+
+        if form.is_submitted():
+            if form.validate():
+                failure_uuid = form.failure_uuid.data
+                try:
+                    presigned_url = get_failed_submission(failure_uuid)
+                except (ValueError, FileNotFoundError) as e:
+                    flash(str(e), "error")
+                    return self.render("admin/retrieve_failed_submission.html", form=form)
+
+                return redirect(presigned_url)
+
+            flash_errors(form, "%(error)s")
+
+        return self.render("admin/retrieve_failed_submission.html", form=form)

--- a/admin/base.py
+++ b/admin/base.py
@@ -1,0 +1,15 @@
+from flask import abort, g
+from fsd_utils.authentication.config import SupportedApp
+from fsd_utils.authentication.decorators import login_required
+
+
+class AdminAuthorizationMixin:
+    def is_accessible(self):
+        @login_required(roles_required=["FSD_ADMIN"], return_app=SupportedApp.POST_AWARD_FRONTEND)
+        def check_auth():
+            return g.is_authenticated
+
+        if not check_auth():
+            abort(403)
+
+        return g.is_authenticated

--- a/admin/entities.py
+++ b/admin/entities.py
@@ -1,0 +1,165 @@
+from abc import abstractmethod
+from datetime import datetime
+
+from flask import current_app, g
+from flask_admin.contrib import sqla
+from flask_admin.contrib.sqla.typefmt import DEFAULT_FORMATTERS
+from flask_wtf import FlaskForm
+
+from admin.base import AdminAuthorizationMixin
+from data_store.db.entities import Fund, GeospatialDim, Organisation, OutcomeDim, OutputDim, ReportingRound, Submission
+
+
+class BaseAdminView(AdminAuthorizationMixin, sqla.ModelView):
+    form_base_class = FlaskForm
+
+    page_size = 50
+    can_set_page_size = True
+
+    can_create = False
+    can_view_details = True
+    can_edit = False
+    can_delete = False
+    can_export = False
+
+    def __init__(
+        self,
+        session,
+        name=None,
+        category=None,
+        endpoint=None,
+        url=None,
+        static_folder=None,
+        menu_class_name=None,
+        menu_icon_type=None,
+        menu_icon_value=None,
+    ):
+        super().__init__(
+            self._model,
+            session,
+            name=name,
+            category=category,
+            endpoint=endpoint,
+            url=url,
+            static_folder=static_folder,
+            menu_class_name=menu_class_name,
+            menu_icon_type=menu_icon_type,
+            menu_icon_value=menu_icon_value,
+        )
+
+    @property
+    @abstractmethod
+    def _model(self):
+        pass
+
+
+class SubmissionAdminView(BaseAdminView):
+    _model = Submission
+
+    # This view is SQL-query heavy due to relationships, so let's restrict page size
+    page_size = 25
+    can_set_page_size = False
+
+    column_list = [
+        Submission.submission_id,
+        "programme_junction.programme_ref.fund.fund_code",
+        "programme_junction.reporting_round",
+        Submission.submission_date,
+        "programme_junction.programme_ref.programme_id",
+        "programme_junction.programme_ref.organisation.organisation_name",
+    ]
+    column_labels = {
+        "programme_junction.programme_ref.programme_id": "Programme ID",
+        "programme_junction.programme_ref.organisation.organisation_name": "Organisation",
+        "programme_junction.programme_ref.fund.fund_code": "Fund code",
+        "programme_junction.reporting_round": "Reporting round",
+    }
+    column_sortable_list = [
+        Submission.submission_id,
+        "programme_junction.programme_ref.organisation.organisation_name",
+        "programme_junction.reporting_round",
+        Submission.submission_date,
+    ]
+    column_searchable_list = [Submission.id, Submission.submission_id]
+    column_default_sort = [("programme_junction.reporting_round", True)]
+    column_filters = [
+        "programme_junction.reporting_round",
+        "programme_junction.programme_ref.fund.fund_code",
+        "programme_junction.programme_ref.programme_id",
+        "programme_junction.programme_ref.organisation.organisation_name",
+    ]
+
+
+class OrganisationAdminView(BaseAdminView):
+    _model = Organisation
+
+
+class FundAdminView(BaseAdminView):
+    _model = Fund
+
+
+class GeospatialAdminView(BaseAdminView):
+    _model = GeospatialDim
+
+    column_default_sort = [(GeospatialDim.postcode_prefix, False)]
+
+
+class OutputDimAdminView(BaseAdminView):
+    _model = OutputDim
+
+    column_default_sort = [(OutputDim.output_category, False), (OutputDim.output_name, False)]
+    column_searchable_list = [OutputDim.output_name]
+    column_filters = [
+        OutputDim.output_category,
+    ]
+
+
+class OutcomeDimAdminView(BaseAdminView):
+    _model = OutcomeDim
+
+    column_default_sort = [(OutcomeDim.outcome_category, False), (OutcomeDim.outcome_name, False)]
+    column_searchable_list = [OutcomeDim.outcome_name]
+    column_filters = [
+        OutcomeDim.outcome_category,
+    ]
+
+
+class ReportingRoundAdminView(BaseAdminView):
+    _model = ReportingRound
+
+    can_create = True
+
+    # Change how values are rendered in the table
+    column_type_formatters = {
+        **DEFAULT_FORMATTERS,
+        Fund: lambda view, value, name: value.fund_code,
+        datetime: lambda view, value, name: value.strftime("%d %b %Y, %H:%M:%S"),
+    }
+    column_type_formatters_detail = column_type_formatters
+
+    # Hide these relationship fields when creating/viewing/editing
+    form_excluded_columns = [
+        "programme_junctions",
+        "submissions",
+    ]
+
+    def after_model_change(self, form, model, is_created):
+        verb = "created" if is_created else "updated"
+
+        current_app.logger.warning(
+            (
+                "%s %s reporting round %s: "
+                "fund=%s, round_number=%s, "
+                "observation_period_start=%s, observation_period_end=%s, "
+                "submission_period_start=%s, submission_period_end=%s"
+            ),
+            g.user.email,
+            verb,
+            model.id,
+            model.fund.fund_code,
+            model.round_number,
+            model.observation_period_start,
+            model.observation_period_end,
+            model.submission_period_start,
+            model.submission_period_end,
+        )

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -1,0 +1,17 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField
+from wtforms.validators import DataRequired
+
+
+class ReingestAdminForm(FlaskForm):
+    submission_id = StringField("The submission ID to re-ingest", validators=[DataRequired()])
+
+
+class RetrieveSubmissionAdminForm(FlaskForm):
+    submission_id = StringField("The submission ID to retrieve", validators=[DataRequired()])
+
+
+class RetrieveFailedSubmissionAdminForm(FlaskForm):
+    failure_uuid = StringField(
+        "The failure id corresponding to the failed submission to retrieve", validators=[DataRequired()]
+    )

--- a/admin/templates/admin/reingest.html
+++ b/admin/templates/admin/reingest.html
@@ -1,0 +1,20 @@
+{% extends "admin/master.html" %}
+
+{% import "admin/lib.html" as lib with context %}
+{% from "admin/lib.html" import extra with context %} {# backward compatible #}
+
+{% block head %}
+  {{ super() }}
+  {{ lib.form_css() }}
+{% endblock head %}
+
+{% block body %}
+  <h1 class="govuk-heading-l">Reingest submission</h1>
+
+  {{ lib.render_form(form) }}
+{% endblock body %}
+
+{% block tail %}
+  {{ super() }}
+  {{ lib.form_js() }}
+{% endblock tail %}

--- a/admin/templates/admin/retrieve_failed_submission.html
+++ b/admin/templates/admin/retrieve_failed_submission.html
@@ -1,0 +1,20 @@
+{% extends "admin/master.html" %}
+
+{% import "admin/lib.html" as lib with context %}
+{% from "admin/lib.html" import extra with context %} {# backward compatible #}
+
+{% block head %}
+  {{ super() }}
+  {{ lib.form_css() }}
+{% endblock head %}
+
+{% block body %}
+  <h1 class="govuk-heading-l">Retrieve failed submission</h1>
+
+  {{ lib.render_form(form) }}
+{% endblock body %}
+
+{% block tail %}
+  {{ super() }}
+  {{ lib.form_js() }}
+{% endblock tail %}

--- a/admin/templates/admin/retrieve_submission.html
+++ b/admin/templates/admin/retrieve_submission.html
@@ -1,0 +1,20 @@
+{% extends "admin/master.html" %}
+
+{% import "admin/lib.html" as lib with context %}
+{% from "admin/lib.html" import extra with context %} {# backward compatible #}
+
+{% block head %}
+  {{ super() }}
+  {{ lib.form_css() }}
+{% endblock head %}
+
+{% block body %}
+  <h1 class="govuk-heading-l">Retrieve submission</h1>
+
+  {{ lib.render_form(form) }}
+{% endblock body %}
+
+{% block tail %}
+  {{ super() }}
+  {{ lib.form_js() }}
+{% endblock tail %}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -39,7 +39,7 @@ class DefaultConfig(object):
 
     # Funding Service Design Post Award
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
-    AUTHENTICATOR_HOST = os.environ.get("AUTHENTICATOR_HOST", "authenticator")
+    AUTHENTICATOR_HOST = os.environ.get("AUTHENTICATOR_HOST", "http://authenticator.levellingup.gov.localhost:4004")
     COOKIE_DOMAIN = os.environ.get("COOKIE_DOMAIN", None)
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev")
     SESSION_COOKIE_SECURE = True

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -26,7 +26,7 @@ class DevelopmentConfig(DefaultConfig):
     DEBUG_USER = {
         "full_name": "Development User",
         "email": "dev@communities.gov.uk",
-        "roles": ["PF_MONITORING_RETURN_SUBMITTER", "TF_MONITORING_RETURN_SUBMITTER"],
+        "roles": ["PF_MONITORING_RETURN_SUBMITTER", "TF_MONITORING_RETURN_SUBMITTER", "FSD_ADMIN"],
         "highest_role_map": {},
     }
     DEBUG_USER_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"

--- a/data_store/db/entities.py
+++ b/data_store/db/entities.py
@@ -27,6 +27,9 @@ class Fund(BaseModel):
     programmes: Mapped[List["Programme"]] = sqla.orm.relationship(back_populates="fund")
     reporting_rounds: Mapped[List["ReportingRound"]] = sqla.orm.relationship(back_populates="fund")
 
+    def __str__(self):
+        return self.fund_code
+
 
 class Funding(BaseModel):
     """Stores Funding Entities."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ module = [
   "notifications_python_client.*",
   "flask_wtf",
   "govuk_frontend_wtf.wtforms_widgets",
+  "flask_admin.*",
 ]
 ignore_missing_imports = true
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ filterwarnings =
   error
   ignore:Conditional Formatting extension is not supported and will be removed:UserWarning
   ignore:Data Validation extension is not supported and will be removed:UserWarning
+  ignore:'iter_groups' is expected to return 4 items tuple since wtforms 3.1, this will be mandatory in wtforms 3.2:DeprecationWarning:flask_admin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -123,6 +123,7 @@ filelock==3.13.1
 flask==3.0.3
     # via
     #   -r requirements.txt
+    #   flask-admin
     #   flask-assets
     #   flask-babel
     #   flask-migrate
@@ -133,6 +134,8 @@ flask==3.0.3
     #   govuk-frontend-wtf
     #   sentry-sdk
     #   types-flask-migrate
+flask-admin[sqlalchemy]==2.0.0a0
+    # via -r requirements.txt
 flask-assets==2.1.0
     # via -r requirements.txt
 flask-babel==2.0.0
@@ -150,6 +153,7 @@ flask-redis==0.4.0
 flask-sqlalchemy==3.0.3
     # via
     #   -r requirements.txt
+    #   flask-admin
     #   flask-migrate
     #   funding-service-design-utils
     #   types-flask-migrate
@@ -193,6 +197,7 @@ jinja2==3.1.4
     # via
     #   -r requirements.txt
     #   flask
+    #   flask-admin
     #   flask-babel
     #   govuk-frontend-jinja
     #   govuk-frontend-wtf
@@ -214,6 +219,7 @@ mako==1.3.5
 markupsafe==2.1.2
     # via
     #   -r requirements.txt
+    #   flask-admin
     #   jinja2
     #   mako
     #   sentry-sdk
@@ -401,6 +407,7 @@ sqlalchemy==2.0.9
     # via
     #   -r requirements.txt
     #   alembic
+    #   flask-admin
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
@@ -510,6 +517,7 @@ werkzeug==3.0.3
     # via
     #   -r requirements.txt
     #   flask
+    #   flask-admin
 wheel==0.43.0
     # via pip-tools
 wrapt==1.16.0
@@ -519,6 +527,7 @@ wrapt==1.16.0
 wtforms==3.1.2
     # via
     #   -r requirements.txt
+    #   flask-admin
     #   flask-wtf
     #   govuk-frontend-wtf
 xlsxwriter==3.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ email_validator==2.0.0.post2
 #   Flask
 #-----------------------------------
 Flask==3.0.*
+flask-admin[sqlalchemy]==2.0.0a0
 flask-talisman==1.0.0
 flask-WTF==1.2.*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ et-xmlfile==1.1.0
 flask==3.0.3
     # via
     #   -r requirements.in
+    #   flask-admin
     #   flask-assets
     #   flask-babel
     #   flask-migrate
@@ -77,6 +78,8 @@ flask==3.0.3
     #   funding-service-design-utils
     #   govuk-frontend-wtf
     #   sentry-sdk
+flask-admin[sqlalchemy]==2.0.0a0
+    # via -r requirements.in
 flask-assets==2.1.0
     # via -r requirements.in
 flask-babel==2.0.0
@@ -88,6 +91,7 @@ flask-redis==0.4.0
 flask-sqlalchemy==3.0.3
     # via
     #   -r requirements.in
+    #   flask-admin
     #   flask-migrate
     #   funding-service-design-utils
 flask-talisman==1.0.0
@@ -104,8 +108,6 @@ govuk-frontend-jinja==3.3.0
     #   govuk-frontend-wtf
 govuk-frontend-wtf==3.1.0
     # via -r requirements.in
-greenlet==3.0.3
-    # via sqlalchemy
 gunicorn==22.0.0
     # via funding-service-design-utils
 idna==3.7
@@ -119,6 +121,7 @@ itsdangerous==2.1.2
 jinja2==3.1.4
     # via
     #   flask
+    #   flask-admin
     #   flask-babel
     #   govuk-frontend-jinja
     #   govuk-frontend-wtf
@@ -134,6 +137,7 @@ mako==1.3.5
     # via alembic
 markupsafe==2.1.2
     # via
+    #   flask-admin
     #   jinja2
     #   mako
     #   sentry-sdk
@@ -224,6 +228,7 @@ sqlalchemy==2.0.9
     # via
     #   -r requirements.in
     #   alembic
+    #   flask-admin
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
@@ -256,12 +261,15 @@ wcwidth==0.2.13
 webassets==2.0
     # via flask-assets
 werkzeug==3.0.3
-    # via flask
+    # via
+    #   flask
+    #   flask-admin
 wrapt==1.16.0
     # via pandera
 wtforms==3.1.2
     # via
     #   -r requirements.in
+    #   flask-admin
     #   flask-wtf
     #   govuk-frontend-wtf
 xlsxwriter==3.1.1

--- a/tests/admin_tests/test_auth.py
+++ b/tests/admin_tests/test_auth.py
@@ -1,0 +1,187 @@
+import contextlib
+import inspect
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from flask import url_for
+
+
+class TestAdminModelsAuthorization:
+    models = (
+        "fund",
+        "geospatialdim",
+        "organisation",
+        "outcomedim",
+        "outputdim",
+        "submission",
+        "reportinground",
+    )
+
+    def test_all_models_captured(self, find_test_client):
+        from admin import entities
+
+        admin_module_classes = [
+            obj
+            for _, obj in inspect.getmembers(entities)
+            if inspect.isclass(obj) and issubclass(obj, entities.BaseAdminView) and obj is not entities.BaseAdminView
+        ]
+        assert len(admin_module_classes) == len(self.models), (
+            "If this test is failing and you've added a new admin model, "
+            "then increase this number and make sure it's appropriately tested below."
+        )
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", models)
+    def test_get(self, request: FixtureRequest, seeded_test_client, has_admin_role: bool, admin_view_name: str):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        with client.application.app_context():
+            response = client.get(f"/admin/{admin_view_name}/")
+            if has_admin_role:
+                assert response.status_code == 200
+            else:
+                assert response.status_code == 302
+                assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", models)
+    def test_create_new_instance(
+        self, request: FixtureRequest, seeded_test_client, has_admin_role: bool, admin_view_name: str
+    ):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        CAN_CREATE_MODELS = ["reportinground"]
+
+        with client.application.app_context():
+            response = client.post(f"/admin/{admin_view_name}/new/")
+
+            if has_admin_role:
+                if admin_view_name in CAN_CREATE_MODELS:
+                    assert response.status_code == 200
+
+                else:
+                    assert response.status_code == 302
+                    assert response.location == f"/admin/{admin_view_name}/"
+
+            else:
+                assert response.status_code == 302
+                assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", models)
+    def test_edit_instances(
+        self, request: FixtureRequest, seeded_test_client, has_admin_role: bool, admin_view_name: str
+    ):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        CAN_EDIT_MODELS: list[str] = []
+
+        with client.application.app_context():
+            # Bit of a hack - we pass a non-uuid ID through. This only gets checked if all of the authorization checks
+            # pass and the view is actually enabled for edits, so we use this to short-circuit having to find a
+            # valid instance in the DB to hook up.
+            should_be_able_to_edit = admin_view_name in CAN_EDIT_MODELS and has_admin_role
+            ignore_id_error = pytest.raises(Exception) if should_be_able_to_edit else contextlib.nullcontext()
+
+            with ignore_id_error:
+                response = client.post(f"/admin/{admin_view_name}/edit/?id=invalid-oh-no")
+
+                if has_admin_role:
+                    assert response.status_code == 302
+                    assert response.location == f"/admin/{admin_view_name}/"
+
+                else:
+                    assert response.status_code == 302
+                    assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")
+
+            if should_be_able_to_edit:
+                # We expect this error if the view was accessed "successfully" (ie user has admin group and the entity
+                # is configured to allow edits
+                assert "invalid input syntax for type uuid" in str(
+                    ignore_id_error.excinfo
+                ), "Looks like the test thinks you can edit the model, but you actually can't"
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", models)
+    def test_delete_instances(
+        self, request: FixtureRequest, seeded_test_client, has_admin_role: bool, admin_view_name: str
+    ):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        CAN_DELETE_MODELS: list[str] = []
+
+        with client.application.app_context():
+            # Bit of a hack - we pass a non-uuid ID through. This only gets checked if all of the authorization checks
+            # pass and the view is actually enabled for edits, so we use this to short-circuit having to find a
+            # valid instance in the DB to hook up.
+            should_be_able_to_delete = admin_view_name in CAN_DELETE_MODELS and has_admin_role
+            ignore_id_error = pytest.raises(Exception) if should_be_able_to_delete else contextlib.nullcontext()
+
+            response = client.post(f"/admin/{admin_view_name}/delete/", json={"id": "invalid-oh-no"})
+
+            if has_admin_role:
+                assert response.status_code == 302
+                assert response.location == f"/admin/{admin_view_name}/"
+
+            else:
+                assert response.status_code == 302
+                assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")
+
+            if should_be_able_to_delete:
+                # We expect this error if the view was accessed "successfully" (ie user has admin group and the entity
+                # is configured to allow edits
+                assert "invalid input syntax for type uuid" in str(
+                    ignore_id_error.excinfo
+                ), "Looks like the test thinks you can delete the model, but you actually can't"
+
+
+class TestAdminActionsAuthorization:
+    actions = (
+        "reingest",
+        "retrieve_submission",
+        "retrieve_failed_submission",
+    )
+
+    def test_all_actions_captured(self, find_test_client):
+        from admin import actions
+
+        admin_module_classes = [
+            obj
+            for _, obj in inspect.getmembers(actions)
+            if inspect.isclass(obj) and issubclass(obj, actions.BaseAdminView) and obj is not actions.BaseAdminView
+        ]
+        assert len(admin_module_classes) == len(self.actions), (
+            "If this test is failing and you've added a new admin action, "
+            "then increase this number and make sure it's appropriately tested below."
+        )
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", actions)
+    def test_get_authorization(
+        self, request: FixtureRequest, seeded_test_client, has_admin_role: bool, admin_view_name: str
+    ):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        with client.application.app_context():
+            response = client.get(f"/admin/{admin_view_name}/")
+            if has_admin_role:
+                assert response.status_code == 200
+            else:
+                assert response.status_code == 302
+                assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")
+
+    @pytest.mark.parametrize("has_admin_role", [True, False])
+    @pytest.mark.parametrize("admin_view_name", actions)
+    def test_post_authorization(self, request, has_admin_role, seeded_test_client, admin_view_name):
+        client = request.getfixturevalue("admin_test_client" if has_admin_role else "find_test_client")
+
+        with client.application.test_request_context():
+            reingest_url = url_for(f"{admin_view_name}.index")
+
+        response = client.post(reingest_url)
+
+        if has_admin_role:
+            assert response.status_code == 200  # request authorized (but will be in form error state)
+        else:
+            assert response.status_code == 302
+            assert response.location.startswith("http://authenticator.levellingup.gov.localhost:4004/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,6 +658,18 @@ def mocked_find_auth(mocker):
     )
 
 
+@pytest.fixture(scope="function")
+def mocked_admin_user(mocker):
+    mocker.patch(
+        "fsd_utils.authentication.decorators._check_access_token",
+        return_value={
+            "accountId": "test-user",
+            "roles": ["FSD_ADMIN"],
+            "email": "admin@communities.gov.uk",
+        },
+    )
+
+
 class _SubmitFlaskClient(FlaskClient):
     def open(
         self,
@@ -725,6 +737,14 @@ def find_test_client(mocked_find_auth) -> Generator[FlaskClient, None, None]:
 
     :return: A flask test client.
     """
+    app = create_app(config.Config)
+    app.test_client_class = _FindFlaskClient
+    with app.test_client() as test_client:
+        yield test_client
+
+
+@pytest.fixture(scope="function")
+def admin_test_client(mocked_admin_user) -> Generator[FlaskClient, None, None]:
     app = create_app(config.Config)
     app.test_client_class = _FindFlaskClient
     with app.test_client() as test_client:

--- a/tests/find_tests/test_routes.py
+++ b/tests/find_tests/test_routes.py
@@ -153,9 +153,9 @@ def test_download_confirmation_page(find_test_client):
 def test_user_not_signed(unauthenticated_find_test_client):
     response = unauthenticated_find_test_client.get("/request-received")
     assert response.status_code == 302
-    assert (
-        response.location
-        == "authenticator/sessions/sign-out?return_app=post-award-frontend&return_path=%2Frequest-received"
+    assert response.location == (
+        "http://authenticator.levellingup.gov.localhost:4004"
+        "/sessions/sign-out?return_app=post-award-frontend&return_path=%2Frequest-received"
     )
 
 

--- a/tests/submit_tests/test_routes.py
+++ b/tests/submit_tests/test_routes.py
@@ -291,9 +291,9 @@ def test_unauthenticated_upload(unauthenticated_submit_test_client):
     response = unauthenticated_submit_test_client.get(f"/upload/{TEST_FUND_CODE}/{TEST_ROUND}")
     # Assert redirect to authenticator
     assert response.status_code == 302
-    assert (
-        response.location
-        == "authenticator/sessions/sign-out?return_app=post-award-submit&return_path=%2Fupload%2FTF%2F4"
+    assert response.location == (
+        "http://authenticator.levellingup.gov.localhost:4004"
+        "/sessions/sign-out?return_app=post-award-submit&return_path=%2Fupload%2FTF%2F4"
     )
 
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-579

### Change description
Integrates [Flask-Admin](https://flask-admin.readthedocs.io/en/v2.0.0a0/) with some basic admin views:

#### Models
* View funds
* View geospatial dim (postcodes)
* View organisations
* View outcomes
* View outputs
* View submissions
* View and create reporting rounds

#### Admin actions
* Re-ingest submission by ID
* Download submission spreadsheet by ID
* Retrieve failed (500-style error) submission by UUID

These are all protected by membership of the `FSD_ADMIN` Microsoft AD group.

- [x] Unit tests and other appropriate tests added or updated


### How to test
* Go to http://find-monitoring-data.levellingup.gov.localhost:4001/admin/