### PR TITLE
Update test fixtures for ReportingRound model

### DIFF
--- a/tests/data_store_tests/db_tests/test_constraints.py
+++ b/tests/data_store_tests/db_tests/test_constraints.py
@@ -20,6 +20,7 @@ from data_store.db.entities import (
     ProgrammeJunction,
     Project,
     ProjectProgress,
+    ReportingRound,
     RiskRegister,
     Submission,
 )
@@ -136,13 +137,16 @@ def test_geospatial_dim_unique_constraint(test_client_rollback):
 
 def test_project_geospatial_association_pk_constraint(seeded_test_client_rollback):
     """Tests the unique constraint on project_geospatial_association."""
+    fund = Fund.query.filter_by(fund_code="PF").one()
+    rr1 = ReportingRound.query.filter_by(fund_id=fund.id, round_number=1).one()
 
     geospatial = GeospatialDim.query.filter_by(postcode_prefix="SW").one()
     geospatial_2 = GeospatialDim.query.filter_by(postcode_prefix="SW").one()
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID",
-        reporting_period_start=datetime(2019, 10, 10),
-        reporting_period_end=datetime(2021, 10, 10),
+        reporting_period_start=rr1.observation_period_start,
+        reporting_period_end=rr1.observation_period_end,
+        reporting_round=rr1,
     )
 
     organisation = Organisation(organisation_name="TEST-ORGANISATION")
@@ -170,6 +174,7 @@ def test_project_geospatial_association_pk_constraint(seeded_test_client_rollbac
         submission_id=submission.id,
         programme_id=programme.id,
         reporting_round=1,
+        reporting_round_entity=rr1,
     )
     db.session.add(programme_junction)
     db.session.flush()

--- a/tests/data_store_tests/db_tests/test_queries.py
+++ b/tests/data_store_tests/db_tests/test_queries.py
@@ -17,6 +17,7 @@ from data_store.db.entities import (
     Programme,
     ProgrammeJunction,
     Project,
+    ReportingRound,
     Submission,
 )
 from data_store.db.queries import (
@@ -439,10 +440,21 @@ def test_get_project_id_fk(seeded_test_client, additional_test_data):
 
 
 def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback, additional_test_data):
+    fund = Fund.query.filter_by(fund_code="TEST").one()
+    reporting_round = ReportingRound(
+        fund_id=fund.id,
+        round_number=3,
+        observation_period_start=datetime(2019, 10, 10),
+        observation_period_end=datetime(2021, 10, 10),
+    )
+    db.session.add(reporting_round)
+    db.session.flush()
+
     submission_2 = Submission(
         submission_id="S-R03-2",
-        reporting_period_start=datetime(2019, 10, 10),
-        reporting_period_end=datetime(2021, 10, 10),
+        reporting_period_start=reporting_round.observation_period_start,
+        reporting_period_end=reporting_round.observation_period_end,
+        reporting_round=reporting_round,
     )
 
     programme_2 = Programme(
@@ -458,7 +470,8 @@ def test_get_latest_submission_id_by_round_and_fund(seeded_test_client_rollback,
     programme_junction_2 = ProgrammeJunction(
         programme_id=programme_2.id,
         submission_id=submission_2.id,
-        reporting_round=3,
+        reporting_round=reporting_round.round_number,
+        reporting_round_entity=reporting_round,
     )
 
     db.session.add(programme_junction_2)

--- a/tests/data_store_tests/serialisation_tests/conftest.py
+++ b/tests/data_store_tests/serialisation_tests/conftest.py
@@ -12,18 +12,25 @@ from data_store.db.entities import (
     Programme,
     ProgrammeJunction,
     Project,
+    ReportingRound,
     Submission,
 )
 
 
 @pytest.fixture
-def non_transport_outcome_data(seeded_test_client):
+def non_transport_outcome_data(seeded_test_client, additional_test_data):
     """Inserts a tree of data with no links to a transport outcome to assert against."""
-    reporting_round = 1
+
+    # These are created in `additional_test_data` fixture
+    fund = Fund.query.filter_by(fund_code="TEST").one()
+    reporting_round = ReportingRound.query.filter_by(fund_id=fund.id, round_number=1).one()
+    # --------
+
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID-OUTCOME-TEST",
-        reporting_period_start=datetime(2019, 10, 10),
-        reporting_period_end=datetime(2021, 10, 10),
+        reporting_period_start=reporting_round.observation_period_start,
+        reporting_period_end=reporting_round.observation_period_end,
+        reporting_round=reporting_round,
     )
     organisation = Organisation(organisation_name="TEST-ORGANISATION-OUTCOME-TEST")
     test_outcome_dim = OutcomeDim(outcome_name="TEST-OUTCOME-3", outcome_category="TEST-OUTCOME-CATEGORY-OUTCOME-TEST")
@@ -41,7 +48,8 @@ def non_transport_outcome_data(seeded_test_client):
     programme_junction = ProgrammeJunction(
         submission_id=submission.id,
         programme_id=programme_no_transport_outcome_or_transport_child_projects.id,
-        reporting_round=reporting_round,
+        reporting_round=reporting_round.round_number,
+        reporting_round_entity=reporting_round,
     )
     db.session.add(programme_junction)
     db.session.flush()

--- a/tests/integration_tests/test_ingest_component_pathfinders.py
+++ b/tests/integration_tests/test_ingest_component_pathfinders.py
@@ -9,7 +9,7 @@ from werkzeug.datastructures import FileStorage
 from data_store.const import EXCEL_MIMETYPE
 from data_store.controllers.ingest import ingest, save_submission_file_name_and_user_metadata
 from data_store.db import db
-from data_store.db.entities import Programme, ProgrammeJunction, Submission
+from data_store.db.entities import Fund, Programme, ProgrammeJunction, ReportingRound, Submission
 
 
 @pytest.fixture()
@@ -539,11 +539,15 @@ def test_save_submission_file_name_and_user_metadata(seeded_test_client_rollback
     """Tests save_submission_file_name_and_user_metadata() function in isolation, that submitting_account_id and
     submitting_user_email values are saved to Submission model successfully."""
 
+    fund = Fund.query.filter_by(fund_code="PF").one()
+    rr1 = ReportingRound.query.filter_by(fund_id=fund.id, round_number=1).one()
+
     new_sub = Submission(
         submission_id="S-PF-R01-1",
         submission_date=datetime(2024, 5, 1),
-        reporting_period_start=datetime(2024, 4, 1),
-        reporting_period_end=datetime(2024, 4, 30),
+        reporting_period_start=rr1.observation_period_start,
+        reporting_period_end=rr1.observation_period_end,
+        reporting_round=rr1,
     )
     db.session.add(new_sub)
 


### PR DESCRIPTION
### Change description
In some previous code, we created the ReportingRound model and instances to replace a bunch of disparate data spread across various models.

We didn't update all of the tests to consistently have ReportingRound entities attached via relationships, so this patch fixes it.