### PR TITLE
Enable mypy "extra checks"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ warn_unused_ignores = false
 
 # Getting these passing should be easy
 strict_equality = false
-strict_concatenate = false
 
 # Strongly recommend enabling this one as soon as you can
 check_untyped_defs = false
@@ -57,7 +56,7 @@ warn_return_any = false
 
 # MyPy just says these are "extra checks that are technically correct but may be inpractical in real code"
 # We can try this out and if it's too difficult, we can leave it disabled.
-extra_checks = false
+extra_checks = true
 
 # If all of the above options are enabled, we should be able to just turn on `strict` mode
 strict = false


### PR DESCRIPTION
### Change description
This is a replacement for `strict-concat` (and possibly some others); "Warning: --strict-concatenate is deprecated; use --extra-checks instead"

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")