### PR TITLE
Bau/admin action reupload

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -1,6 +1,6 @@
 from admin.actions import (
-    ReingestAdminView,
     ReingestFileAdminView,
+    ReingestFromS3AdminView,
     RetrieveFailedSubmissionAdminView,
     RetrieveSubmissionAdminView,
 )
@@ -25,7 +25,9 @@ def register_admin_views(flask_admin, db):
     flask_admin.add_view(SubmissionAdminView(db.session, category="Reporting data"))
     flask_admin.add_view(ReportingRoundAdminView(db.session, category="Reporting data"))
 
-    flask_admin.add_view(ReingestAdminView(name="Reingest", endpoint="reingest", category="Admin actions"))
+    flask_admin.add_view(
+        ReingestFromS3AdminView(name="Reingest from S3", endpoint="reingest_s3", category="Admin actions")
+    )
     flask_admin.add_view(
         ReingestFileAdminView(name="Reingest from file", endpoint="reingest_file", category="Admin actions")
     )

--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -1,4 +1,9 @@
-from admin.actions import ReingestAdminView, RetrieveFailedSubmissionAdminView, RetrieveSubmissionAdminView
+from admin.actions import (
+    ReingestAdminView,
+    ReingestFileAdminView,
+    RetrieveFailedSubmissionAdminView,
+    RetrieveSubmissionAdminView,
+)
 from admin.entities import (
     FundAdminView,
     GeospatialAdminView,
@@ -21,6 +26,9 @@ def register_admin_views(flask_admin, db):
     flask_admin.add_view(ReportingRoundAdminView(db.session, category="Reporting data"))
 
     flask_admin.add_view(ReingestAdminView(name="Reingest", endpoint="reingest", category="Admin actions"))
+    flask_admin.add_view(
+        ReingestFileAdminView(name="Reingest from file", endpoint="reingest_file", category="Admin actions")
+    )
     flask_admin.add_view(
         RetrieveSubmissionAdminView(
             name="Retrieve Submission", endpoint="retrieve_submission", category="Admin actions"

--- a/admin/actions.py
+++ b/admin/actions.py
@@ -98,6 +98,7 @@ class ReingestFileAdminView(BaseAdminView):
                 try:
                     with db.session.begin():
                         submission = Submission.query.filter_by(submission_id=submission_id).one()
+                        original_id = submission.id
 
                         match submission.programme_junction.programme_ref.fund.fund_code:
                             case "PF":
@@ -120,7 +121,15 @@ class ReingestFileAdminView(BaseAdminView):
                         auth=None,  # Don't run any auth checks because we're admins
                     )
 
+                    submission = Submission.query.filter_by(submission_id=submission_id).one()  # re-fetch after changes
                     if status_code == 200:
+                        current_app.logger.warning(
+                            "Submission ID %s (original db id=%s, new db id=%s) reingested by %s from a local file",
+                            submission_id,
+                            original_id,
+                            submission.id,
+                            g.user.email,
+                        )
                         flash(f"Successfully re-ingested submission {submission.submission_id}")
 
                     else:

--- a/admin/actions.py
+++ b/admin/actions.py
@@ -9,8 +9,8 @@ from werkzeug.datastructures import CombinedMultiDict, FileStorage
 
 from admin.base import AdminAuthorizationMixin
 from admin.forms import (
-    ReingestAdminForm,
     ReingestFromFileAdminForm,
+    ReingestFromS3AdminForm,
     RetrieveFailedSubmissionAdminForm,
     RetrieveSubmissionAdminForm,
 )
@@ -25,10 +25,10 @@ class BaseAdminView(AdminAuthorizationMixin, BaseView):
     pass
 
 
-class ReingestAdminView(BaseAdminView):
+class ReingestFromS3AdminView(BaseAdminView):
     @expose("/", methods=["GET", "POST"])
     def index(self):
-        form = ReingestAdminForm(request.form)
+        form = ReingestFromS3AdminForm(request.form)
 
         if form.is_submitted():
             if form.validate():
@@ -79,7 +79,7 @@ class ReingestAdminView(BaseAdminView):
                 else:
                     flash(f"Issues re-ingesting submission {submission.submission_id}: {response_data}", "error")
 
-                return redirect(url_for("reingest.index"))
+                return redirect(url_for("reingest_s3.index"))
 
             flash_errors(form, "%(error)s")
 

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed, FileField
 from wtforms import StringField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, InputRequired
 
 
 class ReingestFromS3AdminForm(FlaskForm):
@@ -12,7 +12,7 @@ class ReingestFromFileAdminForm(FlaskForm):
     submission_id = StringField("The submission ID to retrieve", validators=[DataRequired()])
     excel_file = FileField(
         "Excel spreadsheet to reingest",
-        validators=[FileAllowed(["xlsx"])],
+        validators=[InputRequired(), FileAllowed(["xlsx"])],
     )
 
 

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -1,10 +1,19 @@
 from flask_wtf import FlaskForm
+from flask_wtf.file import FileAllowed, FileField
 from wtforms import StringField
 from wtforms.validators import DataRequired
 
 
 class ReingestAdminForm(FlaskForm):
     submission_id = StringField("The submission ID to re-ingest", validators=[DataRequired()])
+
+
+class ReingestFromFileAdminForm(FlaskForm):
+    submission_id = StringField("The submission ID to retrieve", validators=[DataRequired()])
+    excel_file = FileField(
+        "Excel spreadsheet to reingest",
+        validators=[FileAllowed(["xlsx"])],
+    )
 
 
 class RetrieveSubmissionAdminForm(FlaskForm):

--- a/admin/forms.py
+++ b/admin/forms.py
@@ -4,7 +4,7 @@ from wtforms import StringField
 from wtforms.validators import DataRequired
 
 
-class ReingestAdminForm(FlaskForm):
+class ReingestFromS3AdminForm(FlaskForm):
     submission_id = StringField("The submission ID to re-ingest", validators=[DataRequired()])
 
 

--- a/admin/templates/admin/reingest.html
+++ b/admin/templates/admin/reingest.html
@@ -9,7 +9,7 @@
 {% endblock head %}
 
 {% block body %}
-  <h1 class="govuk-heading-l">Reingest submission</h1>
+  <h1 class="govuk-heading-l">Reingest submission from S3</h1>
 
   {{ lib.render_form(form) }}
 {% endblock body %}

--- a/admin/templates/admin/reingest_file.html
+++ b/admin/templates/admin/reingest_file.html
@@ -1,0 +1,20 @@
+{% extends "admin/master.html" %}
+
+{% import "admin/lib.html" as lib with context %}
+{% from "admin/lib.html" import extra with context %} {# backward compatible #}
+
+{% block head %}
+  {{ super() }}
+  {{ lib.form_css() }}
+{% endblock head %}
+
+{% block body %}
+  <h1 class="govuk-heading-l">Reingest submission by file</h1>
+
+  {{ lib.render_form(form) }}
+{% endblock body %}
+
+{% block tail %}
+  {{ super() }}
+  {{ lib.form_js() }}
+{% endblock tail %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ module = [
   "flask_assets",
   "fsd_utils.*",
   "notifications_python_client.*",
-  "flask_wtf",
+  "flask_wtf.*",
   "govuk_frontend_wtf.wtforms_widgets",
   "flask_admin.*",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,9 +111,7 @@ govuk-frontend-jinja==3.3.0
 govuk-frontend-wtf==3.1.0
     # via -r requirements.in
 greenlet==3.0.3
-    # via
-    #   -r requirements.in
-    #   sqlalchemy
+    # via -r requirements.in
 gunicorn==22.0.0
     # via funding-service-design-utils
 idna==3.7

--- a/tests/admin_tests/test_actions.py
+++ b/tests/admin_tests/test_actions.py
@@ -6,7 +6,19 @@ from data_store.controllers.ingest import ingest
 from data_store.db.entities import Submission
 
 
-class TestReingestFile:
+class TestReingestS3AdminView:
+    # TODO: add some tests
+    ...
+
+
+class TestReingestFileAdminView:
+    # NOTE[RESP_CLOSE]
+    # Flask's test client sometimes does not close large files passed to it correctly, so we force them to close
+    # here. Not doing this manually can make pytest throw a ResourceWarning, which gets flagged as an error.
+    # See also:
+    #    https://github.com/pallets/werkzeug/issues/1785
+    #    https://github.com/pallets/werkzeug/pull/2041
+
     def test_success(
         self,
         test_client_reset,
@@ -38,6 +50,8 @@ class TestReingestFile:
         submitted_at_after = Submission.query.with_entities(func.max(Submission.submission_date)).one()
         assert submitted_at_before < submitted_at_after  # NS precision so shouldn't need to freeze time
 
+        resp.close()  # See note `RESP_CLOSE` near top of class
+
     def test_no_matching_submission(
         self,
         test_client_reset,
@@ -55,5 +69,18 @@ class TestReingestFile:
                 },
                 follow_redirects=True,
             )
+
+            resp.close()  # See note `RESP_CLOSE` near top of class
+
         assert resp.status_code == 200
         assert "Could not find a matching submission with ID S-R03-999" in resp.text
+
+
+class TestRetrieveSubmissionAdminView:
+    # TODO: add some tests
+    ...
+
+
+class TestRetrieveFailedSubmissionAdminView:
+    # TODO: add some tests
+    ...

--- a/tests/admin_tests/test_actions.py
+++ b/tests/admin_tests/test_actions.py
@@ -1,0 +1,59 @@
+from sqlalchemy import func
+from werkzeug.datastructures import FileStorage
+
+from data_store.const import EXCEL_MIMETYPE
+from data_store.controllers.ingest import ingest
+from data_store.db.entities import Submission
+
+
+class TestReingestFile:
+    def test_success(
+        self,
+        test_client_reset,
+        towns_fund_round_3_success_file_path,
+        test_buckets,
+        mock_sentry_metrics,
+        admin_test_client,
+    ):
+        with open(towns_fund_round_3_success_file_path, "rb") as tf_r3:
+            ingest(
+                fund_name="Towns Fund",
+                reporting_round=3,
+                do_load=True,
+                excel_file=FileStorage(tf_r3, content_type=EXCEL_MIMETYPE),
+            )
+        submitted_at_before = Submission.query.with_entities(func.max(Submission.submission_date)).one()
+
+        with open(towns_fund_round_3_success_file_path, "rb") as tf_r3:
+            resp = admin_test_client.post(
+                "/admin/reingest_file/",
+                data={
+                    "submission_id": "s-r03-1",  # also sneakily testing case-insensitivity
+                    "excel_file": FileStorage(tf_r3, content_type=EXCEL_MIMETYPE),
+                },
+                follow_redirects=True,
+            )
+        assert resp.status_code == 200
+
+        submitted_at_after = Submission.query.with_entities(func.max(Submission.submission_date)).one()
+        assert submitted_at_before < submitted_at_after  # NS precision so shouldn't need to freeze time
+
+    def test_no_matching_submission(
+        self,
+        test_client_reset,
+        towns_fund_round_3_success_file_path,
+        test_buckets,
+        mock_sentry_metrics,
+        admin_test_client,
+    ):
+        with open(towns_fund_round_3_success_file_path, "rb") as tf_r3:
+            resp = admin_test_client.post(
+                "/admin/reingest_file/",
+                data={
+                    "submission_id": "S-R03-999",
+                    "excel_file": FileStorage(tf_r3, content_type=EXCEL_MIMETYPE),
+                },
+                follow_redirects=True,
+            )
+        assert resp.status_code == 200
+        assert "Could not find a matching submission with ID S-R03-999" in resp.text

--- a/tests/admin_tests/test_auth.py
+++ b/tests/admin_tests/test_auth.py
@@ -137,6 +137,7 @@ class TestAdminModelsAuthorization:
 
 class TestAdminActionsAuthorization:
     actions = (
+        "reingest_s3",
         "reingest_file",
         "retrieve_submission",
         "retrieve_failed_submission",

--- a/tests/admin_tests/test_auth.py
+++ b/tests/admin_tests/test_auth.py
@@ -137,7 +137,7 @@ class TestAdminModelsAuthorization:
 
 class TestAdminActionsAuthorization:
     actions = (
-        "reingest",
+        "reingest_file",
         "retrieve_submission",
         "retrieve_failed_submission",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -833,12 +833,17 @@ def pathfinders_round_2_file_success() -> Generator[BinaryIO, None, None]:
         yield file
 
 
+@pytest.fixture(scope="module")
+def towns_fund_round_3_success_file_path():
+    """Filepath to an example spreadsheet for Towns Fund Round 3 that should ingest without validation errors."""
+    filepath = Path(__file__).parent / "integration_tests" / "mock_tf_returns" / "TF_Round_3_Success.xlsx"
+    yield filepath
+
+
 @pytest.fixture(scope="function")
-def towns_fund_round_3_file_success() -> Generator[BinaryIO, None, None]:
+def towns_fund_round_3_file_success(towns_fund_round_3_success_file_path) -> Generator[BinaryIO, None, None]:
     """An example spreadsheet for reporting round 3 of Towns Fund that should ingest without validation errors."""
-    with open(
-        Path(__file__).parent / "integration_tests" / "mock_tf_returns" / "TF_Round_3_Success.xlsx", "rb"
-    ) as file:
+    with open(towns_fund_round_3_success_file_path, "rb") as file:
         yield file
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -833,7 +833,7 @@ def pathfinders_round_2_file_success() -> Generator[BinaryIO, None, None]:
         yield file
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def towns_fund_round_3_success_file_path():
     """Filepath to an example spreadsheet for Towns Fund Round 3 that should ingest without validation errors."""
     filepath = Path(__file__).parent / "integration_tests" / "mock_tf_returns" / "TF_Round_3_Success.xlsx"

--- a/tests/data_store_tests/controller_tests/test_admin_tasks.py
+++ b/tests/data_store_tests/controller_tests/test_admin_tasks.py
@@ -15,13 +15,6 @@ from data_store.db.entities import Submission
 
 
 @pytest.fixture(scope="module")
-def towns_fund_round_3_sucess_file_path():
-    """Filepath to an example spreadsheet for Towns Fund Round 3 that should ingest without validation errors."""
-    filepath = Path(__file__).parent.parent.parent / "integration_tests" / "mock_tf_returns" / "TF_Round_3_Success.xlsx"
-    yield filepath
-
-
-@pytest.fixture(scope="module")
 def reingest_submission_ids_file_path():
     """Filepath to text file with line-separated submission IDs for reingesting."""
     filepath = Path(__file__).parent / "mock_admin_tasks_files" / "mock_reingest_submission_ids.txt"
@@ -29,7 +22,7 @@ def reingest_submission_ids_file_path():
 
 
 def test_reingest_file(
-    test_client_reset, test_buckets, towns_fund_round_3_file_success, towns_fund_round_3_sucess_file_path, capfd
+    test_client_reset, test_buckets, towns_fund_round_3_file_success, towns_fund_round_3_success_file_path, capfd
 ):
     """
     Tests successful reingestion of a single local submission file.
@@ -42,7 +35,7 @@ def test_reingest_file(
     )
     db.session.close()  # Close the existing db session before re-ingesting the file
 
-    reingest_file(towns_fund_round_3_sucess_file_path, "S-R03-1")
+    reingest_file(towns_fund_round_3_success_file_path, "S-R03-1")
     out, error = capfd.readouterr()
     assert out.strip() == ("Successfully re-ingested submission S-R03-1")
 


### PR DESCRIPTION
### Change description
Add an admin form for reingesting from a file. This is similar to the CLI action `flask admin reingest-file`.

I've decided not to remove the CLI action for now because flask-admin is still maybe a WIP (until we re-skin it using the Design System), so if we ever decide to drop it out again it's nice for the CLI commands to still exist.

### How to test
- Do a submission normally through Submit
- Look in the DB and find the `submission_dim` entry for it.
- Use the admin view to reingest the file - make sure submission ID matches.
- Should be reingested correctly - the old entry in `submission_dim` should be gone and a new one should be present with the same `submission_id`.
- Try uploading some mismatched spreadsheets too.


### Screenshots of UI changes (if applicable)
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/5d842e87-7fc7-4115-a9ed-198f486c3db4">
