### PR TITLE
Add SubmissionDate to download's SubmissionRef section

### DIFF
--- a/data_store/db/queries.py
+++ b/data_store/db/queries.py
@@ -638,6 +638,7 @@ def submission_metadata_query(base_query: Query) -> Query:
         ents.ReportingRound.observation_period_start,
         ents.ReportingRound.observation_period_end,
         ents.ReportingRound.round_number,
+        ents.Submission.submission_date,
     ).distinct()
 
 

--- a/data_store/serialisation/data_serialiser.py
+++ b/data_store/serialisation/data_serialiser.py
@@ -530,3 +530,4 @@ class SubmissionSchema(SQLAlchemySchema):
         "observation_period_end", model=ReportingRound, data_key="ReportingPeriodEnd", field_class=Raw
     )
     reporting_round = auto_field("round_number", model=ReportingRound, data_key="ReportingRound")
+    submission_date = auto_field(data_key="SubmissionDate", field_class=Raw)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,7 @@ def additional_test_data() -> dict[str, Any]:
     submission = Submission(
         submission_id="TEST-SUBMISSION-ID",
         reporting_round=reporting_round,
+        submission_date=datetime(2024, 10, 1),
     )
 
     organisation = Organisation(organisation_name="TEST-ORGANISATION")

--- a/tests/data_store_tests/serialisation_tests/test_serialisation.py
+++ b/tests/data_store_tests/serialisation_tests/test_serialisation.py
@@ -275,6 +275,7 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
         "ReportingPeriodStart",
         "ReportingPeriodEnd",
         "ReportingRound",
+        "SubmissionDate",
     ]
     assert list(pd.DataFrame.from_records(test_serialised_data["ProgrammeManagementFunding"]).columns) == [
         "SubmissionID",
@@ -363,6 +364,7 @@ def test_serialise_submission_metadata(seeded_test_client, additional_test_data)
         "ReportingPeriodStart": datetime.datetime(2022, 10, 1, 0, 0),
         "ReportingPeriodEnd": datetime.datetime(2023, 3, 31, 23, 59, 59),
         "ReportingRound": 3,
+        "SubmissionDate": datetime.datetime(1945, 12, 3),
     } in test_serialised_data["SubmissionRef"]
 
     assert {
@@ -371,6 +373,7 @@ def test_serialise_submission_metadata(seeded_test_client, additional_test_data)
         "ReportingPeriodStart": datetime.datetime(2019, 10, 10, 0, 0),
         "ReportingPeriodEnd": datetime.datetime(2021, 10, 10, 0, 0),
         "ReportingRound": 1,
+        "SubmissionDate": datetime.datetime(2024, 10, 1),
     } in test_serialised_data["SubmissionRef"]
 
 

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -104,6 +104,7 @@ def test_multiple_rounds_multiple_funds_end_to_end(
 
     assert_frame_equal(expected_programme_ref, df_dict["ProgrammeRef"])
 
+    now = datetime.now()
     expected_submission_ref = pd.DataFrame(
         {
             "SubmissionID": ["S-PF-R01-1", "S-R03-1", "S-R04-1"],
@@ -119,8 +120,13 @@ def test_multiple_rounds_multiple_funds_end_to_end(
                 datetime(2023, 9, 30, 23, 59, 59),
             ],
             "ReportingRound": [1, 3, 4],
+            "SubmissionDate": [pd.Timestamp(now), pd.Timestamp(now), pd.Timestamp(now)],
         }
     )
+
+    # Round the SubmissionDate to the nearest minute for comparison
+    expected_submission_ref["SubmissionDate"] = expected_submission_ref["SubmissionDate"].dt.round("min")
+    df_dict["SubmissionRef"]["SubmissionDate"] = df_dict["SubmissionRef"]["SubmissionDate"].dt.round("min")
 
     assert_frame_equal(expected_submission_ref, df_dict["SubmissionRef"])
 


### PR DESCRIPTION
Ticket:
https://dluhcdigital.atlassian.net/browse/FPASF-588

Description:
This is the first step of the work in the ticket, to add "SubmissionDate" to the "SubmissionRef" section of the data extract.

Screenshot:
![Screenshot 2024-10-04 at 09 18 09](https://github.com/user-attachments/assets/28f0d5b2-f986-4912-b68b-3c8866248ed2)



