### PR TITLE
Use Parameter Store variable to allow activation of PF R2 on all environments

### DIFF
--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -48,6 +48,7 @@ variables:
   AWS_S3_BUCKET_FIND_DOWNLOAD_FILES:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-postawardfinddownloadfilesBucketName
   ACCOUNT_STORE_API_HOST: "http://fsd-account-store:8080"
+  ENABLE_PF_R2: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_ENABLE_PF_R2
 
 # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 secrets:
@@ -100,7 +101,6 @@ environments:
       COOKIE_DOMAIN: '.test.access-funding.test.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.test.access-funding.test.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.test.access-funding.test.levellingup.gov.uk
-      ENABLE_PF_R2: true
     sidecars:
       nginx:
         port: 8087
@@ -130,7 +130,6 @@ environments:
       COOKIE_DOMAIN: '.dev.access-funding.test.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-      ENABLE_PF_R2: true
     sidecars:
       nginx:
         port: 8087


### PR DESCRIPTION
### Ticket

[Deploy code live and enable Round 2 reporting from given start date](https://dluhcdigital.atlassian.net/browse/FPASF-580)

### Description

Using AWS Parameter Store to configure `ENABLE_PF_R2` on all AWS envs (dev, test and prod) ready for PF R2.
