### PR TITLE
Run e2e tests by default when deploying; allow dev

### DIFF
--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -12,9 +12,9 @@ on:
             type: string
             required: true
         run_e2e_tests:
-            description: "Run end-to-end (browser) tests; only works for the `test` environment"
+            description: "Run end-to-end (browser) tests; only works for the `dev` and `test` environments"
             type: boolean
-            default: false
+            default: true
             required: false
 
 jobs:
@@ -82,7 +82,7 @@ jobs:
 
   e2e_test:
     # Do not run these against the prod environment without addressing the auth/JWT self-signing done by e2e tests.
-    if: ${{ inputs.copilot_environment == 'test' && inputs.run_e2e_tests == true }}
+    if: ${{ inputs.run_e2e_tests == true && (inputs.copilot_environment == 'dev' || inputs.copilot_environment == 'test') }}
     name: Run end-to-end (browser) tests
     needs: [ migrate, deploy ]
     uses: ./.github/workflows/test_e2e.yml

--- a/.github/workflows/deploy_combined_service.yml
+++ b/.github/workflows/deploy_combined_service.yml
@@ -9,6 +9,11 @@ on:
           required: true
           options:
           - dev
+        run_e2e_tests:
+          description: Run end-to-end tests?
+          type: boolean
+          default: true
+          required: true
 
 jobs:
   paketo_build:


### PR DESCRIPTION
### Change description
I find myself fairly often doing deploys of branches to dev and then manually triggering the e2e test suite. I think it's fine to just put these two together by default.