### PR TITLE
Prevent SSM plugin update request during deployment

### DIFF
--- a/scripts/migration-task-script.py
+++ b/scripts/migration-task-script.py
@@ -24,7 +24,7 @@ def get_db_revision_id() -> str | None:
     try:
         grep_result = subprocess.check_output(
             (
-                "copilot svc exec --name post-award "
+                "copilot svc exec --name post-award --yes false "
                 "--command \"bash -c 'launcher flask db current 2> /dev/null | grep head'\""
             ),
             shell=True,


### PR DESCRIPTION
### Description

When attempting to make a deployment with AWS Copilot, if the AWS Session Manager plugin is not up-to-date, then user input will be requested to update it, causing the pipeline to fail as the terminal is non-interactive.

This change adds a flag `yes=false` to the `copilot svc exec` command in the migration script to cause it to respond automatically in the negative when the update request is levied, unblocking the pipeline.

Fix identified from: https://github.com/aws/copilot-cli/issues/4627#issuecomment-1470324659