### PR TITLE
FPASF-599 - PF R2 - accounting for textual discrepancies in outputs and outcomes between rounds 1 and 2

### DIFF
--- a/data_store/transformation/pathfinders/pf_transform_r1.py
+++ b/data_store/transformation/pathfinders/pf_transform_r1.py
@@ -89,6 +89,13 @@ OUTPUT_OUTCOME_REPORTING_PERIOD_HEADERS_TO_DATES = {
 }
 
 
+BESPOKE_OUTPUT_DISCREPANCY_MAPPING: dict[str, str] = {
+    "Amount of Floor Space Ratinalised (Sqm)": "Amount of Floor Space Rationalised (Sqm)",
+    "number of cleared sites": "Number of cleared sites",
+    "m2 of heritage buildings renovated/restored": "m2 of Heritage buildings renovated/restored",
+}
+
+
 def transform(df_dict: dict[str, pd.DataFrame], reporting_round: int) -> dict[str, pd.DataFrame]:
     """
     Transform the data extracted from the Excel file into a format that can be loaded into the database.
@@ -393,6 +400,11 @@ def _outputs(
             programme_junction_id   - assigned during map_data_to_models based on "Programme ID" in the transformed DF
                                       "Output_Data"  # Not currently implemented
     """
+    # Certain bespoke outputs had small text changes after round 1, which were then applied manually to the database.
+    # This mapping is used to ensure that the bespoke outputs are consistent with the database in case we re-ingest a
+    # round 1 file.
+    df_dict["Bespoke outputs"]["Output"].replace(BESPOKE_OUTPUT_DISCREPANCY_MAPPING, inplace=True)
+
     organisation_name = df_dict["Organisation name"].iloc[0, 0]
     programme_id = programme_name_to_id_mapping[organisation_name]
     standard_outputs = df_dict["Outputs"]["Output"]

--- a/data_store/validation/pathfinders/cross_table_validation/common.py
+++ b/data_store/validation/pathfinders/cross_table_validation/common.py
@@ -53,10 +53,13 @@ def check_values_against_allowed(
     :return: List of row indices with breaching values
     """
 
+    allowed_values_lowercased = [s.lower() for s in allowed_values]
     breaching_row_indices = []
     for index, row in df.iterrows():
-        value = row[value_column]
-        if value not in allowed_values:
+        value: str = row[value_column]
+        value_lowercased = value.lower()
+
+        if value_lowercased not in allowed_values_lowercased:
             breaching_row_indices.append(index)
 
     return breaching_row_indices
@@ -80,13 +83,17 @@ def check_values_against_mapped_allowed(
     :return: List of row indices with breaching values
     """
 
+    allowed_values_map_lowercased = {k.lower(): [s.lower() for s in v] for k, v in allowed_values_map.items()}
     breaching_row_indices = []
     for index, row in df.iterrows():
-        value = row[value_column]
-        allowed_values_key = row[allowed_values_key_column]
-        allowed_values = allowed_values_map.get(allowed_values_key, [])
+        value: str = row[value_column]
+        value_lowercased = value.lower()
 
-        if value not in allowed_values:
+        allowed_values_key: str = row[allowed_values_key_column]
+        allowed_values_key_lowercased = allowed_values_key.lower()
+        allowed_values_lowercased = allowed_values_map_lowercased.get(allowed_values_key_lowercased, [])
+
+        if value_lowercased not in allowed_values_lowercased:
             breaching_row_indices.append(index)
 
     return breaching_row_indices

--- a/data_store/validation/pathfinders/cross_table_validation/ct_validate_r2.py
+++ b/data_store/validation/pathfinders/cross_table_validation/ct_validate_r2.py
@@ -242,7 +242,16 @@ def _check_bespoke_outputs(extracted_table_dfs: dict[str, pd.DataFrame]) -> list
     :return: List of error messages
     """
     bespoke_outputs_control = extracted_table_dfs["Bespoke outputs control"]
-    programme_to_allowed_bespoke_outputs = {
+
+    # This output is spelt incorrectly in the bespoke outputs control table and round 2 spreadsheets have already been
+    # sent out to LAs. The correct spelling appears in the bespoke outputs user table, and so we should validate against
+    # that instead.
+    bespoke_outputs_control.replace(
+        {"Output": {"Amount of Floor Space Ratinalised (Sqm)": "Amount of Floor Space Rationalised (Sqm)"}},
+        inplace=True,
+    )
+
+    programme_to_allowed_bespoke_outputs: dict[str, list[str]] = {
         programme: bespoke_outputs_control.loc[
             bespoke_outputs_control["Local Authority"] == programme, "Output"
         ].tolist()

--- a/tests/data_store_tests/transformation_tests/pathfinders/test_pf_transform_r1.py
+++ b/tests/data_store_tests/transformation_tests/pathfinders/test_pf_transform_r1.py
@@ -225,6 +225,28 @@ def test__outputs(
     mock_pf_r1_df_dict: dict[str, pd.DataFrame],
     mock_programme_name_to_id_mapping: dict[str, str],
 ):
+    mock_pf_r1_df_dict["Bespoke outputs"] = pd.concat(
+        (
+            mock_pf_r1_df_dict["Bespoke outputs"],
+            pd.DataFrame(
+                {
+                    "Intervention theme": ["Bespoke"],
+                    "Output": ["Amount of Floor Space Ratinalised (Sqm)"],
+                    "Unit of measurement": ["sqm"],
+                    "Financial year 2023 to 2024, (Jan to Mar), Actual": [5.0],
+                    "Financial year 2024 to 2025, (Apr to Jun), Forecast": [5.0],
+                    "Financial year 2024 to 2025, (Jul to Sep), Forecast": [5.0],
+                    "Financial year 2024 to 2025, (Oct to Dec), Forecast": [5.0],
+                    "Financial year 2024 to 2025, (Jan to Mar), Forecast": [5.0],
+                    "Financial year 2025 to 2026, (Apr to Jun), Forecast": [5.0],
+                    "Financial year 2025 to 2026, (Jul to Sep), Forecast": [5.0],
+                    "Financial year 2025 to 2026, (Oct to Dec), Forecast": [5.0],
+                    "Financial year 2025 to 2026, (Jan to Mar), Forecast": [5.0],
+                    "April 2026 and after, Total": [5.0],
+                }
+            ),
+        )
+    )
     transformed_df_dict = pf._outputs(
         df_dict=mock_pf_r1_df_dict,
         programme_name_to_id_mapping=mock_programme_name_to_id_mapping,
@@ -240,23 +262,29 @@ def test__outputs(
     expected_df_dict = {
         "Outputs_Ref": pd.DataFrame(
             {
-                "Output Name": ["Total length of pedestrian paths improved", "Potential entrepreneurs assisted"],
+                "Output Name": [
+                    "Total length of pedestrian paths improved",
+                    "Potential entrepreneurs assisted",
+                    "Amount of Floor Space Rationalised (Sqm)",
+                ],
                 "Output Category": [
                     "Enhancing subregional and regional connectivity",
+                    "Bespoke",
                     "Bespoke",
                 ],
             }
         ),
         "Output_Data": pd.DataFrame(
             {
-                "Programme ID": ["PF-BOL"] * len(start_dates) * 2,
+                "Programme ID": ["PF-BOL"] * len(start_dates) * 3,
                 "Output": (["Total length of pedestrian paths improved"] * len(start_dates))
-                + (["Potential entrepreneurs assisted"] * len(start_dates)),
-                "Start_Date": start_dates * 2,
-                "End_Date": end_dates * 2,
-                "Unit of Measurement": (["km"] * len(start_dates)) + (["n of"] * len(start_dates)),
-                "Actual/Forecast": (["Actual"] + (["Forecast"] * (len(start_dates) - 1))) * 2,
-                "Amount": ([1.0] * len(start_dates)) + ([5.0] * len(start_dates)),
+                + (["Potential entrepreneurs assisted", "Amount of Floor Space Rationalised (Sqm)"] * len(start_dates)),
+                "Start_Date": start_dates + [i for p in zip(start_dates, start_dates, strict=False) for i in p],
+                "End_Date": end_dates + [i for p in zip(end_dates, end_dates, strict=False) for i in p],
+                "Unit of Measurement": (["km"] * len(start_dates)) + (["n of", "sqm"] * len(start_dates)),
+                "Actual/Forecast": (["Actual"] + (["Forecast"] * (len(start_dates) - 1)))
+                + (["Actual", "Actual"] + (["Forecast"] * (len(start_dates) * 2 - 2))),
+                "Amount": ([1.0] * len(start_dates)) + ([5.0] * len(start_dates)) * 2,
             }
         ),
     }

--- a/tests/data_store_tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r2.py
+++ b/tests/data_store_tests/validation_tests/pathfinders/cross_table_validation_tests/test_ct_validate_r2.py
@@ -80,6 +80,12 @@ def test__check_standard_outcomes_passes(mock_pf_r2_df_dict):
     _check_standard_outcomes(mock_pf_r2_df_dict)
 
 
+def test__check_standard_outcomes_passes_with_differently_cased_outcome(mock_pf_r2_df_dict):
+    mock_pf_r2_df_dict["Outcomes"].loc[0, "Outcome"] = "vEhIcLe FlOw"
+    error_messages = _check_standard_outcomes(mock_pf_r2_df_dict)
+    assert error_messages == []
+
+
 def test__check_standard_outcomes_fails(mock_pf_r2_df_dict):
     mock_pf_r2_df_dict["Outcomes"].loc[0, "Outcome"] = "Invalid Outcome"
     error_messages = _check_standard_outcomes(mock_pf_r2_df_dict)
@@ -97,6 +103,34 @@ def test__check_standard_outcomes_fails(mock_pf_r2_df_dict):
 
 def test__check_bespoke_outputs_passes(mock_pf_r2_df_dict):
     _check_bespoke_outputs(mock_pf_r2_df_dict)
+
+
+@pytest.mark.parametrize(
+    "old_text, new_text, uom",
+    [
+        ("Amount of Floor Space Ratinalised (Sqm)", "Amount of Floor Space Rationalised (Sqm)", "sqm"),
+        ("number of sites cleared", "Number of sites cleared", "n of"),
+        ("m2 of heritage buildings renovated/restored", "m2 of Heritage buildings renovated/restored", "sqm"),
+    ],
+)
+def test__check_bespoke_outputs_passes_with_text_changes(mock_pf_r2_df_dict, old_text, new_text, uom):
+    mock_pf_r2_df_dict["Bespoke outputs control"] = pd.concat(
+        (
+            mock_pf_r2_df_dict["Bespoke outputs control"],
+            pd.DataFrame(
+                {
+                    "Local Authority": ["Bolton Council"],
+                    "Output": [old_text],
+                    "UoM": [uom],
+                    "Intervention theme": ["Bespoke"],
+                }
+            ),
+        )
+    )
+    mock_pf_r2_df_dict["Bespoke outputs"].loc[0, "Output"] = new_text
+    mock_pf_r2_df_dict["Bespoke outputs"].loc[0, "Unit of measurement"] = uom
+    error_messages = _check_bespoke_outputs(mock_pf_r2_df_dict)
+    assert error_messages == []
 
 
 def test__check_bespoke_outputs_fails(mock_pf_r2_df_dict):


### PR DESCRIPTION
### Ticket

[Fix PF R2 outputs / outcomes validation issue](https://dluhcdigital.atlassian.net/browse/FPASF-599)

### Description

A copy and paste of outputs and outcomes from an unverified location into the R2 spreadsheet that was sent out to LAs broke the link between the outputs and outcomes control tables in the hidden worksheets and the outputs and outcomes user tables in the user-facing worksheets. An analysis identified several small discrepancies between the outputs and outcomes as they appear in round 1 and the outputs and outcomes as they appear in round 2, specifically differences in whitespace, capitalisation and in one case, a spelling fix ('Ratinalised').

Because we are going to apply the spelling fix manually to production data, we need to apply the spelling fix as a transform in the PF round 1 ingest pipeline. And then because the R2 spreadsheets have already been sent out to LAs with the old text for the bespoke outputs in the hidden worksheets, we need to make cross-table validation checks case-insensitive and handle the spelling fix case in PF round 2 cross-table validation. We don't need to apply the same transform in the PF round 2 ingest pipeline as we don't expect the text coming in to suffer from this specific problem. And we don't need to modify cross-table validation checks for PF round 1 because the hidden worksheets align with the user-facing worksheets.

Please note also that there was no need to handle whitespace stripping, as this is already done during table extraction.

### Important note

We need to apply the database fix first, this is in a separate PR.