### PR TITLE
Make data-store use post /logout endpoint

### DIFF
--- a/find/templates/find/base.html
+++ b/find/templates/find/base.html
@@ -21,40 +21,75 @@
 {% endblock head %}
 
 {% block header %}
-  {{ govukHeader({
-    'homepageUrl': url_for('find.download'),
-    'serviceUrl': url_for('find.download'),
-    'serviceName': config['FIND_SERVICE_NAME'],
-  }) }}
+  {% if g.user %}
+    {% set signOutButton %}
+      <form method="post" action="{{ config['AUTHENTICATOR_HOST'] + '/sso/logout' }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="button-as-link">
+            <a class="govuk-header__link">Sign out</a>
+        </button>
+      </form>
+    {% endset %}
+    {{
+      govukHeader(
+        {
+          'homepageUrl': url_for('find.index'),
+          'serviceUrl': url_for('find.index'),
+          'serviceName': config['FIND_SERVICE_NAME'],
+          'navigation': [
+            {
+              'html': signOutButton,
+            }
+          ]
+        }
+      )
+    }}
+  {% else %}
+    {{
+      govukHeader(
+        {
+          'homepageUrl': url_for('find.download'),
+          'serviceUrl': url_for('find.download'),
+          'serviceName': config['FIND_SERVICE_NAME'],
+        }
+      )
+    }}
+  {% endif %}
 {% endblock header %}
 
 {% block beforeContent %}
   {% block phaseBanner %}
-    {{ govukPhaseBanner({
-    'tag': {
-    'text': config['FIND_SERVICE_PHASE']
-    },
-    'html': 'This is a new service – your <a class="govuk-link"
-      href="mailto:' + config['CONTACT_EMAIL'] +'?subject=Feedback">feedback</a> will help us to improve it.'
-    }) }}
-{% endblock phaseBanner %}
+    {{
+      govukPhaseBanner(
+        {
+          'tag': {
+            'text': config['FIND_SERVICE_PHASE']
+          },
+          'html': 'This is a new service – your <a class="govuk-link"
+            href="mailto:' + config['CONTACT_EMAIL'] +'?subject=Feedback">feedback</a> will help us to improve it.'
+        }
+      )
+    }}
+  {% endblock phaseBanner %}
 
-<div class="global-actions">
-  {% if request.path not in [url_for('find.download'), url_for('find.start_page')] %}
-  {{ govukBackLink({
-  'text': 'Back',
-  'href': url_for('find.download')
-  }) }}
-  {% endif %}
+  <div class="global-actions">
+    {% if request.path not in [url_for('find.download'), url_for('find.start_page')] %}
+      {{
+        govukBackLink(
+          {
+            'text': 'Back',
+            'href': url_for('find.download')
+          }
+        )
+      }}
+    {% endif %}
 
-  <div class="govuk-!-margin-top-2">
-    <a href="{{ url_for('find.help') }}"
-      class="govuk-body govuk-link govuk-link--no-underline govuk-link--no-visited-state">Get help</a>
-    <a href="{{ config['AUTHENTICATOR_HOST'] + '/sso/logout' }}"
-      class="govuk-body govuk-link govuk-link--no-underline govuk-link--no-visited-state govuk-!-margin-left-4">Log
-      out</a>
+    <div class="govuk-!-margin-top-2">
+      <a href="{{ url_for('find.help') }}" class="govuk-body govuk-link govuk-link--no-underline govuk-link--no-visited-state">
+        Get help
+      </a>
+    </div>
   </div>
-</div>
 {% endblock beforeContent %}
 
 {% block content %}

--- a/find/templates/find/main/login.html
+++ b/find/templates/find/main/login.html
@@ -13,14 +13,6 @@
   {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
 
-{% block header %}
-  {{ govukHeader({
-    'homepageUrl': url_for('find.download'),
-    'serviceName': '',
-    'serviceUrl': url_for('find.download'),
-  }) }}
-{% endblock header %}
-
 {% block beforeContent %}
   {% block phaseBanner %}
     {{ super() }}

--- a/static/src/css/custom.css
+++ b/static/src/css/custom.css
@@ -1,16 +1,15 @@
-
 .govuk-notification-banner {
-  padding-bottom: 0px;
+  padding-bottom: 0;
   margin-bottom: 15px;
 }
 
 .overdue-notification-banner {
-  border: 5px solid #d4351c;
   background-color: #d4351c;
+  border: 5px solid #d4351c;
 }
 
 .success-text {
-  color: #ffffff;
+  color: #fff;
 }
 
 .govuk-header__content {
@@ -26,37 +25,42 @@
 /* FIND CUSTOM CSS */
 
 .govuk-footer__copyright-logo {
-  background-image: url("/static/govuk-frontend/images/govuk-crest.png")
+  background-image: url("/static/govuk-frontend/images/govuk-crest.png");
 }
-
 
 .govuk-footer__meta {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-end;
   margin-right: -15px;
   margin-left: -15px;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -ms-flex-align: end;
-  align-items: flex-end;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
 
+  -ms-flex-align: end;
+  -ms-flex-pack: center;
+  -ms-flex-wrap: wrap;
+}
 
 .global-actions {
   display: flex;
   justify-content: space-between;
 }
 
-
 .scrollable-checkboxes {
-  max-height: 250px;
   overflow-y: auto;
+  max-height: 250px;
 }
 
-
 .card {
-  background-color: #f3f2f1;
   padding: 16px;
   margin: 16px 0;
+  background-color: #f3f2f1;
+}
+
+/* COMMON CUSTOM CSS */
+
+.button-as-link {
+  cursor: pointer !important;
+
+  all: unset; /* Remove default button styles */
 }

--- a/submit/templates/submit/base.html
+++ b/submit/templates/submit/base.html
@@ -10,46 +10,64 @@
 {% block pageTitle %}{{ config['SUBMIT_SERVICE_NAME'] }} – GOV.UK{% endblock pageTitle %}
 
 {% block head %}
-<meta name="description" content="{{ config['SUBMIT_SERVICE_NAME'] }}">
-<meta name="keywords"
-  content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
-<meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-<link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
-<link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
-{% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
+  <meta name="description" content="{{ config['SUBMIT_SERVICE_NAME'] }}">
+  <meta name="keywords"
+    content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
+  <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for('.static', filename='govuk-frontend/govuk-frontend-5.6.0.min.css') }}" />
+  <link rel="shortcut icon" href="{{ url_for('static', filename='govuk-frontend/images/favicon.ico') }}">
+  {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock head %}
 
 {% block header %}
-{% if g.user %}
-{{ govukHeader({
-'homepageUrl': url_for('submit.index'),
-'serviceUrl': url_for('submit.index'),
-'serviceName': config['SUBMIT_SERVICE_NAME'],
-'navigation': [
-{
-'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
-'text': 'Sign out',
-},
-]
-}) }}
-{% else %}
-{{ govukHeader({
-'homepageUrl': url_for('submit.index'),
-'serviceUrl': url_for('submit.index'),
-'serviceName': config['SUBMIT_SERVICE_NAME'],
-}) }}
-{% endif %}
+  {% if g.user %}
+    {% set signOutButton %}
+      <form method="post" action="{{ config['AUTHENTICATOR_HOST'] + '/sso/logout' }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="button-as-link">
+            <a class="govuk-header__link">Sign out</a>
+        </button>
+      </form>
+    {% endset %}
+    {{
+      govukHeader(
+        {
+          'homepageUrl': url_for('submit.index'),
+          'serviceUrl': url_for('submit.index'),
+          'serviceName': config['SUBMIT_SERVICE_NAME'],
+          'navigation': [
+            {
+              'html': signOutButton,
+            }
+          ]
+        }
+      )
+    }}
+  {% else %}
+    {{
+      govukHeader(
+        {
+          'homepageUrl': url_for('submit.index'),
+          'serviceUrl': url_for('submit.index'),
+          'serviceName': config['SUBMIT_SERVICE_NAME'],
+        }
+      )
+    }}
+  {% endif %}
 {% endblock header %}
 
 {% block beforeContent %}
-{{ govukPhaseBanner({
-'tag': {
-'text': config['SUBMIT_SERVICE_PHASE']
-},
-'html': 'This is a new service – your <a class="govuk-link"
-  href="mailto:' + config['CONTACT_EMAIL'] +'?subject=Feedback">feedback</a> will help us to improve it.'
-}) }}
-
+  {{
+    govukPhaseBanner(
+      {
+        'tag': {
+        'text': config['SUBMIT_SERVICE_PHASE']
+      },
+      'html': 'This is a new service – your <a class="govuk-link"
+        href="mailto:' + config['CONTACT_EMAIL'] +'?subject=Feedback">feedback</a> will help us to improve it.'
+      }
+    )
+  }}
 {% endblock beforeContent %}
 
 {% block footer %}
@@ -77,7 +95,6 @@
     </div>
   </div>
 </footer>
-
 {% endblock footer %}
 
 {% block bodyEnd %}
@@ -87,6 +104,5 @@
       import { initAll } from '{{ govukFrontendJsURI }}'
       initAll()
   </script>
-{% assets "js" %}
-<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "js" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
 {% endblock bodyEnd %}

--- a/submit/templates/submit/main/login.html
+++ b/submit/templates/submit/main/login.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="govuk-width-container">
-    <h1 class="govuk-heading-l">Sign in to submit your data</h1>
+    <h1 class="govuk-heading-xl">Sign in to submit your data</h1>
     <p class="govuk-body">
       Sign in using the Microsoft account for your work email address.
     </p>


### PR DESCRIPTION
### Change description
Bit of scope creeping that crept in the scope:
- Fixing Jinja indentation for submit/base, submit/login, find/base and find/login
- find/login was doing a weird thing so, I brought in line with what submit/login does
- css formatting: there is a standard for the correct css attributes order - had that accidentally on and was applied over the whole custom.css file

### How to test
- Compare submit/login and find/login they will look similar now
- Try the Sign out buttons, they should look the same as before and work the same as befor

After merge we should remove the GET /sign-out endpoint from Authenticator.