### PR TITLE
Use ReportingRound as reference data

### DIFF
--- a/data_store/const.py
+++ b/data_store/const.py
@@ -746,27 +746,3 @@ PLACE_TO_FUND_TYPE = {
     "Northampton": {"Town_Deal", "Future_High_Street_Fund"},
     "Barrow": {"Town_Deal"},
 }
-
-# Maps Pathfinder reporting round numbers to observation window start and end dates
-PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES = {
-    1: {
-        "start": datetime(2024, 1, 1),
-        "end": datetime(2024, 3, 31, 23, 59, 59),
-    },
-    2: {
-        "start": datetime(2024, 4, 1),
-        "end": datetime(2024, 9, 30, 23, 59, 59),
-    },
-}
-
-# Maps Pathfinder reporting round numbers to submission period start and end dates
-PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES = {
-    1: {
-        "start": datetime(2024, 4, 1),
-        "end": datetime(2024, 4, 30, 23, 59, 59),
-    },
-    2: {
-        "start": datetime(2024, 10, 1),
-        "end": datetime(2024, 11, 1, 23, 59, 59),
-    },
-}

--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -467,7 +467,7 @@ def populate_db(
     if submission_to_del:
         delete_existing_submission(submission_to_del)
 
-    reporting_round_id = get_reporting_round_id(transformed_data["ReportingRound"], fund_code)
+    reporting_round_id = get_reporting_round_id(fund_code, round_number)
 
     for mapping in mappings:
         if load_function := load_mapping.get(mapping.table):

--- a/data_store/db/queries.py
+++ b/data_store/db/queries.py
@@ -1,12 +1,10 @@
 from datetime import datetime
 from typing import Type
 
-import pandas as pd
 from sqlalchemy import Integer, Select, and_, case, desc, func, or_, select
 from sqlalchemy.orm import Query
 
 import data_store.db.entities as ents
-from data_store.db import db
 from data_store.db.types import GUID
 
 
@@ -773,28 +771,19 @@ def get_latest_submission_by_round_and_fund(round_number: int, fund_code: str) -
     return latest_submission_id
 
 
-def get_reporting_round_id(reporting_round_df: pd.DataFrame, fund_code: str) -> GUID:
+def get_reporting_round_id(fund_code: str, round_number: int) -> GUID:
     """
     Get the reporting round id for a given reporting round dataframe and fund code.
     """
     fund: ents.Fund = ents.Fund.query.filter(ents.Fund.fund_code == fund_code).first()
     if not fund:
         raise ValueError(f"Fund with code {fund_code} not found in database.")
-    round_number = int(reporting_round_df["Round Number"].iloc[0])
-    existing_reporting_round: ents.ReportingRound | None = ents.ReportingRound.query.filter(
-        ents.ReportingRound.round_number == round_number,
-        ents.ReportingRound.fund_id == fund.id,
-    ).first()
-    if existing_reporting_round:
-        return existing_reporting_round.id
-    reporting_round = ents.ReportingRound(
-        round_number=round_number,
-        fund_id=fund.id,
-        observation_period_start=reporting_round_df["Observation Period Start"].iloc[0],
-        observation_period_end=reporting_round_df["Observation Period End"].iloc[0],
-        submission_period_start=reporting_round_df["Submission Period Start"].iloc[0] or None,
-        submission_period_end=reporting_round_df["Submission Period End"].iloc[0] or None,
+
+    return (
+        ents.ReportingRound.query.filter(
+            ents.ReportingRound.fund_id == fund.id,
+            ents.ReportingRound.round_number == round_number,
+        )
+        .one()
+        .id
     )
-    db.session.add(reporting_round)
-    db.session.flush()
-    return reporting_round.id

--- a/data_store/transformation/pathfinders/pf_transform_r1.py
+++ b/data_store/transformation/pathfinders/pf_transform_r1.py
@@ -4,8 +4,6 @@ from datetime import datetime
 import pandas as pd
 
 from data_store.const import (
-    PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES,
-    PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES,
     FundTypeIdEnum,
 )
 from data_store.transformation.utils import create_dataframe, extract_postcodes
@@ -118,7 +116,6 @@ def transform(df_dict: dict[str, pd.DataFrame], reporting_round: int) -> dict[st
     transformed.update(_outcomes(df_dict, programme_name_to_id_mapping))
     transformed["RiskRegister"] = _risk_register(df_dict, programme_name_to_id_mapping)
     transformed["ProjectFinanceChange"] = _project_finance_changes(df_dict, programme_name_to_id_mapping)
-    transformed["ReportingRound"] = _reporting_round(reporting_round)
     return transformed
 
 
@@ -576,27 +573,5 @@ def _project_finance_changes(
             "Reason for Change": pfcs["Reason for change (100 words max)"],
             "Actual or Forecast": pfcs["Actual, forecast or cancelled"],
             "Reporting Period Change Takes Place": pfcs["Reporting period change takes place"],
-        }
-    )
-
-
-def _reporting_round(reporting_round: int) -> pd.DataFrame:
-    """
-    Populates `reporting_round` table:
-        round_number             - from "Round Number" in the transformed DF
-        fund_id                  - assigned during map_data_to_models based on "Fund Code" in the transformed DF
-        observation_period_start - from "Observation Period Start" in the transformed DF
-        observation_period_end   - from "Observation Period End" in the transformed DF
-        submission_period_start  - from "Submission Period Start" in the transformed DF
-        submission_period_end    - from "Submission Period End" in the transformed DF
-    """
-    return create_dataframe(
-        {
-            "Round Number": [reporting_round],
-            "Fund Code": [FundTypeIdEnum.PATHFINDERS.value],
-            "Observation Period Start": [PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES[reporting_round]["start"]],
-            "Observation Period End": [PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES[reporting_round]["end"]],
-            "Submission Period Start": [PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES[reporting_round]["start"]],
-            "Submission Period End": [PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES[reporting_round]["end"]],
         }
     )

--- a/data_store/transformation/pathfinders/pf_transform_r2.py
+++ b/data_store/transformation/pathfinders/pf_transform_r2.py
@@ -4,8 +4,6 @@ from datetime import datetime
 import pandas as pd
 
 from data_store.const import (
-    PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES,
-    PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES,
     FundTypeIdEnum,
 )
 from data_store.transformation.utils import create_dataframe, extract_postcodes
@@ -158,7 +156,6 @@ def transform(df_dict: dict[str, pd.DataFrame], reporting_round: int) -> dict[st
     transformed.update(_outcomes(df_dict, programme_name_to_id_mapping))
     transformed["RiskRegister"] = _risk_register(df_dict, programme_name_to_id_mapping)
     transformed["ProjectFinanceChange"] = _project_finance_changes(df_dict, programme_name_to_id_mapping)
-    transformed["ReportingRound"] = _reporting_round(reporting_round)
     return transformed
 
 
@@ -637,27 +634,5 @@ def _project_finance_changes(
             "Reason for Change": pfcs["Reason for change (100 words max)"],
             "Actual or Forecast": pfcs["Actual, forecast or cancelled"],
             "Reporting Period Change Takes Place": pfcs["Reporting period change takes place"],
-        }
-    )
-
-
-def _reporting_round(reporting_round: int) -> pd.DataFrame:
-    """
-    Populates `reporting_round` table:
-        round_number             - from "Round Number" in the transformed DF
-        fund_id                  - assigned during map_data_to_models based on "Fund Code" in the transformed DF
-        observation_period_start - from "Observation Period Start" in the transformed DF
-        observation_period_end   - from "Observation Period End" in the transformed DF
-        submission_period_start  - from "Submission Period Start" in the transformed DF
-        submission_period_end    - from "Submission Period End" in the transformed DF
-    """
-    return create_dataframe(
-        {
-            "Round Number": [reporting_round],
-            "Fund Code": [FundTypeIdEnum.PATHFINDERS.value],
-            "Observation Period Start": [PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES[reporting_round]["start"]],
-            "Observation Period End": [PF_REPORTING_ROUND_NUMBER_TO_OBSERVATION_DATES[reporting_round]["end"]],
-            "Submission Period Start": [PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES[reporting_round]["start"]],
-            "Submission Period End": [PF_REPORTING_ROUND_NUMBER_TO_SUBMISSION_DATES[reporting_round]["end"]],
         }
     )

--- a/data_store/transformation/towns_fund/common.py
+++ b/data_store/transformation/towns_fund/common.py
@@ -2,8 +2,7 @@ from datetime import datetime
 
 import pandas as pd
 
-from data_store.const import REPORTING_ROUND_TO_OBSERVATION_PERIOD, REPORTING_ROUND_TO_SUBMISSION_PERIOD, FundTypeIdEnum
-from data_store.transformation.utils import create_dataframe
+from data_store.const import REPORTING_ROUND_TO_OBSERVATION_PERIOD, FundTypeIdEnum
 
 
 def get_reporting_period_start_end(reporting_round: int) -> tuple[datetime, datetime]:
@@ -40,18 +39,3 @@ def get_fund_code(df_place: pd.DataFrame) -> str:
         "Future_High_Street_Fund": FundTypeIdEnum.HIGH_STREET_FUND.value,
     }
     return mapping[fund_type]
-
-
-def get_reporting_round(fund_code: str, round_number: int) -> pd.DataFrame:
-    observation_start, observation_end = get_reporting_period_start_end(round_number)
-    submission_period = REPORTING_ROUND_TO_SUBMISSION_PERIOD.get(round_number, {})
-    return create_dataframe(
-        {
-            "Round Number": [round_number],
-            "Fund Code": [fund_code],
-            "Observation Period Start": [observation_start],
-            "Observation Period End": [observation_end],
-            "Submission Period Start": [submission_period.get("start")],
-            "Submission Period End": [submission_period.get("end")],
-        }
-    )

--- a/data_store/transformation/towns_fund/tf_transform_r3.py
+++ b/data_store/transformation/towns_fund/tf_transform_r3.py
@@ -91,9 +91,6 @@ def transform(df_ingest: dict[str, pd.DataFrame], reporting_round: int = 3) -> d
         project_lookup,
         programme_id,
     )
-    towns_fund_extracted["ReportingRound"] = common.get_reporting_round(
-        fund_code=fund_code, round_number=reporting_round
-    )
 
     return towns_fund_extracted
 

--- a/data_store/transformation/towns_fund/tf_transform_r4.py
+++ b/data_store/transformation/towns_fund/tf_transform_r4.py
@@ -78,9 +78,6 @@ def transform(df_ingest: dict[str, pd.DataFrame], reporting_round: int = 4) -> d
     towns_fund_extracted["RiskRegister"] = r3.extract_risks(
         df_ingest["7 - Risk Register"], project_lookup, programme_id, reporting_round
     )
-    towns_fund_extracted["ReportingRound"] = common.get_reporting_round(
-        fund_code=fund_code, round_number=reporting_round
-    )
 
     for sheet_name, df in towns_fund_extracted.items():
         # +1 to account for Excel files being 1-indexed


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-495

### Change description
Stop using the hard-coded dictionaries that contain reporting round
dates. Instead, we can now just reference the reporting round records
in the DB directly.

This change means that ingesting a spreadsheet will no longer *create* a
new ReportingRound entry - this is now a thing that needs to be done
manually by a developer as part of setting up a new reporting round for
a fund. It's very low maintenance, however, using the flask-admin
interface.
