### PR TITLE
Start using ReportingRound directly

### DIFF
--- a/data_store/controllers/admin_tasks.py
+++ b/data_store/controllers/admin_tasks.py
@@ -40,7 +40,7 @@ def reingest_file(filepath, submission_id):
             fund_name = (
                 "Pathfinders" if submission.programme_junction.programme_ref.fund.fund_code == "PF" else "Towns Fund"
             )
-            reporting_round = submission.programme_junction.reporting_round
+            reporting_round = submission.reporting_round.round_number
             account_id, user_email = submission.submitting_account_id, submission.submitting_user_email
             db.session.close()  # ingest (specifically `populate_db`) wants to start a new clean session/transaction
 
@@ -112,7 +112,7 @@ def reingest_files(file):
                     if submission.programme_junction.programme_ref.fund.fund_code == "PF"
                     else "Towns Fund"
                 )
-                reporting_round = submission.programme_junction.reporting_round
+                reporting_round = submission.reporting_round.round_number
                 account_id, user_email = submission.submitting_account_id, submission.submitting_user_email
                 db.session.close()  # ingest (specifically `populate_db`) wants to start a new clean session/transaction
 

--- a/data_store/controllers/get_filters.py
+++ b/data_store/controllers/get_filters.py
@@ -7,7 +7,7 @@ from data_store.const import FUND_ID_TO_NAME
 from data_store.db import db
 
 # isort: off
-from data_store.db.entities import GeospatialDim, Organisation, OutcomeDim, Programme, Submission, Fund
+from data_store.db.entities import GeospatialDim, Organisation, OutcomeDim, Programme, Fund, ReportingRound
 
 
 # isort: on
@@ -88,7 +88,8 @@ def get_reporting_period_range() -> Optional[dict[str, datetime]]:
     :return: Minimum reporting start and maximum reporting end period
     """
     result = db.session.query(
-        func.min(Submission.reporting_period_start), func.max(Submission.reporting_period_end)
+        func.min(ReportingRound.observation_period_start),
+        func.max(ReportingRound.observation_period_end),
     ).first()
 
     start = result[0]  # earliest reporting period start date

--- a/data_store/controllers/load_functions.py
+++ b/data_store/controllers/load_functions.py
@@ -9,7 +9,7 @@ import pandas as pd
 from data_store.const import SUBMISSION_ID_FORMAT
 from data_store.controllers.mappings import DataMapping
 from data_store.db import db
-from data_store.db.entities import GeospatialDim, Organisation, Programme, ProgrammeJunction, Submission
+from data_store.db.entities import GeospatialDim, Organisation, Programme, ProgrammeJunction, ReportingRound, Submission
 from data_store.db.queries import (
     get_latest_submission_by_round_and_fund,
     get_organisation_exists,
@@ -196,8 +196,8 @@ def get_submission_by_programme_and_round(
     return (
         Submission.query.join(ProgrammeJunction)
         .join(Programme)
-        .filter(Programme.programme_id == programme_id)
-        .filter(ProgrammeJunction.reporting_round == round_number)
+        .join(ReportingRound, Submission.reporting_round_id == ReportingRound.id)
+        .filter(Programme.programme_id == programme_id, ReportingRound.round_number == round_number)
         .first()
     )
 

--- a/data_store/controllers/retrieve_submission_file.py
+++ b/data_store/controllers/retrieve_submission_file.py
@@ -1,6 +1,6 @@
 from config import Config
 from data_store.aws import create_presigned_url, get_file_header
-from data_store.db.entities import Fund, Organisation, Programme, ProgrammeJunction, Submission
+from data_store.db.entities import Fund, Organisation, Programme, ProgrammeJunction, ReportingRound, Submission
 
 
 def retrieve_submission_file(submission_id) -> str:
@@ -58,21 +58,22 @@ def get_custom_file_name(submission_id: str) -> str:
         .join(Submission)
         .join(Fund)
         .join(Organisation)
+        .join(ReportingRound, Submission.reporting_round_id == ReportingRound.id)
         .filter(Submission.id == submission_id)
         .with_entities(
             Submission.submission_id,
             Fund.fund_code,
             Submission.ingest_date,
-            Submission.reporting_period_start,
-            Submission.reporting_period_end,
+            ReportingRound.observation_period_start,
+            ReportingRound.observation_period_end,
             Organisation.organisation_name,
         )
         .one_or_none()
     )
 
     date = submission_info.ingest_date.strftime("%Y-%m-%d")
-    start_date = submission_info.reporting_period_start.strftime("%b%Y")
-    end_date = submission_info.reporting_period_end.strftime("%b%Y")
+    start_date = submission_info.observation_period_start.strftime("%b%Y")
+    end_date = submission_info.observation_period_end.strftime("%b%Y")
 
     file_name = f"{date}-{submission_info.fund_code}-{submission_info.organisation_name}-{start_date}-{end_date}"
 

--- a/data_store/serialisation/data_serialiser.py
+++ b/data_store/serialisation/data_serialiser.py
@@ -26,6 +26,7 @@ These are:
 from typing import Any, Callable, Generator
 
 from marshmallow import fields
+from marshmallow.fields import Raw
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 from sqlalchemy.orm import Query
 from sqlalchemy.sql import text
@@ -45,10 +46,10 @@ from data_store.db.entities import (
     PrivateInvestment,
     Programme,
     ProgrammeFundingManagement,
-    ProgrammeJunction,
     ProgrammeProgress,
     Project,
     ProjectProgress,
+    ReportingRound,
     RiskRegister,
     Submission,
 )
@@ -522,6 +523,10 @@ class SubmissionSchema(SQLAlchemySchema):
 
     submission_id = auto_field(data_key="SubmissionID")
     programme_id = auto_field(model=Programme, data_key="ProgrammeID")
-    reporting_period_start = fields.Raw(data_key="ReportingPeriodStart")
-    reporting_period_end = fields.Raw(data_key="ReportingPeriodEnd")
-    reporting_round = auto_field(model=ProgrammeJunction, data_key="ReportingRound")
+    reporting_period_start = auto_field(
+        "observation_period_start", model=ReportingRound, data_key="ReportingPeriodStart", field_class=Raw
+    )
+    reporting_period_end = auto_field(
+        "observation_period_end", model=ReportingRound, data_key="ReportingPeriodEnd", field_class=Raw
+    )
+    reporting_round = auto_field("round_number", model=ReportingRound, data_key="ReportingRound")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,6 +476,7 @@ def additional_test_data() -> dict[str, Any]:
         "organisation": organisation,
         "submission": submission,
         "fund": fund,
+        "reporting_round": reporting_round,
         "programme": programme,
         "project1": project1,
         "project2": project2,

--- a/tests/data_store_tests/controller_tests/test_filters.py
+++ b/tests/data_store_tests/controller_tests/test_filters.py
@@ -232,6 +232,6 @@ def test_get_reporting_period_range(seeded_test_client_rollback):
     data = get_reporting_period_range()
 
     expected_start = datetime(2019, 4, 1)
-    expected_end = datetime(2023, 9, 30, 23, 59, 59)
+    expected_end = datetime(2024, 3, 31, 23, 59, 59)
 
     assert data == {"start_date": expected_start, "end_date": expected_end}

--- a/tests/data_store_tests/serialisation_tests/test_serialisation.py
+++ b/tests/data_store_tests/serialisation_tests/test_serialisation.py
@@ -360,8 +360,8 @@ def test_serialise_submission_metadata(seeded_test_client, additional_test_data)
     assert {
         "SubmissionID": "S-R03-1",
         "ProgrammeID": "FHSF001",
-        "ReportingPeriodStart": datetime.datetime(2023, 1, 1, 0, 0),
-        "ReportingPeriodEnd": datetime.datetime(2023, 7, 1, 0, 0),
+        "ReportingPeriodStart": datetime.datetime(2022, 10, 1, 0, 0),
+        "ReportingPeriodEnd": datetime.datetime(2023, 3, 31, 23, 59, 59),
         "ReportingRound": 3,
     } in test_serialised_data["SubmissionRef"]
 
@@ -424,8 +424,8 @@ def test_funding_question_programme_joins(seeded_test_client, additional_test_da
 
     # this is a funding question with the same parent programme, that shouldn't be returned in this query.
     funding_question = additional_test_data["funding_question"]
-    unwanted_submission = additional_test_data["submission"]
-    rp_start_wanted = unwanted_submission.reporting_period_end
+    reporting_round = additional_test_data["reporting_round"]
+    rp_start_wanted = reporting_round.observation_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
@@ -458,8 +458,8 @@ def test_programme_progress_joins(seeded_test_client, additional_test_data):
 
     # this is a programme progress record with the same parent programme, that shouldn't be returned in this query.
     programme_progress = additional_test_data["programme_progress"]
-    unwanted_submission = additional_test_data["submission"]
-    rp_start_wanted = unwanted_submission.reporting_period_end
+    reporting_round = additional_test_data["reporting_round"]
+    rp_start_wanted = reporting_round.observation_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
@@ -492,8 +492,8 @@ def test_place_detail_joins(seeded_test_client, additional_test_data):
 
     # this is a place details record with the same parent programme, that shouldn't be returned in this query.
     place_detail = additional_test_data["place_detail"]
-    unwanted_submission = additional_test_data["submission"]
-    rp_start_wanted = unwanted_submission.reporting_period_end
+    reporting_round = additional_test_data["reporting_round"]
+    rp_start_wanted = reporting_round.observation_period_end
 
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
@@ -523,8 +523,8 @@ def test_risk_table_for_programme_join(seeded_test_client, additional_test_data)
     """
 
     programme_risk = additional_test_data["prog_risk"]
-    unwanted_submission = additional_test_data["submission"]
-    rp_start_wanted = unwanted_submission.reporting_period_end
+    reporting_round = additional_test_data["reporting_round"]
+    rp_start_wanted = reporting_round.observation_period_end
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
 
@@ -553,8 +553,8 @@ def test_outcome_table_for_programme_join(seeded_test_client, additional_test_da
     """
 
     programme_outcome = additional_test_data["outcome_programme"]
-    unwanted_submission = additional_test_data["submission"]
-    rp_start_wanted = unwanted_submission.reporting_period_end
+    reporting_round = additional_test_data["reporting_round"]
+    rp_start_wanted = reporting_round.observation_period_end
     base_query = download_data_base_query(min_rp_start=rp_start_wanted)
     test_serialised_data = {sheet: data for sheet, data in serialise_download_data(base_query)}
     df_outcome = pd.DataFrame.from_records(test_serialised_data["OutcomeData"])

--- a/tests/integration_tests/test_retrieve_submission_file.py
+++ b/tests/integration_tests/test_retrieve_submission_file.py
@@ -91,7 +91,7 @@ def test_retrieve_submission_file_ingest_spreadsheet_name(
     filename_param = query_params.get("response-content-disposition", [""])[0]
     filename = unquote(filename_param.split("filename = ")[-1])
 
-    assert "1955-03-12-hs-a-district-council-from-hogwarts-jan2023-jul2023.xlsx" in filename
+    assert "1955-03-12-hs-a-district-council-from-hogwarts-oct2022-mar2023.xlsx" in filename
     assert "data-store-successful-files-unit-tests" in path_segments
     assert filename.endswith(".xlsx")
 
@@ -101,4 +101,4 @@ def test_get_custom_file_name(seeded_test_client):
 
     custom_file_name = get_custom_file_name(submission.id)
 
-    assert custom_file_name == "1955-03-12-hs-a-district-council-from-hogwarts-jan2023-jul2023"
+    assert custom_file_name == "1955-03-12-hs-a-district-council-from-hogwarts-oct2022-mar2023"


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-493

### Change description
This patch stops using both the Submission.reporting_period_[start|end] and ProgrammeJunction.reporting_round fields, instead preferring to reach into the ReportingRound table/entity itself for that data.


### How to test
* Checkout the main branch
* Restart docker-compose so that celery is running `main` code
* Upload a submission
* Do a JSON data dump from Find (maybe use filters to restrict to only dump that submission)
* Switch over to this branch. Remember that celery doesn't hot reload, so you may need to docker-compose down and up again.
* Re-ingest the same submission.
* Do another JSON dump from Find with the same filters. The JSON files should match exactly (except for maybe `SubmissionRef.ReportingPeriodEnd` where we have some potentially known-bad data)