### PR TITLE
Extend from shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
-  ],
-  "pre-commit": {
-    "enabled": true
-  },
-  "packageRules": [
-    {
-      "groupName": "Ruff updates",
-      "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"],
-      "matchManagers": ["pep621", "pre-commit"]
-    }
+    "github>communitiesuk/renovate-config"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "pre-commit": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "groupName": "Ruff updates",
+      "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"],
+      "matchManagers": ["pep621", "pre-commit"]
+    }
   ]
 }


### PR DESCRIPTION
### Change description
Pulls renovate config from a shared central repository ([communitiesuk/renovate-config](https://github.com/communitiesuk/renovate-config/blob/main/default.json)). The main difference this adds, for now, is that it will group updates for ruff in Python and pre-commit together, because otherwise it's annoying.