### PR TITLE
Include default context args and close gracefully, and bump playwright version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -168,7 +168,9 @@ govuk-frontend-jinja==3.1.0
 govuk-frontend-wtf==3.1.0
     # via -r requirements.txt
 greenlet==3.0.3
-    # via playwright
+    # via
+    #   -r requirements.txt
+    #   playwright
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -329,7 +331,7 @@ pytest-env==0.8.1
     # via -r requirements-dev.in
 pytest-mock==3.10.0
     # via -r requirements-dev.in
-pytest-playwright==0.5.1
+pytest-playwright==0.5.2
     # via -r requirements-dev.in
 python-dateutil==2.8.2
     # via

--- a/tests/e2e_tests/config.py
+++ b/tests/e2e_tests/config.py
@@ -51,7 +51,10 @@ class AWSEndToEndSecrets:
         self.e2e_aws_vault_profile = e2e_aws_vault_profile
 
         if self.e2e_env == "prod":  # type: ignore[comparison-overlap]
-            raise ValueError("shouldn't be possible, but also must never happen")
+            # It shouldn't be possible to set e2e_env to `prod` based on current setup; this is a safeguard against it
+            # being added in the future without thinking about this fixture. When it comes to prod secrets, remember:
+            #   keep it secret; keep it safe.
+            raise ValueError("Refusing to init against prod environment because it would read production secrets")
 
     def _read_aws_parameter_store_value(self, parameter):
         # This flow is used to collect secrets when running tests *from* your local machine

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -97,11 +97,16 @@ def user_auth(
     context: BrowserContext,
     e2e_test_secrets: EndToEndTestSecrets,
 ) -> Account:
+    """This fixture sets up the browser with an auth cookie so that the test user is 'logged in' correctly.
+
+    It bypasses the standard authentication process of doing this (using Authenticator), and instead (ab)uses our
+    JWT authentication model by self-signing the blob of data that authenticator provides.
+
+    We should be careful to keep this blob of JWT data in sync with what Authenticator would actually set."""
     email_address = generate_email_address(
         test_name=request.node.originalname,
         email_domain="communities.gov.uk",
     )
-
     roles_marker = request.node.get_closest_marker("user_roles")
     user_roles = roles_marker.args[0] if roles_marker else []
 

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -4,8 +4,9 @@ import warnings
 
 import jwt
 import pytest
-from playwright.sync_api import Browser, BrowserContext, ConsoleMessage, Page
+from playwright.sync_api import BrowserContext, ConsoleMessage, Page
 from pytest import FixtureRequest
+from pytest_playwright.pytest_playwright import CreateContextCallback
 
 from config import Config
 from tests.e2e_tests.config import AWSEndToEndSecrets, EndToEndTestSecrets, LocalEndToEndSecrets
@@ -68,10 +69,10 @@ def authenticator_fund_config(request: FixtureRequest) -> TestFundConfig:
 
 
 @pytest.fixture
-def context(request: FixtureRequest, browser: Browser, e2e_test_secrets: EndToEndTestSecrets):
+def context(new_context: CreateContextCallback, request: FixtureRequest, e2e_test_secrets: EndToEndTestSecrets):
     e2e_env = request.config.getoption("e2e_env")
     http_credentials = e2e_test_secrets.HTTP_BASIC_AUTH if e2e_env in {"dev", "test"} else None
-    return browser.new_context(http_credentials=http_credentials)
+    return new_context(http_credentials=http_credentials)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Change description
This closes the browser contexts correctly at the end of each test run,
and uses playwright's `new_context` fixture which will pass default
parameters correctly, therefore allowing flags like `--video=on` to work
properly.