### PR TITLE
Upgrade utils version; pinning greenlet due to conflict

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,9 @@ blinker==1.8.2
     #   flask
     #   sentry-sdk
 boto3==1.34.151
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   funding-service-design-utils
 boto3-stubs[logs,s3]==1.34.133
     # via -r requirements-dev.in
 botocore==1.34.151
@@ -168,7 +170,7 @@ flask-wtf==1.2.1
     # via
     #   -r requirements.txt
     #   govuk-frontend-wtf
-funding-service-design-utils==5.0.1
+funding-service-design-utils==5.1.0
     # via -r requirements.txt
 govuk-frontend-jinja==3.3.0
     # via
@@ -178,6 +180,7 @@ govuk-frontend-wtf==3.1.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via
+    #   -r requirements.txt
     #   playwright
     #   sqlalchemy
 gunicorn==22.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #-----------------------------------
 #   Utils
 #-----------------------------------
-funding-service-design-utils==5.0.1
+funding-service-design-utils==5.1.*
 email_validator==2.0.0.post2
 
 #-----------------------------------
@@ -31,7 +31,7 @@ SQLAlchemy>=2.0.9,<=2.1.0
 Flask-SQLAlchemy==3.0.*
 psycopg2-binary
 marshmallow-sqlalchemy
-
+greenlet==3.0.3  # pinned due to SQLAlchemy and pytest-playwright conflict
 
 #-----------------------------------
 #   tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,9 @@ blinker==1.8.2
     #   flask
     #   sentry-sdk
 boto3==1.34.151
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   funding-service-design-utils
 botocore==1.34.151
     # via
     #   boto3
@@ -100,7 +102,7 @@ flask-wtf==1.2.1
     # via
     #   -r requirements.in
     #   govuk-frontend-wtf
-funding-service-design-utils==5.0.1
+funding-service-design-utils==5.1.0
     # via -r requirements.in
 govuk-frontend-jinja==3.3.0
     # via
@@ -108,6 +110,10 @@ govuk-frontend-jinja==3.3.0
     #   govuk-frontend-wtf
 govuk-frontend-wtf==3.1.0
     # via -r requirements.in
+greenlet==3.0.3
+    # via
+    #   -r requirements.in
+    #   sqlalchemy
 gunicorn==22.0.0
     # via funding-service-design-utils
 idna==3.7


### PR DESCRIPTION
### Change description
Upgrade fsd utils version and pin greenlet version due to conflict.

### How to test
Set `FSD_UTILS_ENABLE_CONFIG_TABLE` in `.env` docker runner.

`data-store` will no longer show the table.