### PR TITLE
Fix non aschii filename error

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -503,7 +503,7 @@ def save_submission_file_s3(excel_file: FileStorage, submission_id: str):
         object_name=f"{fund_type}/{str(uuid)}",
         metadata={
             "submission_id": submission_id,
-            "filename": excel_file.filename,
+            "filename": f"{fund_type}-{str(uuid)}.xlsx",
             "programme_name": programme_name,
         },
     )

--- a/tests/integration_tests/test_aws.py
+++ b/tests/integration_tests/test_aws.py
@@ -92,7 +92,7 @@ def test_save_submission_file_s3(seeded_test_client, test_buckets):
 
     assert response["Body"].read() == filebytes
     assert metadata["submission_id"] == submission_id
-    assert metadata["filename"] == filename
+    assert metadata["filename"] == f"HS-{uuid}.xlsx"
     assert metadata["programme_name"] == "Leaky Cauldron regeneration"
 
 


### PR DESCRIPTION
### Change description
Fixes the recent Sentry error caused by uploading files with non-aschii names. 

The change make it so we no longer use the user submitted file name on AWS upload.
The user confirmation email will still show the user submitted file name. 


### How to test
Use a file with non-aschii chars and try to submit it.
