### PR TITLE
Stop backfilling ProgrammeJunction/SubmissionDim for reporting rounds

### DIFF
--- a/data_store/reference_data.py
+++ b/data_store/reference_data.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pandas as pd
-from sqlalchemy import text
 
 from data_store.controllers.mappings import DataMapping
 from data_store.db import db
@@ -101,8 +100,7 @@ def seed_fund_table():
 
 def seed_reporting_round_table():
     """
-    Seed the reporting round table with the data in /tests/resources/reporting_round.csv and update the submission_dim
-    and programme_junction tables with the new reporting_round_id.
+    Seed the reporting round table with the data in /tests/resources/reporting_round.csv.
     """
     resources = Path(__file__).parent / ".." / "tests" / "resources"
     reporting_round_df = pd.read_csv(resources / "reporting_round.csv")
@@ -128,34 +126,4 @@ def seed_reporting_round_table():
             )
             reporting_round.submission_period_end = spe if not pd.isnull(spe := row["submission_period_end"]) else None
         db.session.add(reporting_round)
-    db.session.commit()
-
-    # Update reporting_round_id in submission_dim
-    db.session.execute(
-        text("""
-        UPDATE submission_dim AS sd
-        SET reporting_round_id = rr.id
-        FROM reporting_round AS rr
-            JOIN programme_dim AS pd
-                ON rr.fund_id = pd.fund_type_id
-                    JOIN programme_junction AS pj
-                        ON pd.id = pj.programme_id
-                            AND rr.round_number = pj.reporting_round
-        WHERE sd.id = pj.submission_id
-    """)
-    )
-
-    # Update reporting_round_id in programme_junction
-    db.session.execute(
-        text("""
-        UPDATE programme_junction AS pj
-        SET reporting_round_id = rr.id
-        FROM reporting_round AS rr
-            JOIN programme_dim AS pd
-                ON rr.fund_id = pd.fund_type_id
-        WHERE pj.programme_id = pd.id
-        AND pj.reporting_round = rr.round_number
-    """)
-    )
-
     db.session.commit()


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-494

### Change description
We are removing the old reporting round columns on these tables, so they won't be available for backfilling lookups any more. All of our deployed and local data has already been migrated, so this is no longer required.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
