### PR TITLE
Ensure TF schema validation on project start and end dates handles non-datetime input

### DIFF
--- a/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
+++ b/data_store/validation/towns_fund/fund_specific_validation/fs_validate_r6.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pandas as pd
 
 from data_store.const import StatusEnum
@@ -34,7 +36,7 @@ def validate_project_progress(data_dict: dict[str, pd.DataFrame], reporting_roun
     failures = []
     for idx, row in not_started_rows.iterrows():
         start_date = row["Start Date"]
-        if pd.isnull(start_date):
+        if pd.isnull(start_date) or not isinstance(start_date, datetime):
             continue
         if start_date.date() <= observation_period_end_date.date():
             failures.append(

--- a/data_store/validation/towns_fund/schema_validation/validate.py
+++ b/data_store/validation/towns_fund/schema_validation/validate.py
@@ -11,7 +11,6 @@ from typing import Union
 
 import pandas as pd
 from numpy.typing import NDArray
-from pandas import Timestamp
 from pandas.api.extensions import ExtensionArray
 
 from data_store.messaging.tf_messaging import TFMessages as msgs
@@ -390,13 +389,12 @@ def validate_project_dates(
     :return: A list of GenericFailure objects for any rows with invalid project dates.
     """
     data_df = data_dict[table]
-    invalid_project_dates = []
+    invalid_project_dates: list[user.GenericFailure] = []
 
     for idx, row in data_df.iterrows():
-        start_date = typing.cast(Timestamp | None, row.get(project_date_cols[0]))
-        completion_date = typing.cast(Timestamp | None, row.get(project_date_cols[1]))
-
-        if start_date is not None and completion_date is not None:
+        start_date = row.get(project_date_cols[0])
+        completion_date = row.get(project_date_cols[1])
+        if isinstance(start_date, datetime) and isinstance(completion_date, datetime):
             if start_date > completion_date:
                 invalid_project_dates.append(
                     user.GenericFailure(


### PR DESCRIPTION
Bug noticed by Craig when he was playing about with rogue input on test. If we have a non-null, non-datetime input in "Start Date" column of "Project Progress" table in TF spreadsheet, we fail completely at the line `if start_date > completion_date` in `funding-service-design-post-award-data-store/data_store/validation/towns_fund/schema_validation/validate.py::validate_project_dates`, with `'>' not supported between instances of 'WRONG_TYPE' and 'datetime.datetime'`.