### PR TITLE
Create and use FKMapping class in mappings.py module

### DIFF
--- a/data_store/controllers/mappings.py
+++ b/data_store/controllers/mappings.py
@@ -19,10 +19,10 @@ from data_store.util import move_data_to_jsonb_blob
 
 @dataclass
 class FKMapping:
-    parent_lookup: str | tuple[str, str]  # Lookup attribute(s) in the parent model
+    parent_lookups: list[str]  # Lookup attribute(s) in the parent model
     parent_model: Type[BaseModel]  # Parent model class
     child_fk: str  # Attribute name of the FK in the child model
-    child_lookup: str | tuple[str, str]  # Column name(s) in the child data frame
+    child_lookups: list[str]  # Column name(s) in the child data frame
 
 
 @dataclass
@@ -78,15 +78,15 @@ class DataMapping:
         for row in data_rows:
             # create foreign key relations
             for fk_mapping in self.fk_relations:
-                parent_lookup = fk_mapping.parent_lookup
+                parent_lookups = fk_mapping.parent_lookups
                 parent_model = fk_mapping.parent_model
                 child_fk = fk_mapping.child_fk
-                child_lookup = fk_mapping.child_lookup
+                child_lookups = fk_mapping.child_lookups
 
                 # 'programme_junction_id' requires two look-ups
                 if child_fk == "programme_junction_id":
-                    programme_parent_lookup, submission_parent_lookup = parent_lookup
-                    programme_child_lookup, submission_child_lookup = child_lookup
+                    programme_parent_lookup, submission_parent_lookup = parent_lookups
+                    programme_child_lookup, submission_child_lookup = child_lookups
                     lookups = {
                         programme_parent_lookup: self.get_row_id(
                             ents.Programme, {programme_parent_lookup: row.get(programme_child_lookup)}
@@ -101,14 +101,14 @@ class DataMapping:
                         del row[submission_child_lookup]
                 else:
                     # different funds will lack certain look-ups
-                    if not row.get(child_lookup):
+                    if not row.get(child_lookups[0]):
                         continue
 
                     # find parent entity via this lookup
-                    lookups = {parent_lookup: row[child_lookup]}
+                    lookups = {parent_lookups[0]: row[child_lookups[0]]}
 
-                    if child_fk != child_lookup:
-                        del row[child_lookup]
+                    if child_fk != child_lookups[0]:
+                        del row[child_lookups[0]]
 
                 # set the child FK to match the parent PK
                 # project id needs to be looked up via the project's programme junction
@@ -176,16 +176,16 @@ INGEST_MAPPINGS = (
         },
         fk_relations=[
             FKMapping(
-                parent_lookup="organisation_name",
+                parent_lookups=["organisation_name"],
                 parent_model=ents.Organisation,
                 child_fk="organisation_id",
-                child_lookup="organisation",
+                child_lookups=["organisation"],
             ),
             FKMapping(
-                parent_lookup="fund_code",
+                parent_lookups=["fund_code"],
                 parent_model=ents.Fund,
                 child_fk="fund_type_id",
-                child_lookup="fund_type_id",
+                child_lookups=["fund_type_id"],
             ),
         ],
     ),
@@ -199,16 +199,16 @@ INGEST_MAPPINGS = (
         },
         fk_relations=[
             FKMapping(
-                parent_lookup="submission_id",
+                parent_lookups=["submission_id"],
                 parent_model=ents.Submission,
                 child_fk="submission_id",
-                child_lookup="submission_id",
+                child_lookups=["submission_id"],
             ),
             FKMapping(
-                parent_lookup="programme_id",
+                parent_lookups=["programme_id"],
                 parent_model=ents.Programme,
                 child_fk="programme_id",
-                child_lookup="programme_id",
+                child_lookups=["programme_id"],
             ),
         ],
     ),
@@ -227,10 +227,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -251,10 +251,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -277,10 +277,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -308,10 +308,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -348,10 +348,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
         ],
     ),
@@ -381,16 +381,16 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -404,10 +404,10 @@ INGEST_MAPPINGS = (
         cols_to_jsonb=["comment"],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
         ],
     ),
@@ -431,10 +431,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
         ],
     ),
@@ -469,22 +469,22 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
             FKMapping(
-                parent_lookup="output_name",
+                parent_lookups=["output_name"],
                 parent_model=ents.OutputDim,
                 child_fk="output_id",
-                child_lookup="output",
+                child_lookups=["output"],
             ),
         ],
     ),
@@ -518,22 +518,22 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
             FKMapping(
-                parent_lookup="outcome_name",
+                parent_lookups=["outcome_name"],
                 parent_model=ents.OutcomeDim,
                 child_fk="outcome_id",
-                child_lookup="outcome",
+                child_lookups=["outcome"],
             ),
         ],
     ),
@@ -573,16 +573,16 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup="project_id",
+                parent_lookups=["project_id"],
                 parent_model=ents.Project,
                 child_fk="project_id",
-                child_lookup="project_id",
+                child_lookups=["project_id"],
             ),
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -617,10 +617,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),
@@ -643,10 +643,10 @@ INGEST_MAPPINGS = (
         ],
         fk_relations=[
             FKMapping(
-                parent_lookup=("programme_id", "submission_id"),
+                parent_lookups=["programme_id", "submission_id"],
                 parent_model=ents.ProgrammeJunction,
                 child_fk="programme_junction_id",
-                child_lookup=("programme_id", "submission_id"),
+                child_lookups=["programme_id", "submission_id"],
             ),
         ],
     ),

--- a/tests/data_store_tests/controller_tests/test_mappings.py
+++ b/tests/data_store_tests/controller_tests/test_mappings.py
@@ -42,10 +42,10 @@ def test_data_mapping(mocked_get_row_id):
 
     # foreign key relation
     fk_mapping = FKMapping(
-        parent_lookup="parent_lookup",
+        parent_lookups=["parent_lookup"],
         parent_model=MockParentModel,
         child_fk="fk",
-        child_lookup="fk_lookup_col",
+        child_lookups=["fk_lookup_col"],
     )
     mapping.fk_relations.append(fk_mapping)
 
@@ -79,10 +79,10 @@ def test_data_mapping_project_id_fk(mocked_get_row_id):
 
     # project_id foreign key relation
     fk_mapping = FKMapping(
-        parent_lookup="parent_lookup",
+        parent_lookups=["parent_lookup"],
         parent_model=MockParentModel,
         child_fk="programme_id",
-        child_lookup="fk_lookup_col",
+        child_lookups=["fk_lookup_col"],
     )
     mapping.fk_relations.append(fk_mapping)
 
@@ -110,10 +110,10 @@ def test_data_mapping_child_fk_attribute_matches_lookup_attribute(mocked_get_row
 
     # project_id foreign key relation
     fk_mapping = FKMapping(
-        parent_lookup="parent_lookup",
+        parent_lookups=["parent_lookup"],
         parent_model=MockParentModel,
         child_fk="child_fk_and_lookup",
-        child_lookup="child_fk_and_lookup",
+        child_lookups=["child_fk_and_lookup"],
     )
     mapping.fk_relations.append(fk_mapping)
 

--- a/tests/data_store_tests/controller_tests/test_mappings.py
+++ b/tests/data_store_tests/controller_tests/test_mappings.py
@@ -19,7 +19,7 @@ class MockParentModel:
     """Mocks a parent SQL Model to test a FKMapping with."""
 
     def __init__(self):
-        # this attribute must exist as per the FKMapping instantiated in test_data_mapping, the value in unimportant
+        # this attribute must exist as per the FKMapping instantiated in test_data_mapping, the value is unimportant
         self.parent_lookup = "mocked"
 
 
@@ -42,7 +42,10 @@ def test_data_mapping(mocked_get_row_id):
 
     # foreign key relation
     fk_mapping = FKMapping(
-        parent_lookup="parent_lookup", parent_model=MockParentModel, child_fk="fk", child_lookup="fk_lookup_col"
+        parent_lookup="parent_lookup",
+        parent_model=MockParentModel,
+        child_fk="fk",
+        child_lookup="fk_lookup_col",
     )
     mapping.fk_relations.append(fk_mapping)
 
@@ -92,7 +95,7 @@ def test_data_mapping_project_id_fk(mocked_get_row_id):
 
 def test_data_mapping_child_fk_attribute_matches_lookup_attribute(mocked_get_row_id):
     """Test the special path for when a child fk attribute name is the same as the lookup attribute.
-    In this case, do don't want to delete the child attribute lookup because it's value has been replaced with the FK.
+    In this case, we don't want to delete the child attribute lookup because its value has been replaced with the FK.
     """
     # sample worksheet and mapping
     worksheet = pd.DataFrame(
@@ -154,6 +157,6 @@ def test_data_mapping_event_data_to_jsonb(mocked_get_row_id):
 
     assert len(df_with_jsonb.columns) == 2
     assert_series_equal(df_with_jsonb["fk_1"], expected_df["fk_1"])
-    # cannot use assert_series_equal as it attempt to account for order of keys in json_blob
+    # cannot use assert_series_equal as it attempts to account for order of keys in json_blob
     assert df_with_jsonb["data_blob"][0]["event_data_1"] == expected_df["data_blob"][0]["event_data_1"]
     assert df_with_jsonb["data_blob"][0]["event_data_2"] == expected_df["data_blob"][0]["event_data_2"]


### PR DESCRIPTION
### Ticket

No ticket created - happy to create one.

### Description

Database load has always been a bit of a pain point in our code. So rather than just talk of a big future refactor, I thought I'd begin with an incremental improvement to readability that I spotted as an opportunity a while back. Basically, in the mappings module at the moment, we have a namedtuple `FKMapping` defined but then not used at all (except in tests), and then we have unlabelled tuples used throughout the rest of the module for the `fk_relations` attribute of `DataMapping` instances. This PR replaces the namedtuple with a dataclass and then actually uses this throughout the module, improving readability by making it obvious what each element represents in each `DataMapping`'s `fk_relations` list.