### PR TITLE
Add watchdog for celery auto refresh

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,6 +2,7 @@
 
 debugpy
 pydot==1.4.2  # ERD diagram
+watchdog==5.0.3  # Celery auto-reload
 
 #-----------------------------------
 #   Testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -173,8 +173,8 @@ govuk-frontend-wtf==3.1.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via
-    #   -r requirements.txt
     #   playwright
+    #   sqlalchemy
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -505,6 +505,8 @@ vine==5.1.0
     #   kombu
 virtualenv==20.25.0
     # via pre-commit
+watchdog==5.0.3
+    # via -r requirements-dev.in
 wcwidth==0.2.13
     # via
     #   -r requirements.txt


### PR DESCRIPTION
### Change description
Add `watchdog` dependency to celery auto refresh.
 
### How to test
- Pull this branch
- Pull docker-runner branch from [this PR](https://github.com/communitiesuk/funding-service-design-post-award-docker-runner/pull/50)
- Run docker runner
- Download a find report
- Make a change to any .py file in the project (I added a print in the download async function)
- You will not see docker-runner say that celery was restarted
- OR if you added a `print` you will not see it printed on download
- Stop docker runner
- Set inside the docker runner CELERY_AUTO_REFRESH to `true`
- Start docker runner
- Make a change to any .py file in the project (I added a print in the download async function)
- You will not see docker-runner say that celery was restarted
- OR if you added a `print` you will not see it printed on download