### PR TITLE
FPASF-599 - PF R2 - SQL to change output names to account for text changes between round 1 and round 2 of Pathfinders reporting

### DIFF
--- a/scripts/pf_r2_outputs_outcomes_fix.sql
+++ b/scripts/pf_r2_outputs_outcomes_fix.sql
@@ -1,0 +1,14 @@
+-- Update "m2 of heritage buildings renovated/restored" to "m2 of Heritage buildings renovated/restored"
+UPDATE output_dim
+SET output_name = 'm2 of Heritage buildings renovated/restored'
+WHERE output_name = 'm2 of heritage buildings renovated/restored';
+
+-- Update "Amount of Floor Space Ratinalised (Sqm)" to "Amount of Floor Space Rationalised (Sqm)"
+UPDATE output_dim
+SET output_name = 'Amount of Floor Space Rationalised (Sqm)'
+WHERE output_name = 'Amount of Floor Space Ratinalised (Sqm)';
+
+-- Update "number of cleared sites" to "Number of cleared sites"
+UPDATE output_dim
+SET output_name = 'Number of cleared sites'
+WHERE output_name = 'number of cleared sites';


### PR DESCRIPTION
### Ticket

[Fix PF R2 outputs / outcomes validation issue](https://dluhcdigital.atlassian.net/browse/FPASF-599)

### Description

This PR contains an SQL script that is to be run against the production database, to update the names of the outputs that were renamed between Pathfinders rounds 1 and 2. By running these updates, in conjunction with the code in the other PR for this ticket (see ticket comments), we ensure that the same real-world output maps to a single output in the database, despite the name change.