### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -39,5 +39,5 @@ types-WTForms
 pip-tools
 
 
-pre-commit
+pre-commit~=4.0.0
 ruff==0.6.7  # If bumping this, please also bump .pre-commit-config.yml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -293,7 +293,7 @@ playwright==1.45.1
     # via pytest-playwright
 pluggy==1.0.0
     # via pytest
-pre-commit==3.6.1
+pre-commit==4.0.1
     # via -r requirements-dev.in
 prompt-toolkit==3.0.47
     # via


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.