### PR TITLE
Move from script hashes to CSP nonces

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from celery import Celery
 from celery.signals import setup_logging
 from flask import Flask, current_app, flash, redirect, render_template, request
 from flask_assets import Environment
-from flask_talisman import Talisman
+from flask_talisman import DEFAULT_CSP_POLICY, Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from fsd_utils import init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
@@ -123,19 +123,15 @@ def create_app(config_class=Config) -> Flask:
     # Security configuration
     csrf.init_app(flask_app)
 
-    # TODO: Work out which scripts these SHAs relate to and comment this better
-    csp = {
-        "default-src": "'self'",
-        "script-src": [
-            "'self'",
-            "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-            "'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='",
-            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
-            "'sha256-ndKdvEBfUn27+cpVrq2H697Dg88x3tsepe3veTUtsaA='",
-            "'sha256-oR+vHsLl1DMudaF9Ay6TIDK2lXwFka0z5sbdN5RZQxE='",
-        ],
-    }
-    talisman.init_app(flask_app, content_security_policy=csp, force_https=False)
+    talisman.init_app(
+        flask_app,
+        content_security_policy={
+            **DEFAULT_CSP_POLICY,
+            "script-src": "'self'",
+        },
+        content_security_policy_nonce_in=["script-src"],
+        force_https=False,
+    )
     WTFormsHelpers(flask_app)
 
     _register_blueprints_and_routes(flask_app)

--- a/common/templates/common/base.html
+++ b/common/templates/common/base.html
@@ -6,6 +6,8 @@
 {%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
 {%- from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader -%}
 
+{% set cspNonce = csp_nonce() %}  {# Used in the base template govuk_frontend_jinja/template.html #}
+
 {% block pageTitle %}{{ service_name }} – GOV.UK{% endblock pageTitle %}
 
 {% block head %}
@@ -76,7 +78,7 @@
 {% block bodyEnd %}
   {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
-  <script type="module">
+  <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'
       initAll()
   </script>

--- a/find/templates/find/base.html
+++ b/find/templates/find/base.html
@@ -7,6 +7,7 @@
 {%- from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader -%}
 
 {% set assetPath = url_for('static', filename='govuk-frontend').rstrip('/') %}
+{% set cspNonce = csp_nonce() %}  {# Used in the base template govuk_frontend_jinja/template.html #}
 
 {% block pageTitle %}{{ config['FIND_SERVICE_NAME'] }} – GOV.UK{% endblock pageTitle %}
 
@@ -111,7 +112,7 @@
 {% block bodyEnd %}
   {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
-  <script type="module">
+  <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'
       initAll()
   </script>

--- a/find/templates/find/main/login.html
+++ b/find/templates/find/main/login.html
@@ -48,7 +48,7 @@
 {% block bodyEnd %}
   {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
-  <script type="module">
+  <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'
       initAll()
   </script>

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -5,6 +5,7 @@
 {%- from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader -%}
 
 {% set assetPath = url_for('static', filename='govuk-frontend').rstrip('/') %}
+{% set cspNonce = csp_nonce() %}  {# Used in the base template govuk_frontend_jinja/template.html #}
 
 {% block pageTitle %}{{ config['SUBMIT_SERVICE_NAME'] }} – GOV.UK{% endblock pageTitle %}
 
@@ -13,11 +14,9 @@
 <meta name="keywords"
   content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
 <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-<link rel="stylesheet" type="text/css"
-  href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
 <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
-{% assets "css" %}
-<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
+{% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
 
 {% block header %}
@@ -84,7 +83,7 @@
 {% block bodyEnd %}
   {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
-  <script type="module">
+  <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'
       initAll()
   </script>


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-433

### Change description
Previously, we allowed custom JS to execute in the browser by whitelisting the hashes of the script contents. This had a few issues

* We reference some JS by domain names, so needed to have the hash for each of our environments whitelisted.
* We didn't comment these well, so it's unclear which hashes are whitelisting which scripts.

We now stop using the hash whitelist and move over to CSP nonces. These are random values that we associate with each custom inline script to tell the browser they're trusted and can be executed.

The CSP nonce present on each script tag must match the CSP nonce passed back in the HTTP response header, otherwise the browser will refuse to run the script.

## How to test

- Run the tests. Maybe even the nice new end-to-end tests ;)
- Check browser console log - shouldn't see any errors about scripts/styles not being executed/loaded.