### PR TITLE
Remove sqlalchemy-stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       additional_dependencies: [
         "boto3-stubs[s3,logs]",
         pandas-stubs,
-        sqlalchemy-stubs,
+        sqlalchemy==2.0.9,
         types-beautifulsoup4,
         types-colorama,
         types-flask,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
         "boto3-stubs[s3,logs]",
         pandas-stubs,
         sqlalchemy==2.0.9,
+        flask-sqlalchemy==3.0.3,
         types-beautifulsoup4,
         types-colorama,
         types-flask,
@@ -41,7 +42,6 @@ repos:
         types-PyYAML,
         types-requests,
         types-setuptools,
-        types-flask-sqlalchemy,
         ]
 - repo: https://github.com/djlint/djLint
   rev: v1.35.2

--- a/data_store/controllers/notify.py
+++ b/data_store/controllers/notify.py
@@ -71,7 +71,7 @@ def send_fund_confirmation_email(
         notify_key=Config.NOTIFY_API_KEY,
         personalisation={
             "name_of_fund": fund_name,
-            "filename": f"{get_custom_file_name(submission.id)}.xlsx",
+            "filename": f"{get_custom_file_name(str(submission.id))}.xlsx",
             "fund_type": FUND_TYPE_ID_TO_FRIENDLY_NAME.get(fund_type, ""),
             "place_name": programme_name or "",
             "date_of_submission": datetime.now().strftime("%e %B %Y at %H:%M").strip(),

--- a/data_store/db/entities.py
+++ b/data_store/db/entities.py
@@ -340,7 +340,7 @@ class Programme(BaseModel):
 
     __tablename__ = "programme_dim"
 
-    programme_id = sqla.Column(sqla.String(), nullable=False, unique=True)
+    programme_id: Mapped[str] = sqla.orm.mapped_column(nullable=False, unique=True)
 
     programme_name = sqla.Column(sqla.String(), nullable=False)
     organisation_id = sqla.Column(GUID(), sqla.ForeignKey("organisation_dim.id"), nullable=False)

--- a/data_store/db/queries.py
+++ b/data_store/db/queries.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Query
 
 import data_store.db.entities as ents
 from data_store.db import db
+from data_store.db.types import GUID
 
 
 def query_extend_with_outcome_filter(base_query: Query, outcome_categories: list[str] | None = None) -> Query:
@@ -769,7 +770,7 @@ def get_latest_submission_by_round_and_fund(round_number: int, fund_code: str) -
     return latest_submission_id
 
 
-def get_reporting_round_id(reporting_round_df: pd.DataFrame, fund_code: str) -> str:
+def get_reporting_round_id(reporting_round_df: pd.DataFrame, fund_code: str) -> GUID:
     """
     Get the reporting round id for a given reporting round dataframe and fund code.
     """

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -19,7 +19,6 @@ pytest-playwright
 mypy==1.11.2  # If bumping this, please also bump .pre-commit-config.yml
 boto3-stubs[s3,logs]
 pandas-stubs
-sqlalchemy-stubs
 types-beautifulsoup4
 types-colorama
 types-flask

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -23,7 +23,6 @@ types-beautifulsoup4
 types-colorama
 types-flask
 types-Flask-Migrate
-types-flask-sqlalchemy
 types-jmespath
 types-openpyxl
 types-psycopg2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -407,8 +407,6 @@ sqlalchemy==2.0.9
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-stubs==0.4
-    # via -r requirements-dev.in
 sqlalchemy-utils==0.41.2
     # via
     #   -r requirements.txt
@@ -484,7 +482,6 @@ typing-extensions==4.6.0
     #   pydantic
     #   pyee
     #   sqlalchemy
-    #   sqlalchemy-stubs
     #   typing-inspect
 typing-inspect==0.9.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -168,10 +168,7 @@ govuk-frontend-jinja==3.1.0
 govuk-frontend-wtf==3.1.0
     # via -r requirements.txt
 greenlet==3.0.3
-    # via
-    #   -r requirements.txt
-    #   playwright
-    #   sqlalchemy
+    # via playwright
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -232,9 +229,7 @@ multimethod==1.10
     #   -r requirements.txt
     #   pandera
 mypy==1.11.2
-    # via
-    #   -r requirements-dev.in
-    #   sqlalchemy-stubs
+    # via -r requirements-dev.in
 mypy-boto3-logs==1.34.151
     # via boto3-stubs
 mypy-boto3-s3==1.34.162
@@ -431,8 +426,6 @@ types-flask==1.1.6
     # via -r requirements-dev.in
 types-flask-migrate==4.0.0.20240311
     # via -r requirements-dev.in
-types-flask-sqlalchemy==2.5.9.4
-    # via -r requirements-dev.in
 types-html5lib==1.1.11.20240228
     # via types-beautifulsoup4
 types-jinja2==2.11.9
@@ -463,8 +456,6 @@ types-setuptools==70.0.0.20240524
     # via
     #   -r requirements-dev.in
     #   types-pygments
-types-sqlalchemy==1.4.53.38
-    # via types-flask-sqlalchemy
 types-urllib3==1.26.25.14
     # via types-requests
 types-werkzeug==1.0.9


### PR DESCRIPTION
### Change description
These are only required for sqlalchemy<2, and with sqlalchemy>=2 they infact become misleading/incorrect.

This does mean that we need to install sqlalchemy itself (and specifically the same version we use in our real code) in the pre-commit hook.