### PR TITLE
Upgrade to GOV.UK Frontend v5.6.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,7 +8,7 @@ import static_assets
 
 
 def build_govuk_assets(static_dist_root="static/src"):
-    GOVUK_FRONTEND_VERSION = "5.4.0"
+    GOVUK_FRONTEND_VERSION = "5.6.0"
     DIST_ROOT = "./" + static_dist_root
     GOVUK_DIR = "/govuk-frontend"
     GOVUK_URL = (

--- a/common/templates/common/base.html
+++ b/common/templates/common/base.html
@@ -14,7 +14,7 @@
 <meta name="description" content="{{ service_name }}">
 <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, mhclg, funding">
 <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
 <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
 {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
@@ -76,7 +76,7 @@
 {% endblock footer %}
 
 {% block bodyEnd %}
-  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
+  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
   <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'

--- a/find/templates/find/base.html
+++ b/find/templates/find/base.html
@@ -15,7 +15,7 @@
   <meta name="description" content="{{ config['FIND_SERVICE_NAME'] }}">
   <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
   <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-  <link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+  <link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
   <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
   {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
@@ -110,7 +110,7 @@
 {% endblock footer %}
 
 {% block bodyEnd %}
-  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
+  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
   <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'

--- a/find/templates/find/main/help.html
+++ b/find/templates/find/main/help.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{{ config['FIND_SERVICE_NAME'] }}">
   <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
   <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
   <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
   {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}

--- a/find/templates/find/main/login.html
+++ b/find/templates/find/main/login.html
@@ -8,7 +8,7 @@
   <meta name="description" content="{{ config['FIND_SERVICE_NAME'] }}">
   <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
   <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
   <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
   {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
@@ -46,7 +46,7 @@
 {{ govukFooter({}) }}
 
 {% block bodyEnd %}
-  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
+  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
   <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'

--- a/requirements.in
+++ b/requirements.in
@@ -53,7 +53,7 @@ sentry-sdk
 #   GOV.UK Frontend
 #-----------------------------------
 govuk-frontend-wtf==3.1.0
-govuk-frontend-jinja==3.1.0  # Specific for GOV.UK Frontend v5.4.0
+govuk-frontend-jinja==3.3.0  # Specific for GOV.UK Frontend v5.6.0
 wtforms~=3.1
 
 #-----------------------------------

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -14,7 +14,7 @@
 <meta name="keywords"
   content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
 <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.4.0.min.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
 <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
 {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
@@ -81,7 +81,7 @@
 {% endblock footer %}
 
 {% block bodyEnd %}
-  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.4.0.min.js') }}{% endset %}
+  {% set govukFrontendJsURI %}{{ url_for('static', filename='govuk-frontend/govuk-frontend-5.6.0.min.js') }}{% endset %}
   <script type="module" src="{{ govukFrontendJsURI }}"> </script>
   <script type="module" nonce="{{ csp_nonce() }}">
       import { initAll } from '{{ govukFrontendJsURI }}'

--- a/tests/common_tests/test_maintenance_mode.py
+++ b/tests/common_tests/test_maintenance_mode.py
@@ -44,5 +44,5 @@ def test_maintenance_mode_healthcheck_available(test_client):
 )
 def test_maintenance_mode_static_assets_available(test_client):
     test_client.application.config["MAINTENANCE_MODE"] = True
-    response = test_client.get("/static/govuk-frontend/govuk-frontend-5.4.0.min.css")
+    response = test_client.get("/static/govuk-frontend/govuk-frontend-5.6.0.min.css")
     assert response.status_code == 200


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-571

### Change description
Upgrades us from GOV.UK Frontend v5.40 to v5.6.0. And tweaks the `build.py` script so that it can be run even if you have old assets in `./static/src` - it will just delete and overwrite them. To simplify the upgrade path for local use.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* Build the container locally
* Check that everything still looks the same and works.
* Maybe run the new `e2e` tests ;)