### PR TITLE
Drop geography column from Organisation model

### DIFF
--- a/data_store/controllers/mappings.py
+++ b/data_store/controllers/mappings.py
@@ -162,7 +162,6 @@ INGEST_MAPPINGS = (
         model=ents.Organisation,
         column_mapping={
             "Organisation": "organisation_name",
-            "Geography": "geography",
         },
     ),
     DataMapping(

--- a/data_store/db/entities.py
+++ b/data_store/db/entities.py
@@ -162,9 +162,6 @@ class Organisation(BaseModel):
     __tablename__ = "organisation_dim"
 
     organisation_name = sqla.Column(sqla.String(), nullable=False, unique=True)
-    # TODO: geography needs review, field definition may change
-    geography = sqla.Column(sqla.String(), nullable=True)
-
     programmes: Mapped[List["Programme"]] = sqla.orm.relationship(back_populates="organisation")
 
 

--- a/data_store/db/queries.py
+++ b/data_store/db/queries.py
@@ -231,7 +231,6 @@ def organisation_query(base_query: Query) -> Query:
     extended_query = (
         base_query.with_entities(
             ents.Organisation.organisation_name,
-            ents.Organisation.geography,
         )
     ).distinct()
 

--- a/data_store/serialisation/data_serialiser.py
+++ b/data_store/serialisation/data_serialiser.py
@@ -234,7 +234,6 @@ class OrganisationSchema(SQLAlchemySchema):
         model = Organisation
 
     organisation_name = auto_field(data_key="OrganisationName")
-    geography = auto_field(data_key="Geography")
 
 
 class OutcomeDataSchema(SQLAlchemySchema):

--- a/data_store/transformation/pathfinders/pf_transform_r1.py
+++ b/data_store/transformation/pathfinders/pf_transform_r1.py
@@ -210,7 +210,6 @@ def _organisation_ref(df_dict: dict[str, pd.DataFrame]) -> pd.DataFrame:
     """
     Populates `organisation_dim` table:
         organisation_name   - from "Organisation Name" in the transformed DF
-        geography           - nullable
     """
     # TODO: Investigate removal of NA-filled fields from transformation output, from this and other functions
     # https://dluhcdigital.atlassian.net/browse/SMD-664

--- a/data_store/transformation/pathfinders/pf_transform_r2.py
+++ b/data_store/transformation/pathfinders/pf_transform_r2.py
@@ -242,7 +242,6 @@ def _organisation_ref(df_dict: dict[str, pd.DataFrame]) -> pd.DataFrame:
     """
     Populates `organisation_dim` table:
         organisation_name   - from "Organisation Name" in the transformed DF
-        geography           - nullable
     """
     # TODO: Investigate removal of NA-filled fields from transformation output, from this and other functions
     # https://dluhcdigital.atlassian.net/browse/SMD-664

--- a/data_store/transformation/towns_fund/tf_transform_r3.py
+++ b/data_store/transformation/towns_fund/tf_transform_r3.py
@@ -229,13 +229,11 @@ def extract_organisation(df_place: pd.DataFrame) -> pd.DataFrame:
     :param df_place: Extracted place information.
     :return: A new DataFrame containing the extracted organisation info.
     """
-    # TODO: Geography currently set to None, as we have no robust way of ingesting / tracking this at the moment
     organisation_name = get_canonical_organisation_name(df_place)
 
     df_org = pd.DataFrame.from_dict(
         {
             "Organisation": [organisation_name],
-            "Geography": np.nan,
         }
     )
     return df_org

--- a/data_store/validation/towns_fund/schema_validation/schemas.py
+++ b/data_store/validation/towns_fund/schema_validation/schemas.py
@@ -13,7 +13,6 @@ TF_ROUND_4_VAL_SCHEMA = parse_schema(
         "Organisation_Ref": {
             "columns": {
                 "Organisation": str,
-                "Geography": str,
             },
             "uniques": ["Organisation"],
             "non-nullable": ["Organisation"],
@@ -373,7 +372,6 @@ TF_ROUND_3_VAL_SCHEMA = parse_schema(
         "Organisation_Ref": {
             "columns": {
                 "Organisation": str,
-                "Geography": str,
             },
             "uniques": ["Organisation"],
             "non-nullable": ["Organisation"],

--- a/find/templates/find/main/data-glossary.html
+++ b/find/templates/find/main/data-glossary.html
@@ -117,7 +117,6 @@
                       </p>
                       <h3 id="geography-indicator" class="govuk-heading-s">Geography indicator</h3>
                       <p class="govuk-body">A geographic indicator could be defined for example, as a town, postcode or local authority.</p>
-
                     '
                 }
             },

--- a/tests/data_store_tests/db_tests/test_entities.py
+++ b/tests/data_store_tests/db_tests/test_entities.py
@@ -17,7 +17,6 @@ def test_programme_contact_organisation(test_client_rollback):
     # Populate organisation table (1 row)
     organisation = ents.Organisation(
         organisation_name="Test Organisation",
-        geography="Earth",
     )
     db.session.add(organisation)
 

--- a/tests/data_store_tests/serialisation_tests/test_serialisation.py
+++ b/tests/data_store_tests/serialisation_tests/test_serialisation.py
@@ -100,7 +100,6 @@ def test_serialise_download_data_no_filters(seeded_test_client, additional_test_
     assert len(test_serialised_data["ProjectDetails"]) == 12
     assert list(pd.DataFrame.from_records(test_serialised_data["OrganisationRef"]).columns) == [
         "OrganisationName",
-        "Geography",
     ]
     assert len(test_serialised_data["OrganisationRef"]) == 2
     assert list(pd.DataFrame.from_records(test_serialised_data["ProgrammeRef"]).columns) == [

--- a/tests/data_store_tests/transformation_tests/towns_fund/resources/assertion_data/round_three/organisation_ref_expected.csv
+++ b/tests/data_store_tests/transformation_tests/towns_fund/resources/assertion_data/round_three/organisation_ref_expected.csv
@@ -1,2 +1,2 @@
-Organisation,Geography
-Fake Canonical Org,
+Organisation
+Fake Canonical Org

--- a/tests/integration_tests/mock_tf_r3_transformed_data/Organisation_Ref.csv
+++ b/tests/integration_tests/mock_tf_r3_transformed_data/Organisation_Ref.csv
@@ -1,2 +1,2 @@
-Organisation,Geography
-A District Council From Hogwarts,SW1 1AA
+Organisation
+A District Council From Hogwarts

--- a/tests/integration_tests/test_ingest_component_all_funds.py
+++ b/tests/integration_tests/test_ingest_component_all_funds.py
@@ -132,7 +132,6 @@ def test_multiple_rounds_multiple_funds_end_to_end(
     organisation_ref_expected_first_row = pd.Series(
         {
             "OrganisationName": "Bolton Council",
-            "Geography": None,
         },
         name=0,
     )

--- a/tests/integration_tests/test_ingest_db_transactions.py
+++ b/tests/integration_tests/test_ingest_db_transactions.py
@@ -16,7 +16,6 @@ from data_store.controllers.load_functions import (
     get_or_generate_submission_id,
     get_submission_by_programme_and_round,
     get_table_to_load_function_mapping,
-    load_organisation_ref,
     load_outputs_outcomes_ref,
     load_programme_ref,
     load_submission_level_data,
@@ -150,10 +149,7 @@ def test_r3_prog_updates_r1(test_client_reset, mock_r3_data_dict, mock_excel_fil
     )
     db.session.add(sub)
     read_sub = Submission.query.first()
-    organisation = Organisation(
-        organisation_name="Some new Org",
-        geography="Mars",
-    )
+    organisation = Organisation(organisation_name="Some new Org")
     db.session.add(organisation)
     read_org = Organisation.query.first()
     prog = Programme(
@@ -338,7 +334,6 @@ def populate_test_data(test_client_function):
 
     organisation = Organisation(
         organisation_name="Some new Org",
-        geography="Mars",
     )
     db.session.add(organisation)
     read_org = Organisation.query.first()
@@ -475,7 +470,6 @@ def test_next_submission_id_existing_submissions(test_client_rollback):
 
     organisation = Organisation(
         organisation_name="Some new Org",
-        geography="Mars",
     )
     db.session.add(organisation)
     db.session.flush()
@@ -684,7 +678,6 @@ def test_remove_unreferenced_org(test_client_reset):
     hs_fund_id = Fund.query.filter_by(fund_code="HS").first().id
     organisation_1 = Organisation(
         organisation_name="Some new Org",
-        geography="Mars",
     )
     db.session.add(organisation_1)
     read_org = Organisation.query.first()
@@ -697,12 +690,10 @@ def test_remove_unreferenced_org(test_client_reset):
     db.session.add(prog)
     organisation_2 = Organisation(
         organisation_name="Some other Org",
-        geography="Venus",
     )
     db.session.add(organisation_2)
     organisation_3 = Organisation(
         organisation_name="Romulan Star Empire",
-        geography="Romulas",
     )
     db.session.add(organisation_3)
     db.session.commit()
@@ -824,27 +815,6 @@ def test_load_programme_ref_upsert(test_client_reset, mock_r3_data_dict, mock_ex
     programme = Programme.query.filter(Programme.programme_id == "FHSF001").first()
 
     assert programme.programme_name == "new name"
-
-
-def test_load_organisation_ref_upsert(
-    test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload
-):
-    # add mock_r3 data to database
-    populate_db(
-        round_number=3,
-        transformed_data=mock_r3_data_dict,
-        mappings=INGEST_MAPPINGS,
-        excel_file=mock_excel_file,
-        load_mapping=get_table_to_load_function_mapping("Towns Fund"),
-    )
-    # change Geography field to test if upsert correct
-    mock_r3_data_dict["Organisation_Ref"]["Geography"].iloc[0] = "new geography"
-    load_organisation_ref(mock_r3_data_dict, INGEST_MAPPINGS[1], reporting_round=3)
-    db.session.commit()
-    organisation = Organisation.query.filter(
-        Organisation.organisation_name == "A District Council From Hogwarts"
-    ).first()
-    assert organisation.geography == "new geography"
 
 
 def test_load_outputs_outcomes_ref(test_client_reset, mock_r3_data_dict, mock_excel_file, mock_successful_file_upload):

--- a/tests/resources/organisation_dim.csv
+++ b/tests/resources/organisation_dim.csv
@@ -1,2 +1,2 @@
-id,organisation_name,geography
-0f0fc549-80ca-4868-a115-ede076023076,A District Council From Hogwarts,SW1 1AA
+id,organisation_name
+0f0fc549-80ca-4868-a115-ede076023076,A District Council From Hogwarts


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FPASF-609
(please see Gideon's comment to drop "geography" column).

Description:
This PR is part 1 to drop the "geography" column from the "Organisation" model. 

We've never used it, it was set to None during ingest. 
It was used in tests only. 
This PR: 
- removes the column from the model, 
- removes it from mappings and lookups,
- removes it from data serialisation, 
- removes it from tests and from some doctstrings, where it wasn't actually used,
- removes it from test csv setup files,
- removes it from other places, where it was "used". 

Note that the DB migration tests are failing. Migration file will follow. 


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
