### PR TITLE
Show find report date on download page

### DIFF
--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -165,7 +165,7 @@ def retrieve_download(filename: str):
         "filename": filename,
         "file_size": file_metadata["file_size"],
         "file_format": file_metadata["file_format"],
-        "last_modified": file_metadata["last_modified"].strftime("%d %B %Y"),
+        "date": file_metadata["last_modified"].strftime("%d %B %Y"),
     }
 
     if form.validate_on_submit():

--- a/tests/find_tests/test_routes.py
+++ b/tests/find_tests/test_routes.py
@@ -193,6 +193,9 @@ def test_download_file_exist(find_test_client):
     download_button = page.select_one("button#download")
     assert download_button is not None
 
+    inset_text = " ".join(page.select_one(".govuk-inset-text").stripped_strings)
+    assert "You requested a data download on 06 July 2024" in inset_text
+
 
 def test_file_not_found(find_test_client):
     with patch("find.main.routes.get_file_header", side_effect=FileNotFoundError()):


### PR DESCRIPTION
### Change description
A recent change tweaking the names of some variables caused this value to stop being shown on the page.

https://github.com/communitiesuk/funding-service-design-post-award-data-store/commit/85c5ecacbb4152fbc0dd32e8a2afc87909281deb#diff-ee51d81c6e3fc5850fa1c22b90d04b8a1262d02a3b76ffd93e417b56008f3222R168

This unwinds the variable renaming and adds a test to prevent regression.

### Screenshots of UI changes (if applicable)

#### Before
<img width="619" alt="image" src="https://github.com/user-attachments/assets/e47d63b3-0307-4abe-ba6f-a45a03e89300">


#### After
<img width="648" alt="image" src="https://github.com/user-attachments/assets/82f1d31c-9094-4a71-a771-57d9c1ddba7a">
