### PR TITLE
FPASF-583 - Support new 'Project progress' validation requirement for TF R6

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -123,6 +123,7 @@ def ingest(
                 workbook_data,
                 ingest_dependencies.validation_schema,
                 ingest_dependencies.fund_specific_validation,
+                reporting_round,
             )
         else:
             if not isinstance(ingest_dependencies, PFIngestDependencies):

--- a/data_store/controllers/ingest_dependencies.py
+++ b/data_store/controllers/ingest_dependencies.py
@@ -69,7 +69,7 @@ class TFIngestDependencies(IngestDependencies):
     messenger: MessengerBase
     validation_schema: dict
     fund_specific_validation: (
-        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame] | None], list[GenericFailure]] | None
+        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame], int], list[GenericFailure]] | None
     ) = None
 
 

--- a/data_store/messaging/tf_messaging.py
+++ b/data_store/messaging/tf_messaging.py
@@ -28,6 +28,10 @@ class TFMessages(SharedMessages):
     MISSING_OTHER_FUNDING_SOURCES = (
         "You’ve not entered any Other Funding Sources. You must enter at least 1 over all projects."
     )
+    DATA_MISMATCH_PROJECT_START = (
+        "You've entered a project start date of today or earlier, but the project delivery status has been entered as "
+        "'Not yet started'. Add a valid start date or change the status."
+    )
 
 
 class TFMessenger(MessengerBase):

--- a/data_store/messaging/tf_messaging.py
+++ b/data_store/messaging/tf_messaging.py
@@ -29,8 +29,8 @@ class TFMessages(SharedMessages):
         "You’ve not entered any Other Funding Sources. You must enter at least 1 over all projects."
     )
     DATA_MISMATCH_PROJECT_START = (
-        "You've entered a project start date of today or earlier, but the project delivery status has been entered as "
-        "'Not yet started'. Add a valid start date or change the status."
+        "You've entered a project start date that is before the end of the reporting period, but the project delivery "
+        "status has been entered as 'Not yet started'. Add a valid start date or change the status."
     )
 
 

--- a/data_store/validation/__init__.py
+++ b/data_store/validation/__init__.py
@@ -13,8 +13,9 @@ def tf_validate(
     original_workbook: dict[str, pd.DataFrame],
     validation_schema: dict,
     fund_specific_validation: (
-        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame] | None], list[GenericFailure]] | None
+        Callable[[dict[str, pd.DataFrame], dict[str, pd.DataFrame], int], list[GenericFailure]] | None
     ),
+    reporting_round: int,
 ):
     """Validate a workbook against its round specific schema.
 
@@ -30,7 +31,7 @@ def tf_validate(
     validation_failures = validate_data(data_dict, validation_schema)
 
     if fund_specific_validation:
-        fund_specific_failures = fund_specific_validation(data_dict, original_workbook)
+        fund_specific_failures = fund_specific_validation(data_dict, original_workbook, reporting_round)
         validation_failures = [*validation_failures, *fund_specific_failures]
 
     if validation_failures:

--- a/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r4.py
+++ b/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r4.py
@@ -40,7 +40,9 @@ FUNDING_ALLOCATION = pd.read_csv(Path(__file__).parent / "resources" / "TF-grant
 
 
 def validate(
-    data_dict: dict[str, pd.DataFrame], original_workbook: dict[str, pd.DataFrame] | None = None
+    data_dict: dict[str, pd.DataFrame],
+    original_workbook: dict[str, pd.DataFrame],
+    reporting_round: int,
 ) -> list[GenericFailure]:
     """Top-level Towns Fund Round 4 specific validation.
 

--- a/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
+++ b/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+import pandas as pd
+
+from data_store.const import StatusEnum
+from data_store.messaging.tf_messaging import TFMessages as msgs
+from data_store.validation.towns_fund.failures.user import GenericFailure
+from data_store.validation.towns_fund.fund_specific_validation.fs_validate_r4 import (
+    validate as validate_r4,
+)
+
+
+def validate(
+    data_dict: dict[str, pd.DataFrame], original_workbook: dict[str, pd.DataFrame] | None = None
+) -> list[GenericFailure]:
+    """Top-level Towns Fund Round 6 specific validation."""
+
+    # Start with validations from Round 4
+    validation_failures = validate_r4(data_dict, original_workbook)
+
+    # Add new validations specific to Round 6
+    project_progress_failures = validate_project_progress(data_dict)
+    validation_failures.extend(project_progress_failures)
+
+    return validation_failures
+
+
+def validate_project_progress(workbook: dict[str, pd.DataFrame]) -> list[GenericFailure]:
+    """Validates the Project Progress table for Round 6 submissions."""
+    project_progress_df = workbook["Project Progress"]
+    not_started_mask = project_progress_df["Project Delivery Status"] == StatusEnum.NOT_YET_STARTED
+    not_started_rows = project_progress_df[not_started_mask]
+    current_date = datetime.now().date()
+    failures = []
+    for idx, row in not_started_rows.iterrows():
+        start_date = row["Start Date"]
+        if pd.isnull(start_date):
+            continue
+        if start_date.date() <= current_date:
+            failures.append(
+                GenericFailure(
+                    table="Project Progress",
+                    section="Projects Progress Summary",
+                    column="Start Date",
+                    message=msgs.DATA_MISMATCH_PROJECT_START,
+                    row_index=idx,  # type: ignore[arg-type]
+                )
+            )
+    return failures

--- a/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
+++ b/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 import pandas as pd
 
 from data_store.const import StatusEnum
 from data_store.messaging.tf_messaging import TFMessages as msgs
+from data_store.transformation.towns_fund import common
 from data_store.validation.towns_fund.failures.user import GenericFailure
 from data_store.validation.towns_fund.fund_specific_validation.fs_validate_r4 import (
     validate as validate_r4,
@@ -11,32 +10,33 @@ from data_store.validation.towns_fund.fund_specific_validation.fs_validate_r4 im
 
 
 def validate(
-    data_dict: dict[str, pd.DataFrame], original_workbook: dict[str, pd.DataFrame] | None = None
+    data_dict: dict[str, pd.DataFrame],
+    original_workbook: dict[str, pd.DataFrame],
+    reporting_round: int,
 ) -> list[GenericFailure]:
     """Top-level Towns Fund Round 6 specific validation."""
-
     # Start with validations from Round 4
-    validation_failures = validate_r4(data_dict, original_workbook)
+    validation_failures = validate_r4(data_dict, original_workbook, reporting_round)
 
     # Add new validations specific to Round 6
-    project_progress_failures = validate_project_progress(data_dict)
+    project_progress_failures = validate_project_progress(data_dict, reporting_round)
     validation_failures.extend(project_progress_failures)
 
     return validation_failures
 
 
-def validate_project_progress(workbook: dict[str, pd.DataFrame]) -> list[GenericFailure]:
+def validate_project_progress(data_dict: dict[str, pd.DataFrame], reporting_round: int) -> list[GenericFailure]:
     """Validates the Project Progress table for Round 6 submissions."""
-    project_progress_df = workbook["Project Progress"]
+    project_progress_df = data_dict["Project Progress"]
     not_started_mask = project_progress_df["Project Delivery Status"] == StatusEnum.NOT_YET_STARTED
     not_started_rows = project_progress_df[not_started_mask]
-    current_date = datetime.now().date()
+    _, observation_period_end_date = common.get_reporting_period_start_end(reporting_round)
     failures = []
     for idx, row in not_started_rows.iterrows():
         start_date = row["Start Date"]
         if pd.isnull(start_date):
             continue
-        if start_date.date() <= current_date:
+        if start_date.date() <= observation_period_end_date.date():
             failures.append(
                 GenericFailure(
                     table="Project Progress",

--- a/tests/data_store_tests/validation_tests/towns_fund/fund_specific_validation_tests/test_fs_validate_r4.py
+++ b/tests/data_store_tests/validation_tests/towns_fund/fund_specific_validation_tests/test_fs_validate_r4.py
@@ -74,14 +74,14 @@ def test_validate_failure(mocker, validation_functions_success_mock):
     )
 
     mock_workbook = {"Sheet 1": pd.DataFrame()}
-    failures = validate(mock_workbook)
+    failures = validate(mock_workbook, original_workbook={}, reporting_round=4)
 
     assert failures == [mocked_failure, mocked_failure]
 
 
 def test_validate_success(validation_functions_success_mock):
     mock_workbook = {"Sheet 1": pd.DataFrame()}
-    failures = validate(mock_workbook)
+    failures = validate(mock_workbook, original_workbook={}, reporting_round=4)
     assert failures == []
 
 

--- a/tests/data_store_tests/validation_tests/towns_fund/fund_specific_validation_tests/test_fs_validate_r6.py
+++ b/tests/data_store_tests/validation_tests/towns_fund/fund_specific_validation_tests/test_fs_validate_r6.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from data_store.const import StatusEnum
+from data_store.messaging.tf_messaging import TFMessages as msgs
+from data_store.validation.towns_fund.fund_specific_validation.fs_validate_r6 import (
+    validate_project_progress,
+)
+
+
+def test_validate_project_progress_start_date_in_past():
+    """Test that validation fails when 'Project Delivery Status' is 'Not yet started' and 'Start Date' is in the
+    past."""
+    current_date = datetime.now().date()
+    past_date = current_date - timedelta(days=1)
+    project_progress_df = pd.DataFrame(
+        index=[0],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.Timestamp(past_date),
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            }
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.table == "Project Progress"
+    assert failure.section == "Projects Progress Summary"
+    assert failure.column == "Start Date"
+    assert failure.message == msgs.DATA_MISMATCH_PROJECT_START
+    assert failure.row_index == 0
+
+
+def test_validate_project_progress_start_date_today():
+    """Test that validation fails when 'Project Delivery Status' is 'Not yet started' and 'Start Date' is today."""
+    current_date = datetime.now().date()
+    project_progress_df = pd.DataFrame(
+        index=[0],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.Timestamp(current_date),
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            }
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.table == "Project Progress"
+    assert failure.section == "Projects Progress Summary"
+    assert failure.column == "Start Date"
+    assert failure.message == msgs.DATA_MISMATCH_PROJECT_START
+    assert failure.row_index == 0
+
+
+def test_validate_project_progress_start_date_in_future():
+    """Test that validation passes when 'Project Delivery Status' is 'Not yet started' and 'Start Date' is in the
+    future."""
+    current_date = datetime.now().date()
+    future_date = current_date + timedelta(days=1)
+    project_progress_df = pd.DataFrame(
+        index=[0],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.Timestamp(future_date),
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            }
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert len(failures) == 0
+
+
+def test_validate_project_progress_status_not_not_yet_started():
+    """Test that validation does not trigger when 'Project Delivery Status' is not 'Not yet started'."""
+    current_date = datetime.now().date()
+    past_date = current_date - timedelta(days=1)
+    project_progress_df = pd.DataFrame(
+        index=[0],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.ONGOING_ON_TRACK,
+                "Start Date": pd.Timestamp(past_date),
+                "Leading Factor of Delay": "No delay",
+                "Current Project Delivery Stage": "Planning",
+            }
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert len(failures) == 0
+
+
+def test_validate_project_progress_start_date_null():
+    """Test that validation skips rows where 'Start Date' is null."""
+    project_progress_df = pd.DataFrame(
+        index=[0],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.NaT,  # Null Start Date
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            }
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert not any(failure.message == msgs.DATA_MISMATCH_PROJECT_START for failure in failures)
+
+
+def test_validate_project_progress_multiple_projects():
+    """Test validation with multiple projects, ensuring it only fails where appropriate."""
+    current_date = datetime.now().date()
+    past_date = current_date - timedelta(days=1)
+    future_date = current_date + timedelta(days=1)
+    project_progress_df = pd.DataFrame(
+        index=[0, 1, 2],
+        data=[
+            {
+                "Project ID": "TD-ABC-01",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.Timestamp(past_date),
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            },
+            {
+                "Project ID": "TD-ABC-02",
+                "Project Delivery Status": StatusEnum.NOT_YET_STARTED,
+                "Start Date": pd.Timestamp(future_date),
+                "Leading Factor of Delay": "Some delay",
+                "Current Project Delivery Stage": "Planning",
+            },
+            {
+                "Project ID": "TD-ABC-03",
+                "Project Delivery Status": StatusEnum.ONGOING_ON_TRACK,
+                "Start Date": pd.Timestamp(past_date),
+                "Leading Factor of Delay": "No delay",
+                "Current Project Delivery Stage": "Planning",
+            },
+        ],
+    )
+    workbook = {"Project Progress": project_progress_df}
+    failures = validate_project_progress(workbook)
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.row_index == 0
+    assert failure.message == msgs.DATA_MISMATCH_PROJECT_START


### PR DESCRIPTION
### Tickets

[Update TF validation for next reporting round](https://dluhcdigital.atlassian.net/browse/FPASF-185)
[Make necessary coding changes](https://dluhcdigital.atlassian.net/browse/FPASF-583)

### Description

Added a new validation rule for the Projects Progress Summary table. It checks that projects marked as "Not yet started" don't have a Start Date in the past. If violated, it triggers a `DATA_MISMATCH_PROJECT_START` error with the content "A Project has not yet started but has a Start Date prior to today declared."

### How to test

- Create a copy of the TF R5 spreadsheet (`funding-service-design-post-award-data-store/tests/integration_tests/mock_tf_returns/TF_Round_5_Success.xlsx`)
- In the copy, change cell G21 on tab "3 - Programme Progress" to "Not yet started"
- In `funding-service-design-post-award-data-store/data_store/controllers/ingest_dependencies.py`, add an import `import data_store.validation.towns_fund.fund_specific_validation.fs_validate_r6 as tf_r6_validate` and for `case ("Towns Fund", 5)`, swap `fund_specific_validation=tf_r4_validate.validate` for `fund_specific_validation=tf_r6_validate.validate`
- Run `data-store` container locally and upload the changed spreadsheet copy at `http://submit-monitoring-data.levellingup.gov.localhost:4001/upload/TF/5`
- Note this row in error table:
Programme progress | Projects progress summary | D21 | A Project has not yet started but has a Start Date prior to today declared 