### PR TITLE
Update Spreadsheet Retrieval using Metadata

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -28,6 +28,7 @@ from data_store.controllers.load_functions import (
     get_or_generate_submission_id,
 )
 from data_store.controllers.mappings import INGEST_MAPPINGS, DataMapping
+from data_store.controllers.retrieve_submission_file import get_custom_file_name
 from data_store.db import db
 from data_store.db.entities import Fund, Programme, ProgrammeJunction, Submission
 from data_store.db.queries import (
@@ -504,6 +505,7 @@ def save_submission_file_s3(excel_file: FileStorage, submission_id: str):
         metadata={
             "submission_id": submission_id,
             "filename": f"{fund_type}-{str(uuid)}.xlsx",
+            "download_filename": f"{get_custom_file_name(uuid)}.xlsx",
             "programme_name": programme_name,
         },
     )

--- a/data_store/controllers/retrieve_submission_file.py
+++ b/data_store/controllers/retrieve_submission_file.py
@@ -71,10 +71,13 @@ def get_custom_file_name(submission_id: str) -> str:
         .one_or_none()
     )
 
-    date = submission_info.submission_date.strftime("%Y-%m-%d")
-    start_date = submission_info.observation_period_start.strftime("%b%Y")
-    end_date = submission_info.observation_period_end.strftime("%b%Y")
+    if submission_info:
+        date = submission_info.submission_date.strftime("%Y-%m-%d")
+        start_date = submission_info.observation_period_start.strftime("%b%Y")
+        end_date = submission_info.observation_period_end.strftime("%b%Y")
 
-    file_name = f"{date}-{submission_info.fund_code}-{submission_info.organisation_name}-{start_date}-{end_date}"
+        file_name = f"{date}-{submission_info.fund_code}-{submission_info.organisation_name}-{start_date}-{end_date}"
+    else:
+        file_name = f"data-return-{submission_id}"
 
     return file_name.replace(" ", "-").lower()

--- a/data_store/controllers/retrieve_submission_file.py
+++ b/data_store/controllers/retrieve_submission_file.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from config import Config
 from data_store.aws import create_presigned_url, get_file_header
 from data_store.db.entities import Fund, Organisation, Programme, ProgrammeJunction, ReportingRound, Submission
@@ -52,7 +54,12 @@ def retrieve_submission_file(submission_id) -> str:
     return presigned_url
 
 
-def get_custom_file_name(submission_id: str) -> str:
+def get_custom_file_name(
+    submission_id: str,
+    fallback_date: Optional[str] = None,
+    fallback_fund_code: Optional[str] = None,
+    fallback_org_name: Optional[str] = None,
+) -> str:
     submission_info = (
         Programme.query.join(ProgrammeJunction)
         .join(Submission)
@@ -78,6 +85,9 @@ def get_custom_file_name(submission_id: str) -> str:
 
         file_name = f"{date}-{submission_info.fund_code}-{submission_info.organisation_name}-{start_date}-{end_date}"
     else:
-        file_name = f"data-return-{submission_id}"
+        date = fallback_date
+        fund_code = fallback_fund_code
+        org_name = fallback_org_name
+        file_name = f"{date}-{fund_code}-{org_name}-{submission_id}"
 
     return file_name.replace(" ", "-").lower()

--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -13,6 +13,7 @@ from flask import (
 from config import Config
 
 from data_store.aws import create_presigned_url, get_file_header
+from data_store.controllers.retrieve_submission_file import get_custom_file_name
 from find.main.decorators import check_internal_user
 
 # isort: on
@@ -197,7 +198,7 @@ def retrieve_spreadsheet(fund_code: str, submission_id: str):
     file_metadata = file_header["metadata"]
     file_name = file_metadata.get("download_filename")
     if not file_name:
-        file_name = f"{fund_code}-{submission_id}"
+        file_name = (f"{get_custom_file_name(submission_id)}.xlsx",)
     if form.validate_on_submit():
         presigned_url = create_presigned_url(
             bucket_name=Config.AWS_S3_BUCKET_SUCCESSFUL_FILES,

--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -197,8 +197,16 @@ def retrieve_spreadsheet(fund_code: str, submission_id: str):
     form = RetrieveForm()
     file_metadata = file_header["metadata"]
     file_name = file_metadata.get("download_filename")
+    programme_name = file_metadata.get("programme_name")
+    submission_date = file_header["last_modified"].strftime("%d %B %Y")
     if not file_name:
-        file_name = (f"{get_custom_file_name(submission_id)}.xlsx",)
+        custom_file_name = get_custom_file_name(
+            submission_id=submission_id,
+            fallback_date=submission_date,
+            fallback_fund_code=fund_code,
+            fallback_org_name=programme_name,
+        )
+        file_name = f"{custom_file_name}.xlsx"
     if form.validate_on_submit():
         presigned_url = create_presigned_url(
             bucket_name=Config.AWS_S3_BUCKET_SUCCESSFUL_FILES,

--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -13,7 +13,6 @@ from flask import (
 from config import Config
 
 from data_store.aws import create_presigned_url, get_file_header
-from data_store.controllers.retrieve_submission_file import get_custom_file_name
 from find.main.decorators import check_internal_user
 
 # isort: on
@@ -195,12 +194,15 @@ def retrieve_spreadsheet(fund_code: str, submission_id: str):
         return abort(404)
 
     form = RetrieveForm()
-
+    file_metadata = file_header["metadata"]
+    file_name = file_metadata.get("download_filename")
+    if not file_name:
+        file_name = f"{fund_code}-{submission_id}"
     if form.validate_on_submit():
         presigned_url = create_presigned_url(
             bucket_name=Config.AWS_S3_BUCKET_SUCCESSFUL_FILES,
             file_key=object_name,
-            filename=f"{get_custom_file_name(submission_id)}.xlsx",
+            filename=file_name,
         )
 
         return redirect(presigned_url)


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-788

When a Local Authority (LA) submits their return, we send the fund team a link to download the file. If the LA re-submits the file, the old submission is removed, and the fund team gets an error because the submission_id has changed.

To fix this, we now store the filename in the `download_filename` metadata when the file is uploaded. This way, we can use the metadata to retrieve the file instead of relying on the database. For older files, if the new metadata is missing, we use a custom fallback name to ensure the file can still be accessed.
