### PR TITLE
Using freezegun to freeze time in integration test to fix occasional minute-rounding mismatch error

### DIFF
--- a/data_store/validation/towns_fund/schema_validation/validate.py
+++ b/data_store/validation/towns_fund/schema_validation/validate.py
@@ -157,7 +157,7 @@ def validate_types(
 
             # do not raise an exception for pandas Timestamp, datetime or number values
             if (isinstance(got_value, numbers.Number) and exp_type in [int, float]) or (
-                isinstance(got_value, (datetime, pd.Timestamp)) and exp_type == datetime
+                isinstance(got_value, (datetime, pd.Timestamp)) and issubclass(exp_type, datetime)
             ):
                 continue
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,6 +14,7 @@ pytest-env
 pytest-mock
 requests-mock==1.11.0
 pytest-playwright
+freezegun
 
 #-----------------------------------
 #   Code Quality

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -170,6 +170,8 @@ flask-wtf==1.2.1
     # via
     #   -r requirements.txt
     #   govuk-frontend-wtf
+freezegun==1.5.1
+    # via -r requirements-dev.in
 funding-service-design-utils==5.1.0
     # via -r requirements.txt
 govuk-frontend-jinja==3.3.0
@@ -182,7 +184,6 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   playwright
-    #   sqlalchemy
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -353,6 +354,7 @@ python-dateutil==2.8.2
     #   -r requirements.txt
     #   botocore
     #   celery
+    #   freezegun
     #   pandas
 python-dotenv==1.0.1
     # via

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pandas as pd
+from freezegun import freeze_time
 from pandas._testing import assert_frame_equal, assert_series_equal
 from werkzeug.datastructures import FileStorage
 
@@ -11,6 +12,7 @@ from data_store.db import db
 from data_store.db import entities as ents
 
 
+@freeze_time("2024-10-14 12:00:00")
 def test_multiple_rounds_multiple_funds_end_to_end(
     test_client_reset,
     towns_fund_round_3_file_success,
@@ -123,10 +125,6 @@ def test_multiple_rounds_multiple_funds_end_to_end(
             "SubmissionDate": [pd.Timestamp(now), pd.Timestamp(now), pd.Timestamp(now)],
         }
     )
-
-    # Round the SubmissionDate to the nearest minute for comparison
-    expected_submission_ref["SubmissionDate"] = expected_submission_ref["SubmissionDate"].dt.round("min")
-    df_dict["SubmissionRef"]["SubmissionDate"] = df_dict["SubmissionRef"]["SubmissionDate"].dt.round("min")
 
     assert_frame_equal(expected_submission_ref, df_dict["SubmissionRef"])
 


### PR DESCRIPTION
### Description

Currently we get unpredictable failures in the `test_multiple_rounds_multiple_funds_end_to_end` integration test, which occur when the ingest occurs in the minute before (or multiple minutes before) the expected dataframe for the extract is created. This is because for each ingest, we use `datetime.now` to set the submission date which appears in the extract, and then only after all ingests and the download have taken place do we then use `datetime.now` again to determine the expected values in the extract. The test passing is currently reliant on the first and last calls to `datetime.now` happening before the minute mark ticks across.

You can observe the failure happening 100% of the time if you add a sleep call of 60 seconds just after all ingest calls in the test function.

This change introduces a new test dependency freezegun to freeze time in the test, meaning that we can exert global control over `datetime.now` without worrying about patching. This breaks the type check in Towns Fund schema validation, which currently relies on the line `exp_type == datetime`, which doesn't work when `datetime` has been replaced by freezegun's `FakeDatetime` - so we need to replace the equality operator with `issubclass`, which is more robust anyway.