### PR TITLE
Pathfinders bugfix - guard against duplicate outputs and outcomes within tables and across tables

### DIFF
--- a/data_store/table_extraction/config/pf_r2_config.py
+++ b/data_store/table_extraction/config/pf_r2_config.py
@@ -210,7 +210,7 @@ PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
         "validate": {
             "columns": {
                 "Intervention theme": string_column(),
-                "Output": string_column(),
+                "Output": string_column(unique=True, report_duplicates="exclude_first"),
                 "Unit of measurement": string_column(),
                 "Total cumulative outputs to date, (Up to and including Mar 2024), Actual": float_column(),
                 "Financial year 2024 to 2025, (Apr to Jun), Actual": float_column(),
@@ -249,7 +249,7 @@ PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
         "validate": {
             "columns": {
                 "Intervention theme": string_column(),
-                "Output": string_column(),
+                "Output": string_column(unique=True, report_duplicates="exclude_first"),
                 "Unit of measurement": string_column(),
                 "Total cumulative outputs to date, (Up to and including Mar 2024), Actual": float_column(),
                 "Financial year 2024 to 2025, (Apr to Jun), Actual": float_column(),
@@ -288,7 +288,7 @@ PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
         "validate": {
             "columns": {
                 "Intervention theme": string_column(),
-                "Outcome": string_column(),
+                "Outcome": string_column(unique=True, report_duplicates="exclude_first"),
                 "Unit of measurement": string_column(),
                 "Total cumulative outcomes to date, (Up to and including Mar 2024), Actual": float_column(),
                 "Financial year 2024 to 2025, (Apr to Jun), Actual": float_column(),
@@ -327,7 +327,7 @@ PF_TABLE_CONFIG: dict[str, dict[str, dict]] = {
         "validate": {
             "columns": {
                 "Intervention theme": string_column(),
-                "Outcome": string_column(),
+                "Outcome": string_column(unique=True, report_duplicates="exclude_first"),
                 "Unit of measurement": string_column(),
                 "Total cumulative outcomes to date, (Up to and including Mar 2024), Actual": float_column(),
                 "Financial year 2024 to 2025, (Apr to Jun), Actual": float_column(),

--- a/data_store/validation/pathfinders/consts.py
+++ b/data_store/validation/pathfinders/consts.py
@@ -46,6 +46,12 @@ class PFErrors:
     )
     LESS_THAN = "Amount must be less than {x}."
     LTE_X_WORDS = "Enter no more than {x} words."
+    OUTCOME_STANDARD_AND_BESPOKE = (
+        "You have entered the same outcome '{outcome}' in both the 'Standard Outcomes' and 'Bespoke Outcomes' tables."
+    )
+    OUTPUT_STANDARD_AND_BESPOKE = (
+        "You have entered the same output '{output}' in both the 'Standard Outputs' and 'Bespoke Outputs' tables."
+    )
     PHONE_NUMBER = "Enter a valid UK telephone number."
     PROJECT_NOT_ALLOWED = "Project name '{project_name}' is not allowed for this organisation."
     STANDARD_OUTCOME_NOT_ALLOWED = (

--- a/tests/data_store_tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r2.py
+++ b/tests/data_store_tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r2.py
@@ -7,6 +7,8 @@ from data_store.validation.pathfinders.cross_table_validation.ct_validate_r2 imp
     _check_bespoke_outputs,
     _check_current_underspend,
     _check_intervention_themes_in_pfcs,
+    _check_no_outcome_both_standard_and_bespoke,
+    _check_no_output_both_standard_and_bespoke,
     _check_projects,
     _check_standard_outcomes,
     cross_table_validate,
@@ -108,6 +110,50 @@ def test__check_bespoke_outputs_fails(mock_pf_r2_df_dict):
             section="Bespoke outputs",
             cell_indexes=("C1",),
             description="Bespoke output value 'Invalid Bespoke Output' is not allowed for this organisation.",
+            error_type=None,
+        )
+    ]
+
+
+def test__check_no_output_both_standard_and_bespoke_passes(mock_pf_r2_df_dict):
+    error_messages = _check_no_output_both_standard_and_bespoke(mock_pf_r2_df_dict)
+    assert error_messages == []
+
+
+def test__check_no_output_both_standard_and_bespoke_fails(mock_pf_r2_df_dict):
+    # Set the output in "Bespoke outputs" to be the same as in "Outputs"
+    output_value = mock_pf_r2_df_dict["Outputs"].loc[0, "Output"]
+    mock_pf_r2_df_dict["Bespoke outputs"].loc[0, "Output"] = output_value
+    error_messages = _check_no_output_both_standard_and_bespoke(mock_pf_r2_df_dict)
+    assert error_messages == [
+        Message(
+            sheet="Outputs",
+            section="Bespoke outputs",
+            cell_indexes=("C1",),
+            description=f"You have entered the same output '{output_value}' in both the 'Standard Outputs' and "
+            "'Bespoke Outputs' tables.",
+            error_type=None,
+        )
+    ]
+
+
+def test__check_no_outcome_both_standard_and_bespoke_passes(mock_pf_r2_df_dict):
+    error_messages = _check_no_outcome_both_standard_and_bespoke(mock_pf_r2_df_dict)
+    assert error_messages == []
+
+
+def test__check_no_outcome_both_standard_and_bespoke_fails(mock_pf_r2_df_dict):
+    # Set the outcome in "Bespoke outcomes" to be the same as in "Outcomes"
+    outcome_value = mock_pf_r2_df_dict["Outcomes"].loc[0, "Outcome"]
+    mock_pf_r2_df_dict["Bespoke outcomes"].loc[0, "Outcome"] = outcome_value
+    error_messages = _check_no_outcome_both_standard_and_bespoke(mock_pf_r2_df_dict)
+    assert error_messages == [
+        Message(
+            sheet="Outcomes",
+            section="Bespoke outcomes",
+            cell_indexes=("C1",),
+            description=f"You have entered the same outcome '{outcome_value}' in both the 'Standard Outcomes' and "
+            "'Bespoke Outcomes' tables.",
             error_type=None,
         )
     ]


### PR DESCRIPTION
This is a fix for a pre-existing problem with the code that basically meant that if a user entered the same output name more than once, even across both the "Standard outputs" and "Bespoke outputs" tables (as in, the user enters the same output in both tables), AND there is no matching output name in the database table `output_dim`, we get an uncaught database integrity error causing a 500 response, because of a lack of unique validation in the application and a unique constraint on `output_dim.output_name`. The same thing applies for outcomes.

Although it appears that at least one LA entered a duplicate output name for Pathfinders R1 (based on the fact that the test spreadsheet that Craig sent to me a couple days ago, which I believe contained the actual data as it was entered by one of the LAs, contained a duplicate output name), my theory is that we didn't see any error then because the submission containing the duplicated output name was by chance submitted after a submission containing the same output name, but not duplicated across tables, which meant that the output name was inserted into `output_dim` okay. And then when the submission with duplicated output names was submitted afterwards, and `funding-service-design-post-award-data-store/data_store/controllers/load_functions.py::get_outcomes_outputs_to_insert` was run to filter out existing outputs, the duplicated output name was filtered out and the application never attempted to insert it into `output_dim`, so no error was thrown. Again, the same thing applies for outcomes.

The code in this PR applies in-table and cross-table checks to ensure all outputs and outcomes entered are unique. It ensures that we never reach a stage where a database integrity error is possible.

This branch was checked out from `RFP-453_pathfinders-round-2` as it contains R2-specific code. It is not _essential_ to merge this - as I mention above, we got lucky in R1 and we now likely have most (if not all, I haven't checked) of the available output and outcome names already in the `output_dim` and `outcome_dim` tables, which means an error is even less likely this time around. Merging this may also have unintended consequences in terms of preventing users from submitting data in the way they expect (i.e., do we actually _know_ that having the same output name in both standard and bespoke outputs is wrong?). However, I wanted to leave this PR here to give the option if we do decide this problem needs fixing, and wanted to avoid database load changes / migrations.