### PR TITLE
Bau/towns fund notify email update

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -86,8 +86,11 @@ class DefaultConfig(object):
     # Gov Notify for confirmation emails
     SEND_CONFIRMATION_EMAILS = True
     NOTIFY_API_KEY = os.environ.get("NOTIFY_API_KEY")
-    LA_CONFIRMATION_EMAIL_TEMPLATE_ID = os.environ.get(
+    PATHFINDERS_CONFIRMATION_EMAIL_TEMPLATE_ID = os.environ.get(
         "LA_CONFIRMATION_EMAIL_TEMPLATE_ID", "e9397bff-7767-4557-bd39-fbcb2ef6217b"
+    )
+    TOWNS_FUND_CONFIRMATION_EMAIL_TEMPLATE_ID = os.environ.get(
+        "TOWNS_FUND_CONFIRMATION_EMAIL_TEMPLATE_ID", "7a5b28e2-c25a-4d92-89ed-72791eec3c1d"
     )
     TF_CONFIRMATION_EMAIL_ADDRESS = os.environ.get("TF_CONFIRMATION_EMAIL_ADDRESS", "fake.email@townsfund.gov.uk")
     PF_CONFIRMATION_EMAIL_ADDRESS = os.environ.get("PF_CONFIRMATION_EMAIL_ADDRESS", "fake.email@pathfinders.gov.uk")

--- a/data_store/controllers/notify.py
+++ b/data_store/controllers/notify.py
@@ -37,7 +37,7 @@ def send_la_confirmation_emails(
 ):
     send_email(
         email_address=user_email,
-        template_id=Config.LA_CONFIRMATION_EMAIL_TEMPLATE_ID,
+        template_id=fund.la_confirmation_email_template,
         notify_key=Config.NOTIFY_API_KEY,
         personalisation={
             "name_of_fund": fund.fund_name,

--- a/submit/main/fund.py
+++ b/submit/main/fund.py
@@ -7,7 +7,6 @@ FundConfig "current" attributes must be updated ready for a new round of reporti
 """
 
 import datetime
-import re
 
 from config import Config
 from submit.main.authorisation import AuthBase, PFAuth, TFAuth
@@ -48,19 +47,6 @@ class FundConfig:
             types.
         :raises ValueError: If confirmation_email is not a valid email.
         """
-        assert isinstance(fund_name, str), "Fund name must be a string"
-        assert isinstance(user_role, str), "Role must be a string"
-        assert isinstance(email, str), "Deadline must be a str"
-        assert isinstance(current_deadline, datetime.date), "Deadline must be a datetime.date"
-        assert re.match(
-            r"^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$", email, re.IGNORECASE
-        ), "Confirmation email must be a valid email"
-        assert isinstance(active, bool), "Active must be a bool"
-        assert issubclass(auth_class, AuthBase), "Auth class must be an implementation of AuthBase"
-        assert isinstance(current_reporting_period, str), "Reporting period must be a string"
-        assert isinstance(current_reporting_round, int), "Reporting round must be an int"
-        assert isinstance(current_deadline, datetime.date), "Deadline must be a datetime.date"
-
         self.fund_name = fund_name
         self.fund_code = fund_code
         self.user_role = user_role

--- a/submit/main/fund.py
+++ b/submit/main/fund.py
@@ -24,6 +24,7 @@ class FundConfig:
         fund_code: str,
         user_role: str,
         email: str,
+        la_confirmation_email_template: str,
         active: bool,
         auth_class: type[AuthBase],
         current_reporting_period: str,
@@ -51,6 +52,7 @@ class FundConfig:
         self.fund_code = fund_code
         self.user_role = user_role
         self.email = email
+        self.la_confirmation_email_template = la_confirmation_email_template
         self.active = active
         self.auth_class = auth_class
         self.current_reporting_period = current_reporting_period
@@ -86,6 +88,7 @@ TOWNS_FUND_APP_CONFIG = FundConfig(
     current_reporting_round=5,
     current_deadline=datetime.date(day=28, month=5, year=2024),
     email=Config.TF_CONFIRMATION_EMAIL_ADDRESS,
+    la_confirmation_email_template=Config.TOWNS_FUND_CONFIRMATION_EMAIL_TEMPLATE_ID,
     active=True if Config.ENABLE_TF_R5 else False,
     auth_class=TFAuth,
     fund_code="TF",
@@ -98,6 +101,7 @@ PATHFINDERS_APP_CONFIG = FundConfig(
     current_reporting_round=2,
     current_deadline=datetime.date(day=1, month=11, year=2024),
     email=Config.PF_CONFIRMATION_EMAIL_ADDRESS,
+    la_confirmation_email_template=Config.PATHFINDERS_CONFIRMATION_EMAIL_TEMPLATE_ID,
     active=True if Config.ENABLE_PF_R2 else False,
     auth_class=PFAuth,
     fund_code="PF",

--- a/submit/main/routes.py
+++ b/submit/main/routes.py
@@ -114,19 +114,16 @@ def upload(fund_code, round):  # noqa: C901
 
                 try:
                     send_la_confirmation_emails(
+                        fund=fund,
+                        fund_type=metadata.get("FundType_ID") or "",
                         filename=excel_file.filename,
-                        fund_name=fund.fund_name,
-                        current_reporting_period=fund.current_reporting_period,
                         user_email=g.user.email,
                         programme_name=metadata.get("Programme Name") or "",
-                        fund_type=metadata.get("FundType_ID") or "",
                     )
                     send_fund_confirmation_email(
-                        fund_name=fund.fund_name,
-                        fund_email=fund.email,
-                        round_number=fund.current_reporting_round,
-                        programme_name=metadata.get("Programme Name") or "",
+                        fund=fund,
                         fund_type=metadata.get("FundType_ID") or "",
+                        programme_name=metadata.get("Programme Name") or "",
                         programme_id=metadata.get("Programme ID") or "",
                     )
                 except ValueError as error:

--- a/tests/data_store_tests/controller_tests/test_notify.py
+++ b/tests/data_store_tests/controller_tests/test_notify.py
@@ -70,7 +70,7 @@ def test_send_la_confirmation_emails_success(mocker):
 
     mock_send_email.assert_called_once_with(
         email_address=user_email,
-        template_id=Config.LA_CONFIRMATION_EMAIL_TEMPLATE_ID,
+        template_id=Config.PATHFINDERS_CONFIRMATION_EMAIL_TEMPLATE_ID,
         notify_key=Config.NOTIFY_API_KEY,
         personalisation={
             "name_of_fund": PATHFINDERS_APP_CONFIG.fund_name,
@@ -135,9 +135,9 @@ def test_send_fund_confirmation_emails_success(mocker, find_test_client):
 
     send_fund_confirmation_email(
         fund=PATHFINDERS_APP_CONFIG,
+        fund_type=fund_type,
         programme_id="AAAA001",
         programme_name=programme_name,
-        fund_type=fund_type,
     )
 
     mock_send_email.assert_called_once_with(

--- a/tests/data_store_tests/controller_tests/test_notify.py
+++ b/tests/data_store_tests/controller_tests/test_notify.py
@@ -11,6 +11,7 @@ from requests import Response
 from config import Config
 from data_store.controllers.notify import send_email, send_fund_confirmation_email, send_la_confirmation_emails
 from data_store.db.entities import Submission
+from submit import PATHFINDERS_APP_CONFIG
 
 
 @pytest.fixture
@@ -58,16 +59,13 @@ def test_send_la_confirmation_emails_success(mocker):
     filename = "test_file.xlsx"
     user_email = "user@example.com"
     programme_name = "Test Programme"
-    fund_name = "Test Fund"
-    current_reporting_period = "Q1 2024"
 
     send_la_confirmation_emails(
+        fund=PATHFINDERS_APP_CONFIG,
+        fund_type="PF",
         filename=filename,
         user_email=user_email,
-        fund_name=fund_name,
-        current_reporting_period=current_reporting_period,
         programme_name=programme_name,
-        fund_type="PF",
     )
 
     mock_send_email.assert_called_once_with(
@@ -75,8 +73,8 @@ def test_send_la_confirmation_emails_success(mocker):
         template_id=Config.LA_CONFIRMATION_EMAIL_TEMPLATE_ID,
         notify_key=Config.NOTIFY_API_KEY,
         personalisation={
-            "name_of_fund": fund_name,
-            "reporting_period": current_reporting_period,
+            "name_of_fund": PATHFINDERS_APP_CONFIG.fund_name,
+            "reporting_period": PATHFINDERS_APP_CONFIG.current_reporting_period,
             "filename": filename,
             "place_name": programme_name,
             "fund_type": "Pathfinders",
@@ -98,18 +96,13 @@ def test_send_fund_confirmation_emails_no_submission(mocker):
         return_value=None,
     )
 
-    round_number = 1
-    fund_email = "user@example.com"
     programme_name = "Test Programme"
-    fund_name = "Fund name"
 
     with pytest.raises(ValueError, match="Submission not found"):
         send_fund_confirmation_email(
-            fund_name=fund_name,
-            fund_email=fund_email,
-            round_number=round_number,
-            programme_name=programme_name,
+            fund=PATHFINDERS_APP_CONFIG,
             fund_type="PF",
+            programme_name=programme_name,
             programme_id="AAAA001",
         )
 
@@ -138,26 +131,21 @@ def test_send_fund_confirmation_emails_success(mocker, find_test_client):
         return_value=Submission(submission_id="S-R03-1", id=submission_id),
     )
 
-    round_number = 1
-    fund_email = "user@example.com"
     programme_name = "Test Programme"
-    fund_name = "Fund name"
 
     send_fund_confirmation_email(
-        fund_name=fund_name,
-        fund_email=fund_email,
-        round_number=round_number,
+        fund=PATHFINDERS_APP_CONFIG,
+        programme_id="AAAA001",
         programme_name=programme_name,
         fund_type=fund_type,
-        programme_id="AAAA001",
     )
 
     mock_send_email.assert_called_once_with(
-        email_address=fund_email,
+        email_address=PATHFINDERS_APP_CONFIG.email,
         template_id=Config.FUND_CONFIRMATION_EMAIL_TEMPLATE_ID,
         notify_key=Config.NOTIFY_API_KEY,
         personalisation={
-            "name_of_fund": fund_name,
+            "name_of_fund": PATHFINDERS_APP_CONFIG.fund_name,
             "filename": "long-file-name.xlsx",
             "place_name": programme_name,
             "date_of_submission": datetime.now().strftime("%e %B %Y at %H:%M").strip(),

--- a/tests/submit_tests/test_fund.py
+++ b/tests/submit_tests/test_fund.py
@@ -1,5 +1,4 @@
 import datetime
-from copy import copy
 
 import pytest
 
@@ -45,66 +44,3 @@ def test_get_active_funds_raises_value_error(test_fund_service):
     fund_configs = test_fund_service.get_active_funds(["Non-existent Role"])
 
     assert not fund_configs
-
-
-def test_fund_config_validations():
-    valid_fund_attrs = dict(
-        fund_name="Test Fund Name",
-        current_reporting_period="Test Reporting Period",
-        current_reporting_round=1,
-        current_deadline=datetime.date(day=1, month=1, year=2001),
-        email="testemail@test.gov.uk",
-        active=True,
-        auth_class=AuthBase,
-        user_role="Test Role",
-        fund_code="TF",
-    )
-
-    # success
-    FundConfig(**valid_fund_attrs)
-
-    # fails
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["fund_name"] = 1234  # not a string
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["current_reporting_period"] = 1234  # not a string
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["current_reporting_round"] = "1234"  # not an int
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["current_deadline"] = "1/1/2001"  # not a datetime
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["email"] = 1234  # not a string
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["email"] = "test.gov.uk"  # not a valid email address
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["active"] = "Not a boolean"  # not a boolean
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["auth_class"] = bool  # not a child of AuthBase
-        FundConfig(**invalid_attrs)
-
-    with pytest.raises(AssertionError):
-        invalid_attrs = copy(valid_fund_attrs)
-        invalid_attrs["user_role"] = 1234  # not a str
-        FundConfig(**invalid_attrs)

--- a/tests/submit_tests/test_fund.py
+++ b/tests/submit_tests/test_fund.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 import pytest
 
@@ -15,6 +16,7 @@ def test_fund_service():
                 current_reporting_period="Test Reporting Period",
                 current_reporting_round=1,
                 current_deadline=datetime.date(day=1, month=1, year=2001),
+                la_confirmation_email_template=str(uuid.uuid4()),
                 email="testemail@test.gov.uk",
                 active=True,
                 auth_class=AuthBase,


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-605

### Change description
Updates FundConfig objects to take an email template to send to the LA after a successful submission, allowing custom content per fund.

### How to test
* Upload a spreadsheet for each of Pathfinders, Town Deal, and Future High Street Fund. Make sure that you receive the right email each time.
