### PR TITLE
New unique constraint for programme junction

### DIFF
--- a/data_store/db/entities.py
+++ b/data_store/db/entities.py
@@ -450,6 +450,11 @@ class ProgrammeJunction(BaseModel):
             "reporting_round",
             name="uq_programme_junction_unique_submission_per_round",
         ),
+        sqla.UniqueConstraint(
+            "programme_id",
+            "reporting_round_id",
+            name="uq_programme_junction_programme_id_reporting_round_id",
+        ),
     )
 
 

--- a/db/migrations/.current-alembic-head
+++ b/db/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-040_fix_check_constraints
+041_new_programme_round_constrai

--- a/db/migrations/versions/041_new_programme_round_constrai.py
+++ b/db/migrations/versions/041_new_programme_round_constrai.py
@@ -1,0 +1,27 @@
+"""new programme+round constraint
+
+Revision ID: 041_new_programme_round_constrai
+Revises: 040_fix_check_constraints
+Create Date: 2024-09-18 20:02:28.453496
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "041_new_programme_round_constrai"
+down_revision = "040_fix_check_constraints"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_programme_junction_programme_id_reporting_round_id", ["programme_id", "reporting_round_id"]
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("programme_junction", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_programme_junction_programme_id_reporting_round_id", type_="unique")


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-493


### Change description
Because we'll be removing the other unique constraint that currently looks at programme_id + reporting_round (number).