### PR TITLE
RFP-453 - Precursor - Common cross-table validation logic

### DIFF
--- a/data_store/validation/pathfinders/cross_table_validation/common.py
+++ b/data_store/validation/pathfinders/cross_table_validation/common.py
@@ -1,0 +1,74 @@
+import pandas as pd
+
+from data_store.messaging import Message
+
+
+def output_outcome_uoms(control_data_df: pd.DataFrame, column_name: str) -> dict[str, list[str]]:
+    """Creates a mapping from standard/bespoke outputs or outcomes to their unit of measurement.
+    :param control_data_df: Dataframe of the extracted control data table
+    :param column_name: String value of the column name from the relevant control table to be used for the mapping
+    :return: Dictionary of output or outcome names to a list of their unit of measurement
+    """
+    return {
+        row[column_name]: control_data_df.loc[control_data_df[column_name] == row[column_name], "UoM"].tolist()
+        for _, row in control_data_df.iterrows()
+        if not pd.isna(row["UoM"])
+    }
+
+
+def error_message(sheet: str, section: str, description: str, cell_index: str | None = None) -> Message:
+    """
+    Create an error message object.
+    :param sheet: Name of the sheet
+    :param section: Name of the section
+    :param description: Description of the error
+    :param cell_index: Index of the cell where the error occurred
+    :return: Message object
+    """
+    return Message(sheet=sheet, section=section, cell_indexes=(cell_index,), description=description, error_type=None)
+
+
+def check_values_against_allowed(df: pd.DataFrame, value_column: str, allowed_values: list[str]) -> list[str]:
+    """
+    Check that the values in the specified column of the DataFrame are within the list of allowed values.
+    :param df: DataFrame to check
+    :param value_column: Name of the column containing the values to check
+    :param allowed_values: List of allowed values
+    :return: List of row indices with breaching values
+    """
+    breaching_row_indices = []
+    for index, row in df.iterrows():
+        value = row[value_column]
+        if value not in allowed_values:
+            breaching_row_indices.append(index)
+    return breaching_row_indices
+
+
+def check_values_against_mapped_allowed(
+    df: pd.DataFrame, value_column: str, allowed_values_key_column: str, allowed_values_map: dict[str, list[str]]
+) -> list[str]:
+    """
+    Check that the values in the specified column of the DataFrame are within the list of allowed values determined by
+    another column.
+    :param df: DataFrame to check
+    :param value_column: Name of the column containing the values to check
+    :param allowed_values_key_column: Name of the column used to determine the list of allowed values
+    :param allowed_values_map: Dictionary mapping themes to their respective lists of allowed values
+    :return: List of row indices with breaching values
+    """
+    breaching_row_indices = []
+    for index, row in df.iterrows():
+        value = row[value_column]
+        allowed_values_key = row[allowed_values_key_column]
+        allowed_values = allowed_values_map.get(allowed_values_key, [])
+        if value not in allowed_values:
+            breaching_row_indices.append(index)
+    return breaching_row_indices
+
+
+__all__ = [
+    "output_outcome_uoms",
+    "error_message",
+    "check_values_against_allowed",
+    "check_values_against_mapped_allowed",
+]

--- a/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
+++ b/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from data_store.messaging import Message
 from data_store.transformation.pathfinders.consts import PF_REPORTING_PERIOD_TO_DATES_PFCS
+from data_store.validation.pathfinders.cross_table_validation import common
 from data_store.validation.pathfinders.schema_validation.consts import PFErrors
 
 
@@ -36,73 +37,6 @@ def cross_table_validate(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[M
     error_messages.extend(_check_intervention_themes_in_pfcs(extracted_table_dfs))
     error_messages.extend(_check_actual_forecast_reporting_period(extracted_table_dfs))
     return error_messages
-
-
-def _output_outcome_uoms(control_data_df: pd.DataFrame, column_name: str) -> dict[str, list[str]]:
-    """Creates a mapping from standard/bespoke outputs or outcomes to their unit of measurement.
-
-    :param control_data_df: Dataframe of the extracted control data table
-    :param column_name: String value of the column name from the relevant control table to be used for the mapping
-    :return: Dictionary of output or outcome names to a list of their unit of measurement
-    """
-    return {
-        row[column_name]: control_data_df.loc[control_data_df[column_name] == row[column_name], "UoM"].tolist()
-        for _, row in control_data_df.iterrows()
-        if not pd.isna(row["UoM"])
-    }
-
-
-def _error_message(sheet: str, section: str, description: str, cell_index: str | None = None) -> Message:
-    """
-    Create an error message object.
-
-    :param sheet: Name of the sheet
-    :param section: Name of the section
-    :param description: Description of the error
-    :param cell_index: Index of the cell where the error occurred
-    :return: Message object
-    """
-    return Message(sheet=sheet, section=section, cell_indexes=(cell_index,), description=description, error_type=None)
-
-
-def _check_values_against_allowed(df: pd.DataFrame, value_column: str, allowed_values: list[str]) -> list[str]:
-    """
-    Check that the values in the specified column of the DataFrame are within the list of allowed values.
-
-    :param df: DataFrame to check
-    :param value_column: Name of the column containing the values to check
-    :param allowed_values: List of allowed values
-    :return: List of row indices with breaching values
-    """
-    breaching_row_indices = []
-    for index, row in df.iterrows():
-        value = row[value_column]
-        if value not in allowed_values:
-            breaching_row_indices.append(index)
-    return breaching_row_indices
-
-
-def _check_values_against_mapped_allowed(
-    df: pd.DataFrame, value_column: str, allowed_values_key_column: str, allowed_values_map: dict[str, list[str]]
-) -> list[str]:
-    """
-    Check that the values in the specified column of the DataFrame are within the list of allowed values determined by
-    another column.
-
-    :param df: DataFrame to check
-    :param value_column: Name of the column containing the values to check
-    :param allowed_values_key_column: Name of the column used to determine the list of allowed values
-    :param allowed_values_map: Dictionary mapping themes to their respective lists of allowed values
-    :return: List of row indices with breaching values
-    """
-    breaching_row_indices = []
-    for index, row in df.iterrows():
-        value = row[value_column]
-        allowed_values_key = row[allowed_values_key_column]
-        allowed_values = allowed_values_map.get(allowed_values_key, [])
-        if value not in allowed_values:
-            breaching_row_indices.append(index)
-    return breaching_row_indices
 
 
 def _check_projects(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:
@@ -141,7 +75,7 @@ def _check_projects(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Messag
         organisation_name = extracted_table_dfs["Organisation name"].iloc[0, 0]
         allowed_project_names = programme_to_projects[organisation_name]
         extracted_table_df = extracted_table_dfs[check_config.table_name]
-        breaching_row_indices = _check_values_against_allowed(
+        breaching_row_indices = common.check_values_against_allowed(
             df=extracted_table_df,
             value_column=check_config.project_name_column,
             allowed_values=allowed_project_names,
@@ -151,7 +85,7 @@ def _check_projects(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Messag
         ].tolist()
         error_messages.extend(
             [
-                _error_message(
+                common.error_message(
                     sheet=check_config.worksheet,
                     section=check_config.table_name,
                     description=PFErrors.PROJECT_NOT_ALLOWED.format(project_name=project_name),
@@ -186,7 +120,7 @@ def _check_standard_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
     intervention_theme_to_standard_outputs["Enhancing subregional and regional connectivity"] = (
         intervention_theme_to_standard_outputs.pop("Enhancing sub-regional and regional connectivity")
     )
-    breaching_row_indices_outputs = _check_values_against_mapped_allowed(
+    breaching_row_indices_outputs = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Outputs"],
         value_column="Output",
         allowed_values_key_column="Intervention theme",
@@ -199,7 +133,7 @@ def _check_standard_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
     )
     breaching_indices_copy = deepcopy(breaching_row_indices_outputs)
     output_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outputs",
             section="Outputs",
             description=PFErrors.STANDARD_OUTPUT_NOT_ALLOWED.format(
@@ -210,8 +144,8 @@ def _check_standard_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
         for output, intervention_theme in breaching_outputs
     ]
     non_breaching_row_indices = extracted_table_dfs["Outputs"].index.difference(breaching_indices_copy)
-    standard_output_uoms = _output_outcome_uoms(outputs_control, "Standard output")
-    breaching_row_indices_uom = _check_values_against_mapped_allowed(
+    standard_output_uoms = common.output_outcome_uoms(outputs_control, "Standard output")
+    breaching_row_indices_uom = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Outputs"].loc[non_breaching_row_indices],
         value_column="Unit of measurement",
         allowed_values_key_column="Output",
@@ -219,7 +153,7 @@ def _check_standard_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
     )
     breaching_uoms = extracted_table_dfs["Outputs"].loc[breaching_row_indices_uom, "Unit of measurement"].tolist()
     uom_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outputs",
             section="Standard outputs",
             description=PFErrors.UOM_NOT_ALLOWED.format(unit_of_measurement=unit_of_measurement),
@@ -252,7 +186,7 @@ def _check_standard_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> li
     intervention_theme_to_standard_outcomes["Enhancing subregional and regional connectivity"] = (
         intervention_theme_to_standard_outcomes.pop("Enhancing sub-regional and regional connectivity")
     )
-    breaching_row_indices_outcomes = _check_values_against_mapped_allowed(
+    breaching_row_indices_outcomes = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Outcomes"],
         value_column="Outcome",
         allowed_values_key_column="Intervention theme",
@@ -265,7 +199,7 @@ def _check_standard_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> li
     )
     breaching_indices_copy = deepcopy(breaching_row_indices_outcomes)
     outcome_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outcomes",
             section="Outcomes",
             description=PFErrors.STANDARD_OUTCOME_NOT_ALLOWED.format(
@@ -276,8 +210,8 @@ def _check_standard_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> li
         for outcome, intervention_theme in breaching_outcomes
     ]
     non_breaching_row_indices = extracted_table_dfs["Outcomes"].index.difference(breaching_indices_copy)
-    standard_outcome_uoms = _output_outcome_uoms(outcomes_control, "Standard outcome")
-    breaching_row_indices_uom = _check_values_against_mapped_allowed(
+    standard_outcome_uoms = common.output_outcome_uoms(outcomes_control, "Standard outcome")
+    breaching_row_indices_uom = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Outcomes"].loc[non_breaching_row_indices],
         value_column="Unit of measurement",
         allowed_values_key_column="Outcome",
@@ -285,7 +219,7 @@ def _check_standard_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> li
     )
     breaching_uoms = extracted_table_dfs["Outcomes"].loc[breaching_row_indices_uom, "Unit of measurement"].tolist()
     uom_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outcomes",
             section="Standard outcomes",
             description=PFErrors.UOM_NOT_ALLOWED.format(unit_of_measurement=unit_of_measurement),
@@ -316,7 +250,7 @@ def _check_bespoke_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> list
     }
     organisation_name = extracted_table_dfs["Organisation name"].iloc[0, 0]
     allowed_outputs = programme_to_allowed_bespoke_outputs[organisation_name]
-    breaching_row_indices_bespoke_outputs = _check_values_against_allowed(
+    breaching_row_indices_bespoke_outputs = common.check_values_against_allowed(
         df=extracted_table_dfs["Bespoke outputs"],
         value_column="Output",
         allowed_values=allowed_outputs,
@@ -328,7 +262,7 @@ def _check_bespoke_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> list
     )
     breaching_indices_copy = deepcopy(breaching_row_indices_bespoke_outputs)
     bespoke_output_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outputs",
             section="Bespoke outputs",
             description=PFErrors.BESPOKE_OUTPUT_NOT_ALLOWED.format(
@@ -339,8 +273,8 @@ def _check_bespoke_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> list
         for output, intervention_theme in breaching_outputs
     ]
     non_breaching_row_indices = extracted_table_dfs["Bespoke outputs"].index.difference(breaching_indices_copy)
-    bespoke_output_uoms = _output_outcome_uoms(bespoke_outputs_control, "Output")
-    breaching_row_indices_uom = _check_values_against_mapped_allowed(
+    bespoke_output_uoms = common.output_outcome_uoms(bespoke_outputs_control, "Output")
+    breaching_row_indices_uom = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Bespoke outputs"].loc[non_breaching_row_indices],
         value_column="Unit of measurement",
         allowed_values_key_column="Output",
@@ -350,7 +284,7 @@ def _check_bespoke_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> list
         extracted_table_dfs["Bespoke outputs"].loc[breaching_row_indices_uom, "Unit of measurement"].tolist()
     )
     uom_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outputs",
             section="Bespoke outputs",
             description=PFErrors.UOM_NOT_ALLOWED.format(unit_of_measurement=unit_of_measurement),
@@ -381,7 +315,7 @@ def _check_bespoke_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
     }
     organisation_name = extracted_table_dfs["Organisation name"].iloc[0, 0]
     allowed_outcomes = programme_to_allowed_bespoke_outcomes[organisation_name]
-    breaching_row_indices_bespoke_outcomes = _check_values_against_allowed(
+    breaching_row_indices_bespoke_outcomes = common.check_values_against_allowed(
         df=extracted_table_dfs["Bespoke outcomes"],
         value_column="Outcome",
         allowed_values=allowed_outcomes,
@@ -393,7 +327,7 @@ def _check_bespoke_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
     )
     breaching_indices_copy = deepcopy(breaching_row_indices_bespoke_outcomes)
     bespoke_outcome_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outcomes",
             section="Bespoke outcomes",
             description=PFErrors.BESPOKE_OUTCOME_NOT_ALLOWED.format(
@@ -404,8 +338,8 @@ def _check_bespoke_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
         for outcome, intervention_theme in breaching_outcomes
     ]
     non_breaching_row_indices = extracted_table_dfs["Bespoke outcomes"].index.difference(breaching_indices_copy)
-    bespoke_outcome_uoms = _output_outcome_uoms(bespoke_outcomes_control, "Outcome")
-    breaching_row_indices_uom = _check_values_against_mapped_allowed(
+    bespoke_outcome_uoms = common.output_outcome_uoms(bespoke_outcomes_control, "Outcome")
+    breaching_row_indices_uom = common.check_values_against_mapped_allowed(
         df=extracted_table_dfs["Bespoke outcomes"].loc[non_breaching_row_indices],
         value_column="Unit of measurement",
         allowed_values_key_column="Outcome",
@@ -415,7 +349,7 @@ def _check_bespoke_outcomes(extracted_table_dfs: dict[str, pd.DataFrame]) -> lis
         extracted_table_dfs["Bespoke outcomes"].loc[breaching_row_indices_uom, "Unit of measurement"].tolist()
     )
     uom_errors = [
-        _error_message(
+        common.error_message(
             sheet="Outcomes",
             section="Bespoke outcomes",
             description=PFErrors.UOM_NOT_ALLOWED.format(unit_of_measurement=unit_of_measurement),
@@ -446,7 +380,7 @@ def _check_credible_plan_fields(extracted_table_dfs: dict[str, pd.DataFrame]) ->
                 # Column names are identical to table names and so can be used interchangeably
                 if pd.isna(row[table_name]):
                     error_messages.append(
-                        _error_message(
+                        common.error_message(
                             sheet=worksheet,
                             section=table_name,
                             description=PFErrors.CREDIBLE_PLAN_YES,
@@ -459,7 +393,7 @@ def _check_credible_plan_fields(extracted_table_dfs: dict[str, pd.DataFrame]) ->
             for idx, row in extracted_table_df.iterrows():
                 if not pd.isna(row[table_name]):
                     error_messages.append(
-                        _error_message(
+                        common.error_message(
                             sheet=worksheet,
                             section=table_name,
                             description=PFErrors.CREDIBLE_PLAN_NO,
@@ -483,7 +417,7 @@ def _check_current_underspend(extracted_table_dfs: dict[str, pd.DataFrame]) -> l
         if pd.isna(current_underspend):
             row_index = current_underspend_df.index[0]
             return [
-                _error_message(
+                common.error_message(
                     sheet="Finances",
                     section="Current underspend",
                     description=PFErrors.CURRENT_UNDERSPEND,
@@ -508,12 +442,12 @@ def _check_intervention_themes_in_pfcs(extracted_table_dfs: dict[str, pd.DataFra
     ]
     error_messages: list = []
     for col_letter, col_name in columns:
-        breaching_indices = _check_values_against_allowed(
+        breaching_indices = common.check_values_against_allowed(
             df=extracted_table_dfs["Project finance changes"], value_column=col_name, allowed_values=allowed_themes
         )
         breaching_themes = extracted_table_dfs["Project finance changes"].loc[breaching_indices, col_name].tolist()
         error_messages.extend(
-            _error_message(
+            common.error_message(
                 sheet="Finances",
                 section="Project finance changes",
                 cell_index=f"{col_letter}{int(row) + 1}",  # +1 because DataFrames are 0-indexed and Excel is not
@@ -544,7 +478,7 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
         if actual_forecast_cancelled == "Actual":
             if change_reporting_period_start_date > submission_reporting_period_start_date:
                 error_messages.append(
-                    _error_message(
+                    common.error_message(
                         sheet="Finances",
                         section="Project finance changes",
                         description=PFErrors.ACTUAL_REPORTING_PERIOD,
@@ -554,7 +488,7 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
         elif actual_forecast_cancelled == "Forecast":
             if change_reporting_period_start_date <= submission_reporting_period_start_date:
                 error_messages.append(
-                    _error_message(
+                    common.error_message(
                         sheet="Finances",
                         section="Project finance changes",
                         description=PFErrors.FORECAST_REPORTING_PERIOD,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,12 @@ module = "data_store.util"
 disable_error_code = ["operator", "union-attr"]
 
 [[tool.mypy.overrides]]
+module = "data_store/validation/pathfinders/cross_table_validation/common"
+disable_error_code = ["arg-type", "return-value"]
+
+[[tool.mypy.overrides]]
 module = "data_store/validation/pathfinders/cross_table_validation/ct_validate_r1"
-disable_error_code = ["arg-type", "operator", "return-value", "union-attr"]
+disable_error_code = ["arg-type", "operator", "union-attr"]
 
 [[tool.mypy.overrides]]
 module = "data_store/validation/towns_fund/fund_specific_validation/fs_validate_r4"


### PR DESCRIPTION
### Ticket
[Pathfinders - Proposed Amendments requested June '24](https://dluhcdigital.atlassian.net/browse/FPASF-453)

### Change description
A precursor to the actual changes to support Pathfinders round 2 ingest. This PR separates out cross-table validation logic that is shared across rounds and logic that is round-specific, with a new module created for shared logic. This is a slight refactoring that will mean we can share code between rounds when we implement round 2 code.

### How to test
This is refactoring rather than new functionality; all existing tests passing should suffice.
