### PR TITLE
RFP-453 - Precursor - Separating shared and round-specific validation constants

### DIFF
--- a/data_store/table_extraction/config/pf_r1_config.py
+++ b/data_store/table_extraction/config/pf_r1_config.py
@@ -3,6 +3,7 @@ Defines the table configurations for the Pathfinder round 1 template. These are 
 the data.
 """
 
+from data_store.validation.pathfinders.r1_consts import PFEnums
 from data_store.validation.pathfinders.schema_validation import checks
 from data_store.validation.pathfinders.schema_validation.columns import (
     datetime_column,
@@ -10,7 +11,6 @@ from data_store.validation.pathfinders.schema_validation.columns import (
     int_column,
     string_column,
 )
-from data_store.validation.pathfinders.schema_validation.consts import PFEnums
 
 PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
     "Reporting period": {

--- a/data_store/validation/pathfinders/consts.py
+++ b/data_store/validation/pathfinders/consts.py
@@ -10,69 +10,6 @@ class PFRegex:
     )
 
 
-class PFEnums:
-    """
-    Lists of allowed values used for validation of dropdown fields in Pathfinders reporting template.
-    """
-
-    ACTUAL_FORECAST = ["Actual", "Forecast", "Cancelled"]
-    INTERVENTION_THEMES = [
-        "Employment & Education",
-        "Enhancing subregional and regional connectivity",
-        "Improving the quality of life of residents",
-        "Strengthening the visitor and local service economy",
-        "Unlocking and enabling industrial, commercial, and residential development",
-        "Unlocking and enabling industrial and commercial development",
-    ]
-    RAGS = ["Green", "Amber/Green", "Amber", "Amber/Red", "Red"]
-    REPORTING_PERIOD = [
-        "Q4 2023/24: Jan 2024 - Mar 2024",
-        "Q1 2024/25: Apr 2024 - Jun 2024",
-        "Q2 2024/25: Jul 2024 - Sep 2024",
-        "Q3 2024/25: Oct 2024 - Dec 2024",
-        "Q4 2024/25: Jan 2025 - Mar 2025",
-        "Q1 2025/26: Apr 2025 - Jun 2025",
-        "Q2 2025/26: Jul 2025 - Sep 2025",
-        "Q3 2025/26: Oct 2025 - Dec 2025",
-        "Q4 2025/26: Jan 2026 - Mar 2026",
-    ]
-    RISK_CATEGORIES = [
-        "Arm’s length body risks",
-        "Commercial or procurement risks",
-        "Delivery Partner",
-        "Financial flexibility",
-        "Financial risks",
-        "Governance risks",
-        "Legal, regulatory or compliance risks",
-        "Local government risks",
-        "Operational process or control risks",
-        "People risks",
-        "Planning Permission / other consents",
-        "Political sensitivity",
-        "Procurement / contracting",
-        "Programme or project delivery risks",
-        "Reputational Risk",
-        "Resilience risks",
-        "Resource & Expertise",
-        "Security risks",
-        "Slippage",
-        "Strategy risks",
-        "Subsidy Control",
-        "System or IT infrastructure risks",
-        "Other",
-    ]
-    RISK_SCORES = ["1 - Very Low", "2 - Low", "3 - Medium", "4 - High", "5 - Very High"]
-    SPEND_TYPE = [
-        "How much of your forecast is contractually committed?",
-        "How much of your forecast is not contractually committed?",
-        "Freedom and flexibilities spend",
-        "Total DLUHC spend (inc. F&F)",
-        "Secured match funding spend",
-        "Unsecured match funding",
-        "Total match",
-    ]
-
-
 class PFErrors:
     """
     Error messages for Pathfinders reporting template validation.

--- a/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
+++ b/data_store/validation/pathfinders/cross_table_validation/ct_validate_r1.py
@@ -14,8 +14,8 @@ import pandas as pd
 
 from data_store.messaging import Message
 from data_store.transformation.pathfinders.consts import PF_REPORTING_PERIOD_TO_DATES_PFCS
+from data_store.validation.pathfinders.consts import PFErrors
 from data_store.validation.pathfinders.cross_table_validation import common
-from data_store.validation.pathfinders.schema_validation.consts import PFErrors
 
 
 def cross_table_validate(extracted_table_dfs: dict[str, pd.DataFrame]) -> list[Message]:

--- a/data_store/validation/pathfinders/r1_consts.py
+++ b/data_store/validation/pathfinders/r1_consts.py
@@ -1,0 +1,61 @@
+class PFEnums:
+    """
+    Lists of allowed values used for validation of dropdown fields in Pathfinders R1 reporting template.
+    """
+
+    ACTUAL_FORECAST = ["Actual", "Forecast", "Cancelled"]
+    INTERVENTION_THEMES = [
+        "Employment & Education",
+        "Enhancing subregional and regional connectivity",
+        "Improving the quality of life of residents",
+        "Strengthening the visitor and local service economy",
+        "Unlocking and enabling industrial, commercial, and residential development",
+        "Unlocking and enabling industrial and commercial development",
+    ]
+    RAGS = ["Green", "Amber/Green", "Amber", "Amber/Red", "Red"]
+    REPORTING_PERIOD = [
+        "Q4 2023/24: Jan 2024 - Mar 2024",
+        "Q1 2024/25: Apr 2024 - Jun 2024",
+        "Q2 2024/25: Jul 2024 - Sep 2024",
+        "Q3 2024/25: Oct 2024 - Dec 2024",
+        "Q4 2024/25: Jan 2025 - Mar 2025",
+        "Q1 2025/26: Apr 2025 - Jun 2025",
+        "Q2 2025/26: Jul 2025 - Sep 2025",
+        "Q3 2025/26: Oct 2025 - Dec 2025",
+        "Q4 2025/26: Jan 2026 - Mar 2026",
+    ]
+    RISK_CATEGORIES = [
+        "Arm’s length body risks",
+        "Commercial or procurement risks",
+        "Delivery Partner",
+        "Financial flexibility",
+        "Financial risks",
+        "Governance risks",
+        "Legal, regulatory or compliance risks",
+        "Local government risks",
+        "Operational process or control risks",
+        "People risks",
+        "Planning Permission / other consents",
+        "Political sensitivity",
+        "Procurement / contracting",
+        "Programme or project delivery risks",
+        "Reputational Risk",
+        "Resilience risks",
+        "Resource & Expertise",
+        "Security risks",
+        "Slippage",
+        "Strategy risks",
+        "Subsidy Control",
+        "System or IT infrastructure risks",
+        "Other",
+    ]
+    RISK_SCORES = ["1 - Very Low", "2 - Low", "3 - Medium", "4 - High", "5 - Very High"]
+    SPEND_TYPE = [
+        "How much of your forecast is contractually committed?",
+        "How much of your forecast is not contractually committed?",
+        "Freedom and flexibilities spend",
+        "Total DLUHC spend (inc. F&F)",
+        "Secured match funding spend",
+        "Unsecured match funding",
+        "Total match",
+    ]

--- a/data_store/validation/pathfinders/schema_validation/checks.py
+++ b/data_store/validation/pathfinders/schema_validation/checks.py
@@ -26,7 +26,7 @@ import pandas as pd
 import pandera as pa
 
 from data_store.transformation.utils import POSTCODE_REGEX
-from data_store.validation.pathfinders.schema_validation.consts import PFErrors, PFRegex
+from data_store.validation.pathfinders.consts import PFErrors, PFRegex
 
 
 def _should_fail_check_because_element_is_nan(element) -> Literal[True] | None:


### PR DESCRIPTION
### Ticket
[Pathfinders - Proposed Amendments requested June '24](https://dluhcdigital.atlassian.net/browse/FPASF-453)

### Change description
A precursor to the actual changes to support Pathfinders round 2 ingest. This PR is for separating validation constants that are shared versus those likely to be round-specific.

### How to test
This is refactoring rather than new functionality; all existing tests passing should suffice.
