### PR TITLE
Logging for download

### DIFF
--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -107,14 +107,14 @@ def download():
             if reporting_period_end:
                 query_params["rp_end"] = reporting_period_end
 
+            query_params_without_email_address = {k: v for k, v in query_params.items() if k != "email_address"}
             try:
                 trigger_async_download(query_params)
                 current_app.logger.info(
                     "Request for download by {user_id} with {query_params}",
                     extra={
                         "user_id": g.account_id,
-                        "email": g.user.email,
-                        "query_params": query_params,
+                        "query_params": query_params_without_email_address,
                         "request_type": "download",
                     },
                 )

--- a/tests/find_tests/test_logging.py
+++ b/tests/find_tests/test_logging.py
@@ -4,4 +4,4 @@ def test_download_logging(find_test_client, caplog, mocked_routes_trigger_async_
     assert len(log_line) == 1
     assert log_line[0].request_type == "download"
     assert log_line[0].user_id == "test-user"
-    assert log_line[0].query_params == {"file_format": "xlsx", "email_address": "test-user@communities.gov.uk"}
+    assert log_line[0].query_params == {"file_format": "xlsx"}


### PR DESCRIPTION
Ticket:
https://dluhcdigital.atlassian.net/browse/FPASF-537

Description:
The users' email addresses should not be logged for download, to avoid logging of PIIs.
To have the email addresses included in the file generated by the report script, a call for each user_id is done to account-store to get that.

Unit test updated, to check that email_address is no longer logged.


