### PR TITLE
Update start date for pathfinders r2

### DIFF
--- a/data_store/transformation/pathfinders/pf_transform_r2.py
+++ b/data_store/transformation/pathfinders/pf_transform_r2.py
@@ -12,7 +12,7 @@ from data_store.transformation.utils import create_dataframe, extract_postcodes
 
 FAS_REPORTING_PERIOD_HEADERS_TO_DATES = {
     "Total cumulative actuals to date, (Up to and including Mar 2024)": {
-        "start": datetime(2024, 1, 1),
+        "start": datetime(2019, 1, 1),
         "end": datetime(2024, 3, 31, 23, 59, 59),
     },
     "Financial year 2024 to 2025, (Apr to Jun)": {
@@ -52,7 +52,7 @@ FAS_REPORTING_PERIOD_HEADERS_TO_DATES = {
 
 OUTPUT_REPORTING_PERIOD_HEADERS_TO_DATES = {
     "Total cumulative outputs to date, (Up to and including Mar 2024)": {
-        "start": datetime(2024, 1, 1),
+        "start": datetime(2019, 1, 1),
         "end": datetime(2024, 3, 31, 23, 59, 59),
     },
     "Financial year 2024 to 2025, (Apr to Jun)": {
@@ -92,7 +92,7 @@ OUTPUT_REPORTING_PERIOD_HEADERS_TO_DATES = {
 
 OUTCOME_REPORTING_PERIOD_HEADERS_TO_DATES = {
     "Total cumulative outcomes to date, (Up to and including Mar 2024)": {
-        "start": datetime(2024, 1, 1),
+        "start": datetime(2019, 1, 1),
         "end": datetime(2024, 3, 31, 23, 59, 59),
     },
     "Financial year 2024 to 2025, (Apr to Jun)": {

--- a/tests/data_store_tests/transformation_tests/pathfinders/test_pf_transform_r2.py
+++ b/tests/data_store_tests/transformation_tests/pathfinders/test_pf_transform_r2.py
@@ -204,6 +204,11 @@ def test__funding_data(
     first_start_date = "2024-01-01"
     last_start_date = "2026-01-01"
     start_dates = list(pd.date_range(start=first_start_date, end=last_start_date, freq="QS"))
+
+    # The actual start date for "Total cumulative actuals to date, (Up to and including Mar 2024)" is 2019-01-01,
+    # as per agreement with PF team.
+    start_dates[0] = start_dates[0].replace(year=2019)
+
     end_dates = [
         ((start_dates[i] - pd.Timedelta(days=1)).replace(hour=23, minute=59, second=59))
         for i in range(1, len(start_dates))
@@ -240,6 +245,11 @@ def test__outputs(
     first_start_date = "2024-01-01"
     last_start_date = "2026-04-01"
     start_dates = list(pd.date_range(start=first_start_date, end=last_start_date, freq="QS"))
+
+    # The actual start date for "Total cumulative actuals to date, (Up to and including Mar 2024)" is 2019-01-01,
+    # as per agreement with PF team.
+    start_dates[0] = start_dates[0].replace(year=2019)
+
     end_dates = [
         ((start_dates[i] - pd.Timedelta(days=1)).replace(hour=23, minute=59, second=59))
         for i in range(1, len(start_dates))
@@ -283,6 +293,11 @@ def test__outcomes(
     first_start_date = "2024-01-01"
     last_start_date = "2026-04-01"
     start_dates = list(pd.date_range(start=first_start_date, end=last_start_date, freq="QS"))
+
+    # The actual start date for "Total cumulative actuals to date, (Up to and including Mar 2024)" is 2019-01-01,
+    # as per agreement with PF team.
+    start_dates[0] = start_dates[0].replace(year=2019)
+
     end_dates = [
         ((start_dates[i] - pd.Timedelta(days=1)).replace(hour=23, minute=59, second=59))
         for i in range(1, len(start_dates))


### PR DESCRIPTION
### Change description
As part of the changes for Pathfinders Round 2, we've updated the headers for some of the tables to include "everything so far up to march 2024". The start date for these was previously unclear but Pathfinders team have recently clarified that it should be considered 2019-01-01, so let's update.