### PR TITLE
Run type checks in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,12 @@ jobs:
       env:
         FLASK_ENV: unit_test
       run: flask db upgrade && flask db check
+  type_checks:
+    name: Type checks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: mypy --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 ci:
   autofix_prs: false
 
+  # mypy needs a lot of dependencies installed, and we hit limits in precommit.ci on the size of the dependencies
+  # which causes precommit to fail. So we now run precommit mypy in github actions separately.
+  skip: [mypy]
+
 default_language_version:
     python: python3.11
 


### PR DESCRIPTION
We are starting to but up against problems using precommit.ci because they "only" allocate ~250mb storage for python dependencies, and we are starting to need to install more than that to allow `mypy` to run with all of the code context it needs.

So this PR moves the `mypy` type check into github actions, but leaves everything else running in precommit.ci since some of the devs like how that works.