### PR TITLE
Fix e2e tests when running locally

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,6 +157,8 @@ def create_app(config_class=Config) -> Flask:
             "'sha256-vTmCV6LqM520vOLtAZ7+WhSSsaFOONqhCgj+dmpjQak='",  # `color: #333333`
             "'sha256-30uhPRk8bIWOPPNKfIRLXY96DVXF/ZHnfIZz8OBS/eg='",  # `color: #008800; font-weight: bold`
             "'sha256-SAqGh+YBD7v4qJypLeMBSlsddU4Qd67qmTMVRroKuqk='",  # `color: #0000DD; font-weight: bold`
+            "'sha256-rietEaLOHfqNF3pcuzajo55dYo9i4UtLS6HN0KrBhbg='",  # `color: #007020`
+            "'sha256-Ut0gFM7k9Dr9sRq/kXKsPL4P6Rh8XX0Vt+tKzrdJo7A='",  # `user-select: none;`
         ]
 
     # We explicitly allow some hashes here because flask-debugtoolbar does not support CSP nonces. If we upgrade

--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ def create_app(config_class=Config) -> Flask:
         toolbar = DebugToolbarExtension(flask_app)
 
         content_security_policy["script-src"] += [
+            # `var DEBUG_TOOLBAR_STATIC_PATH = '/_debug_toolbar/static/'`
             "'sha256-zWl5GfUhAzM8qz2mveQVnvu/VPnCS6QL7Niu6uLmoWU='",
         ]
 

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -17,6 +17,7 @@ class DevelopmentConfig(DefaultConfig):
     SQLALCHEMY_RECORD_QUERIES = True
 
     DEBUG_TB_ENABLED = True
+    DEBUG_TB_INTERCEPT_REDIRECTS = False
     DEBUG_TB_ROUTES_HOST = "*"
 
     # RSA 256 KEYS

--- a/tests/e2e_tests/pages/find.py
+++ b/tests/e2e_tests/pages/find.py
@@ -88,7 +88,7 @@ class FindRequestDataPage(BasePage):
         self.page.locator("#to-year").select_option(to_year)
 
     def select_file_format(self, file_format: Literal["XLSX (Microsoft Excel)", "JSON"]):
-        self.page.get_by_text(file_format).click()
+        self.page.get_by_label(file_format).click()
 
     def request_data(self) -> "FindRequestDataSuccessPage":
         request_data_button = self.page.get_by_role("button", name="Confirm and request data")

--- a/tests/e2e_tests/pages/submit.py
+++ b/tests/e2e_tests/pages/submit.py
@@ -10,7 +10,7 @@ class SubmitDashboardPage(BasePage):
         self.page.goto(f"{self.domain}/dashboard")
 
     def click_fund(self, fund_name: str) -> "SubmitUploadPage":
-        self.page.get_by_text(fund_name).click()
+        self.page.get_by_role("link", name=fund_name).click()
 
         return SubmitUploadPage(self.page)
 


### PR DESCRIPTION
When flask-debugtoolbar is enabled locally, it injects a lot of HTML onto the page to
help explain what's happened when processing the request. This has
subtly broken our e2e tests (but only when running locally with
flask-debugtoolbar enabled).

The easy part of the fix is to tweak our selectors for key elements
during the find and submit tests. When selecting a radio button for file
type, specifically select the input label. When clicking a link for
Pathfinders, specifically look for a link.

We also turn off flask-debugtoolbar redirect interception by default, so that e2e tests
don't have to deal with that.

---

Finally, the e2e tests flagged some more CSP hashes we "need" to add for a couple of obscure flask-debugtoolbar inline styles 🙃 