### PR TITLE
Adjust pandas read excel type hint

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -1,6 +1,7 @@
 """Provides a controller for spreadsheet ingestion."""
 
 import json
+import typing
 import uuid
 from datetime import datetime
 from io import BytesIO
@@ -51,7 +52,7 @@ from data_store.validation.towns_fund.failures.internal import InternalValidatio
 from data_store.validation.towns_fund.failures.user import UserValidationFailure
 
 
-def __get_organisation_name(fund: str, workbook_data: dict[int | str, pd.DataFrame]):
+def __get_organisation_name(fund: str, workbook_data: dict[str, pd.DataFrame]):
     """Helper function - really just for Sentry metrics - to retrieve the org name a submission is about."""
     try:
         match fund:
@@ -205,8 +206,8 @@ def parse_body(body: dict) -> tuple[str, int, dict | None, bool, str | None, str
 
 
 def extract_process_validate_tables(
-    workbook_data: dict[int | str, pd.DataFrame], tables_config: dict[int | str, dict]
-) -> tuple[dict[int | str, pd.DataFrame], list[Message]]:
+    workbook_data: dict[str, pd.DataFrame], tables_config: dict[str, dict]
+) -> tuple[dict[str, pd.DataFrame], list[Message]]:
     """Extracts, processes and validates tables from a workbook based on the specified configuration.
 
     If all tables pass validation, then the data is coerced to the dtypes defined in the schema.
@@ -252,7 +253,7 @@ def extract_process_validate_tables(
     return tables, error_messages
 
 
-def coerce_data(tables: dict[int | str, pd.DataFrame], tables_config: dict) -> None:
+def coerce_data(tables: dict[str, pd.DataFrame], tables_config: dict) -> None:
     """Coerce the data to the specified schema.
 
     If the data has passed validation, this should not raise any exceptions.
@@ -377,7 +378,7 @@ def process_user_failures(user_failures: list[UserValidationFailure], messenger:
     return build_validation_error_response(validation_messages=validation_messages)
 
 
-def extract_data(excel_file: FileStorage) -> dict[int | str, pd.DataFrame]:
+def extract_data(excel_file: FileStorage) -> dict[str, pd.DataFrame]:
     """Extract data from an Excel file.
 
     :param excel_file: an in-memory Excel file
@@ -387,14 +388,17 @@ def extract_data(excel_file: FileStorage) -> dict[int | str, pd.DataFrame]:
         raise ValueError("Invalid file type")
 
     try:
-        workbook = pd.read_excel(
-            BytesIO(excel_file.stream.read()).getvalue(),
-            sheet_name=None,  # extract from all sheets
-            header=None,
-            index_col=None,
-            engine="openpyxl",
-            na_values=[""],
-            keep_default_na=False,
+        workbook = typing.cast(
+            dict[str, pd.DataFrame],
+            pd.read_excel(
+                BytesIO(excel_file.stream.read()).getvalue(),
+                sheet_name=None,  # extract from all sheets
+                header=None,
+                index_col=None,
+                engine="openpyxl",
+                na_values=[""],
+                keep_default_na=False,
+            ),
         )
     except (ValueError, BadZipFile) as bad_file_error:
         current_app.logger.error(
@@ -405,7 +409,7 @@ def extract_data(excel_file: FileStorage) -> dict[int | str, pd.DataFrame]:
     return workbook
 
 
-def clean_data(transformed_data: dict[int | str, pd.DataFrame]) -> None:
+def clean_data(transformed_data: dict[str, pd.DataFrame]) -> None:
     """Clean the transformed data by replacing all occurrences of `np.nan` with an empty string and `pd.NaT`
     with None.
 
@@ -418,7 +422,7 @@ def clean_data(transformed_data: dict[int | str, pd.DataFrame]) -> None:
         table.replace({pd.NaT: None}, inplace=True)
 
 
-def get_metadata(transformed_data: dict[int | str, pd.DataFrame]) -> dict:
+def get_metadata(transformed_data: dict[str, pd.DataFrame]) -> dict:
     """Collect programme-level metadata on the submission.
 
     :param transformed_data: transformed data from the spreadsheet

--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -388,6 +388,7 @@ def extract_data(excel_file: FileStorage) -> dict[str, pd.DataFrame]:
         raise ValueError("Invalid file type")
 
     try:
+        # TODO: Remove type.cast when we upgrade Pandas
         workbook = typing.cast(
             dict[str, pd.DataFrame],
             pd.read_excel(

--- a/data_store/controllers/ingest_dependencies.py
+++ b/data_store/controllers/ingest_dependencies.py
@@ -45,7 +45,7 @@ class IngestDependencies(ABC):
 
     initial_validation_schema: list[Check]
     table_to_load_function_mapping: dict[str, Callable]
-    transform: Callable[[dict[int | str, pd.DataFrame], int], dict[int | str, pd.DataFrame]]
+    transform: Callable[[dict[str, pd.DataFrame], int], dict[str, pd.DataFrame]]
 
 
 @dataclass
@@ -63,7 +63,7 @@ class TFIngestDependencies(IngestDependencies):
     messenger: MessengerBase
     validation_schema: dict
     fund_specific_validation: (
-        Callable[[dict[int | str, pd.DataFrame], dict[int | str, pd.DataFrame] | None], list[GenericFailure]] | None
+        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame] | None], list[GenericFailure]] | None
     ) = None
 
 
@@ -80,8 +80,8 @@ class PFIngestDependencies(IngestDependencies):
             the original Excel file.
     """
 
-    cross_table_validate: Callable[[dict[int | str, pd.DataFrame]], list[Message]]
-    extract_process_validate_schema: dict[int | str, dict[str, dict]]
+    cross_table_validate: Callable[[dict[str, pd.DataFrame]], list[Message]]
+    extract_process_validate_schema: dict[str, dict[str, dict]]
 
 
 def ingest_dependencies_factory(fund: str, reporting_round: int) -> IngestDependencies | None:

--- a/data_store/table_extraction/config/pf_r1_config.py
+++ b/data_store/table_extraction/config/pf_r1_config.py
@@ -12,7 +12,7 @@ from data_store.validation.pathfinders.schema_validation.columns import (
 )
 from data_store.validation.pathfinders.schema_validation.consts import PFEnums
 
-PF_TABLE_CONFIG: dict[int | str, dict[str, dict]] = {
+PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
     "Reporting period": {
         "extract": {
             "id_tag": "PF-USER_CURRENT-REPORTING-PERIOD",

--- a/data_store/table_extraction/extract.py
+++ b/data_store/table_extraction/extract.py
@@ -19,7 +19,7 @@ class TableExtractor:
     Attributes:
         START_TAG (str): The start tag format for identifying tables.
         END_TAG (str): The end tag format for identifying tables.
-        workbook (dict[int | str, pd.DataFrame]): A dictionary containing worksheet names as keys
+        workbook (dict[str, pd.DataFrame]): A dictionary containing worksheet names as keys
             and corresponding pandas DataFrames as values.
 
     Methods:
@@ -40,9 +40,9 @@ class TableExtractor:
 
     START_TAG = "{id}-START"
     END_TAG = "{id}-END"
-    workbook: dict[int | str, pd.DataFrame]
+    workbook: dict[str, pd.DataFrame]
 
-    def __init__(self, workbook: dict[int | str, pd.DataFrame]) -> None:
+    def __init__(self, workbook: dict[str, pd.DataFrame]) -> None:
         self.workbook = workbook
 
     @classmethod

--- a/data_store/transformation/pathfinders/pf_transform_r1.py
+++ b/data_store/transformation/pathfinders/pf_transform_r1.py
@@ -11,7 +11,7 @@ from data_store.transformation.pathfinders.consts import (
 from data_store.transformation.utils import create_dataframe, extract_postcodes
 
 
-def transform(df_dict: dict[int | str, pd.DataFrame], reporting_round: int) -> dict[int | str, pd.DataFrame]:
+def transform(df_dict: dict[str, pd.DataFrame], reporting_round: int) -> dict[str, pd.DataFrame]:
     """
     Transform the data extracted from the Excel file into a format that can be loaded into the database.
 
@@ -24,7 +24,7 @@ def transform(df_dict: dict[int | str, pd.DataFrame], reporting_round: int) -> d
         row["Local Authority"]: row["Reference"][:6] for _, row in project_details_df.iterrows()
     }
     project_name_to_id_mapping = {row["Full name"]: row["Reference"] for _, row in project_details_df.iterrows()}
-    transformed: dict[int | str, pd.DataFrame] = {}
+    transformed: dict[str, pd.DataFrame] = {}
     transformed["Submission_Ref"] = _submission_ref(df_dict, reporting_round)
     transformed["Place Details"] = _place_details(df_dict, programme_name_to_id_mapping)
     transformed["Programme_Ref"] = _programme_ref(df_dict, programme_name_to_id_mapping)
@@ -43,7 +43,7 @@ def transform(df_dict: dict[int | str, pd.DataFrame], reporting_round: int) -> d
 
 
 def _submission_ref(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     reporting_round: int,
 ) -> pd.DataFrame:
     """
@@ -72,7 +72,7 @@ def _submission_ref(
 
 
 def _place_details(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -104,7 +104,7 @@ def _place_details(
 
 
 def _programme_ref(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -128,7 +128,7 @@ def _programme_ref(
     )
 
 
-def _organisation_ref(df_dict: dict[int | str, pd.DataFrame]) -> pd.DataFrame:
+def _organisation_ref(df_dict: dict[str, pd.DataFrame]) -> pd.DataFrame:
     """
     Populates `organisation_dim` table:
         organisation_name   - from "Organisation Name" in the transformed DF
@@ -144,7 +144,7 @@ def _organisation_ref(df_dict: dict[int | str, pd.DataFrame]) -> pd.DataFrame:
 
 
 def _project_details(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
     project_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
@@ -174,7 +174,7 @@ def _project_details(
 
 
 def _programme_progress(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -197,7 +197,7 @@ def _programme_progress(
 
 
 def _project_progress(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     project_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -230,9 +230,7 @@ def _project_progress(
     )
 
 
-def _funding_questions(
-    df_dict: dict[int | str, pd.DataFrame], programme_name_to_id_mapping: dict[str, str]
-) -> pd.DataFrame:
+def _funding_questions(df_dict: dict[str, pd.DataFrame], programme_name_to_id_mapping: dict[str, str]) -> pd.DataFrame:
     """
     Populates `funding_question` table:
         programme_junction_id   - assigned during map_data_to_models based on "Programme ID" in the transformed DF
@@ -260,7 +258,7 @@ def _funding_questions(
 
 
 def _funding_data(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -301,9 +299,9 @@ def _funding_data(
 
 
 def _outputs(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
-) -> dict[int | str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """
     Populates `output_dim` and `output_data` tables:
         For `output_dim`:
@@ -373,9 +371,9 @@ def _outputs(
 
 
 def _outcomes(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
-) -> dict[int | str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """
     Populates `outcome_dim` and `outcome_data` tables:
         For `outcome_dim`:
@@ -446,7 +444,7 @@ def _outcomes(
 
 
 def _risk_register(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """
@@ -476,7 +474,7 @@ def _risk_register(
 
 
 def _project_finance_changes(
-    df_dict: dict[int | str, pd.DataFrame],
+    df_dict: dict[str, pd.DataFrame],
     programme_name_to_id_mapping: dict[str, str],
 ) -> pd.DataFrame:
     """

--- a/data_store/transformation/towns_fund/tf_transform_r3.py
+++ b/data_store/transformation/towns_fund/tf_transform_r3.py
@@ -4,7 +4,6 @@ Methods specifically for extracting data from Towns Fund Round 3 reporting templ
 """
 
 from datetime import datetime
-from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -26,7 +25,7 @@ from data_store.transformation.utils import (
 )
 
 
-def transform(df_ingest: dict[int | str, pd.DataFrame], reporting_round: int = 3) -> Dict[int | str, pd.DataFrame]:
+def transform(df_ingest: dict[str, pd.DataFrame], reporting_round: int = 3) -> dict[str, pd.DataFrame]:
     """
     Extract data from Towns Fund Reporting Template into column headed Pandas DataFrames.
 
@@ -34,7 +33,7 @@ def transform(df_ingest: dict[int | str, pd.DataFrame], reporting_round: int = 3
     :return: Dictionary of extracted "tables" as DataFrames, and str representing reporting period for the form
     """
 
-    towns_fund_extracted: dict[int | str, pd.DataFrame] = dict()
+    towns_fund_extracted: dict[str, pd.DataFrame] = dict()
     towns_fund_extracted["Submission_Ref"] = common.get_submission_details(reporting_round=reporting_round)
     towns_fund_extracted["Place Details"] = extract_place_details(df_ingest["2 - Project Admin"])
     fund_code = common.get_fund_code(towns_fund_extracted["Place Details"])

--- a/data_store/transformation/towns_fund/tf_transform_r4.py
+++ b/data_store/transformation/towns_fund/tf_transform_r4.py
@@ -16,7 +16,7 @@ import data_store.transformation.towns_fund.tf_transform_r3 as r3
 from data_store.transformation.towns_fund import common
 
 
-def transform(df_ingest: dict[int | str, pd.DataFrame], reporting_round: int = 4) -> dict[int | str, pd.DataFrame]:
+def transform(df_ingest: dict[str, pd.DataFrame], reporting_round: int = 4) -> dict[str, pd.DataFrame]:
     """
     Extract data from Towns Fund Round 4 Reporting Template into column headed Pandas DataFrames.
 
@@ -28,7 +28,7 @@ def transform(df_ingest: dict[int | str, pd.DataFrame], reporting_round: int = 4
     :return: Dictionary of extracted "tables" as DataFrames, and str representing reporting period for the form
     """
 
-    towns_fund_extracted: dict[int | str, pd.DataFrame] = dict()
+    towns_fund_extracted: dict[str, pd.DataFrame] = dict()
     towns_fund_extracted["Submission_Ref"] = common.get_submission_details(reporting_round=reporting_round)
     towns_fund_extracted["Place Details"] = r3.extract_place_details(df_ingest["2 - Project Admin"])
     fund_code = common.get_fund_code(towns_fund_extracted["Place Details"])

--- a/data_store/validation/__init__.py
+++ b/data_store/validation/__init__.py
@@ -9,11 +9,11 @@ from data_store.validation.towns_fund.schema_validation.validate import validate
 
 
 def tf_validate(
-    data_dict: dict[int | str, pd.DataFrame],
-    original_workbook: dict[int | str, pd.DataFrame],
+    data_dict: dict[str, pd.DataFrame],
+    original_workbook: dict[str, pd.DataFrame],
     validation_schema: dict,
     fund_specific_validation: (
-        Callable[[dict[int | str, pd.DataFrame], dict[int | str, pd.DataFrame] | None], list[GenericFailure]] | None
+        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame] | None], list[GenericFailure]] | None
     ),
 ):
     """Validate a workbook against its round specific schema.

--- a/data_store/validation/initial_validation/checks.py
+++ b/data_store/validation/initial_validation/checks.py
@@ -16,9 +16,9 @@ class Check(ABC):
         error_message (str): The error message sent to the user if the check fails.
 
     Methods:
-        get_actual_value(workbook: dict[int | str, pd.DataFrame]) -> str:
+        get_actual_value(workbook: dict[str, pd.DataFrame]) -> str:
             Retrieve the actual value from the workbook.
-        run(workbook: dict[int | str, pd.DataFrame]) -> bool:
+        run(workbook: dict[str, pd.DataFrame]) -> bool:
             Execute the check on the provided workbook.
     """
 
@@ -29,11 +29,11 @@ class Check(ABC):
         self.expected_values = expected_values
         self.error_message = error_message
 
-    def get_actual_value(self, workbook: dict[int | str, pd.DataFrame]) -> str:
+    def get_actual_value(self, workbook: dict[str, pd.DataFrame]) -> str:
         return str(workbook[self.sheet].iloc[self.row][self.column]).strip()
 
     @abstractmethod
-    def run(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
+    def run(self, workbook: dict[str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
         pass
 
 
@@ -42,7 +42,7 @@ class BasicCheck(Check):
     Used for checks where the expected values are predefined.
     """
 
-    def run(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
+    def run(self, workbook: dict[str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
         result = self.get_actual_value(workbook) in self.expected_values
         return result, self.error_message
 
@@ -54,7 +54,7 @@ class DynamicCheck(Check, ABC):
     """
 
     @abstractmethod
-    def get_expected_values(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> Iterable:
+    def get_expected_values(self, workbook: dict[str, pd.DataFrame], **kwargs) -> Iterable:
         pass
 
 
@@ -91,11 +91,11 @@ class ConflictingCheck(DynamicCheck):
         self.mapped_row = mapped_row
         self.mapped_column = mapped_column
 
-    def get_expected_values(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> set:
+    def get_expected_values(self, workbook: dict[str, pd.DataFrame], **kwargs) -> set:
         value_to_map = str(workbook[self.sheet].iloc[self.mapped_row][self.mapped_column]).strip()
         return self.mapping.get(value_to_map, set())
 
-    def run(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
+    def run(self, workbook: dict[str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
         result = self.get_actual_value(workbook) in self.get_expected_values(workbook)
         return result, self.error_message
 
@@ -131,11 +131,11 @@ class AuthorisationCheck(DynamicCheck):
             allowed_values=expected_values_str,
         )
 
-    def get_expected_values(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> list:
+    def get_expected_values(self, workbook: dict[str, pd.DataFrame], **kwargs) -> list:
         auth = kwargs.get("auth")
         return auth[self.auth_type] if auth else []
 
-    def run(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
+    def run(self, workbook: dict[str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
         auth = kwargs.get("auth")
         actual_value = self.get_actual_value(workbook)
         expected_values = self.get_expected_values(workbook, auth=auth)
@@ -158,7 +158,7 @@ class SheetCheck(Check):
         self.sheet = sheet
         self.error_message = error_message
 
-    def run(self, workbook: dict[int | str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
+    def run(self, workbook: dict[str, pd.DataFrame], **kwargs) -> tuple[bool, str]:
         sheet_exists = workbook.get(self.sheet)
         if sheet_exists is None:
             return False, self.error_message

--- a/data_store/validation/initial_validation/initial_validate.py
+++ b/data_store/validation/initial_validation/initial_validate.py
@@ -20,7 +20,7 @@ from data_store.validation.initial_validation.checks import (
 )
 
 
-def initial_validate(workbook: dict[int | str, pd.DataFrame], schema: list[Check], auth: dict | None):
+def initial_validate(workbook: dict[str, pd.DataFrame], schema: list[Check], auth: dict | None):
     """
     Executes initial checks based on the provided schema.
 

--- a/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
+++ b/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
@@ -17,7 +17,7 @@ from data_store.transformation.pathfinders.consts import PF_REPORTING_PERIOD_TO_
 from data_store.validation.pathfinders.schema_validation.consts import PFErrors
 
 
-def cross_table_validate(extracted_table_dfs: dict[int | str, pd.DataFrame]) -> list[Message]:
+def cross_table_validate(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:
     """
     Perform cross-table validation checks on the input DataFrames extracted from the original Excel file. These are
     checks that require data from multiple tables to be compared against each other.

--- a/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r4.py
+++ b/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r4.py
@@ -41,7 +41,7 @@ FUNDING_ALLOCATION = pd.read_csv(Path(__file__).parent / "resources" / "TF-grant
 
 
 def validate(
-    data_dict: dict[int | str, pd.DataFrame], original_workbook: dict[int | str, pd.DataFrame] | None = None
+    data_dict: dict[str, pd.DataFrame], original_workbook: dict[str, pd.DataFrame] | None = None
 ) -> list[GenericFailure]:
     """Top-level Towns Fund Round 4 specific validation.
 

--- a/data_store/validation/towns_fund/schema_validation/casting.py
+++ b/data_store/validation/towns_fund/schema_validation/casting.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pandas as pd
 
 
-def cast_to_schema(data: dict[int | str, pd.DataFrame], schema: dict) -> None:
+def cast_to_schema(data: dict[str, pd.DataFrame], schema: dict) -> None:
     """
     Cast each cell in a workbook to the data types specified in the schema. This
     process modifies workbook in-place.

--- a/data_store/validation/towns_fund/schema_validation/validate.py
+++ b/data_store/validation/towns_fund/schema_validation/validate.py
@@ -18,7 +18,7 @@ from data_store.validation.utils import is_blank, remove_duplicate_indexes
 
 
 def validate_data(
-    data_dict: dict[int | str, pd.DataFrame], schema: dict
+    data_dict: dict[str, pd.DataFrame], schema: dict
 ) -> list[user.SchemaUserValidationFailure | internal.InternalValidationFailure]:
     """Validate a set of data against a schema.
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib.util
 import os
+import typing
 
 import pandas as pd
 
@@ -20,8 +21,8 @@ def load_schema(file_path, variable):
         raise AttributeError(f"The Python file does not contain a variable named '{variable}'.")
 
 
-def load_workbook(file_path) -> dict[int | str, pd.DataFrame]:
-    return pd.read_excel(file_path, sheet_name=None, engine="openpyxl")
+def load_workbook(file_path) -> dict[str, pd.DataFrame]:
+    return typing.cast(dict[str, pd.DataFrame], pd.read_excel(file_path, sheet_name=None, engine="openpyxl"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On the current version of `pandas` `read_excel` returns a
`dict[int | str, pd.DataFrame]`.

We incorrectly typed it `dict[str, pd.DataFrame]`. Everywhere.

Luckily the new version of `pandas` returns our version of type-hint.
Until we upgrade pandas version, we should force Python to see it as
`dict[str, pd.DataFrame]`. After upgrade we can remove the `typing.cast`.