### PR TITLE
Remove definitions of old reporting round columns

### DIFF
--- a/data_store/db/entities.py
+++ b/data_store/db/entities.py
@@ -416,7 +416,6 @@ class ProgrammeJunction(BaseModel):
     )
     programme_id: Mapped[GUID] = sqla.orm.mapped_column(sqla.ForeignKey("programme_dim.id"), nullable=False)
     reporting_round_id: Mapped[GUID] = sqla.orm.mapped_column(sqla.ForeignKey("reporting_round.id"), nullable=False)
-    reporting_round = sqla.Column(sqla.Integer, nullable=True)
 
     # parent relationships
     submission: Mapped["Submission"] = sqla.orm.relationship(back_populates="programme_junction", single_parent=True)
@@ -447,16 +446,6 @@ class ProgrammeJunction(BaseModel):
         sqla.Index(
             "ix_programme_junction_join_programme",
             "programme_id",
-        ),
-        sqla.UniqueConstraint(
-            "programme_id",
-            "reporting_round",
-            name="uq_programme_junction_unique_submission_per_round",
-        ),
-        sqla.UniqueConstraint(
-            "programme_id",
-            "reporting_round_id",
-            name="uq_programme_junction_programme_id_reporting_round_id",
         ),
     )
 
@@ -618,8 +607,6 @@ class Submission(BaseModel):
 
     submission_date = sqla.Column(sqla.DateTime(), nullable=True)
     ingest_date = sqla.Column(sqla.DateTime(), nullable=False, default=datetime.now())
-    reporting_period_start = sqla.Column(sqla.DateTime(), nullable=True)
-    reporting_period_end = sqla.Column(sqla.DateTime(), nullable=True)
     submission_filename = sqla.Column(sqla.String(), nullable=True)
     data_blob = sqla.Column(JSONB, nullable=True)
     submitting_account_id = sqla.Column(sqla.String())
@@ -627,21 +614,6 @@ class Submission(BaseModel):
 
     programme_junction: Mapped["ProgrammeJunction"] = sqla.orm.relationship(back_populates="submission")
     reporting_round: Mapped["ReportingRound"] = sqla.orm.relationship(back_populates="submissions")
-
-    __table_args__ = (
-        sqla.Index(
-            "ix_submission_filter_start_date",
-            "reporting_period_start",
-        ),
-        sqla.Index(
-            "ix_submission_filter_end_date",
-            "reporting_period_end",
-        ),
-        sqla.CheckConstraint(
-            "(reporting_period_start <= reporting_period_end)",
-            name="start_before_end",  # gets prefixed with `ck_{table}_`
-        ),
-    )
 
     @hybrid_property
     def submission_number(self) -> int:

--- a/tests/data_store_tests/db_tests/test_constraints.py
+++ b/tests/data_store_tests/db_tests/test_constraints.py
@@ -264,18 +264,6 @@ class TestConstraintOnStartAndEndDates:
 
         assert "ck_output_data_start_before_end" in str(e.value)
 
-    @pytest.mark.xfail(reason="to remove in one of the next patches")
-    def test_reporting_period_start_and_end_dates(self, seeded_test_client_rollback):
-        s = Submission(
-            submission_id="TEST",
-        )
-        db.session.add(s)
-
-        with pytest.raises(IntegrityError) as e:
-            db.session.commit()
-
-        assert "ck_submission_dim_start_before_end" in str(e.value)
-
 
 def test_fund_dim_unique_constraint(test_client_rollback):
     """Tests the unique constraint on fund_dim."""


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-494

### Change description
Removes the old reporting round columns from python model defintions. Once this is out, we know that no code is using those columns, and we can remove them safely in a future migration PR.

**Note**: I know that the DB migrations check will fail, because there are outstanding migrations. But this is intentional.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
