### PR TITLE
Use a system hook for pre-commit mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip' # caching pip dependencies
+    - name: Install dependencies
+      run: pip install -r requirements-dev.txt
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: mypy --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,33 +24,14 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-- repo: https://github.com/pre-commit/mirrors-mypy
-  # mypy - static type checker. If bumping this, bump requirements-dev.txt as well
-  rev: 'v1.11.2'  # Use the sha / tag you want to point at
+- repo: local
   hooks:
     - id: mypy
-      # verbose: true
-      # args: [--show-error-codes]
-      additional_dependencies: [
-        "boto3-stubs[s3,logs]",
-        pandas==1.5.3,
-        pandas-stubs~=1.5.3,
-        sqlalchemy==2.0.9,
-        flask-sqlalchemy==3.0.3,
-        types-beautifulsoup4,
-        types-colorama,
-        types-flask,
-        types-Flask-Migrate,
-        types-jmespath,
-        types-openpyxl,
-        types-psycopg2,
-        types-python-dateutil,
-        types-Pygments,
-        types-PyMySQL,
-        types-PyYAML,
-        types-requests,
-        types-setuptools,
-      ]
+      name: Run type checks
+      language: system
+      types: [python]
+      entry: mypy .
+      pass_filenames: false
 - repo: https://github.com/djlint/djLint
   rev: v1.35.2
   hooks:


### PR DESCRIPTION
### Change description
Now that we're running mypy in github actions, where python is installed and already has all of our dev dependencies available, we can use a system hook instead of the mypy repo hook.

This will make pre-commit run the `mypy` that is available in the current environment, which will be the one pinned by our requirements-dev.txt. Because it uses that mypy, and the environment's python interpreter, all of our dev dependencies will also inherently be available for mypy's type checking, which should give us the best checks available.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
