### PR TITLE
Making ascii safe filenames for submission

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -1,6 +1,5 @@
 """Provides a controller for spreadsheet ingestion."""
 
-import os
 import typing
 import uuid
 from datetime import datetime
@@ -526,8 +525,7 @@ def make_ascii_safe_filename(filename: str) -> str:
     """
     Converts a filename to an ASCII-safe format.
     """
-    base, ext = os.path.splitext(filename)
+    ascii_safe_filename = filename.encode("ascii", "replace").decode("ascii")
+    ascii_safe_filename = ascii_safe_filename.replace("?", "--")
 
-    base = "".join((c if ord(c) < 128 else "-") for c in base)
-
-    return f"{base}{ext}"
+    return ascii_safe_filename

--- a/tests/integration_tests/test_aws.py
+++ b/tests/integration_tests/test_aws.py
@@ -97,8 +97,8 @@ def test_save_submission_file_s3(seeded_test_client, test_buckets):
 
 
 def test_save_submission_file_s3_ascii_safe(seeded_test_client, test_buckets):
-    filename = "example–file.xlsx"
-    ascii_safe_filename = "example-file.xlsx"
+    filename = "example\u2013file.xlsx"
+    ascii_safe_filename = "example--file.xlsx"
     filebytes = b"example file contents"
     file = FileStorage(io.BytesIO(filebytes), filename=filename, content_type=EXCEL_MIMETYPE)
 

--- a/tests/submit_tests/test_utils.py
+++ b/tests/submit_tests/test_utils.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from data_store.controllers.ingest import make_ascii_safe_filename
 from submit.utils import days_between_dates
 
@@ -20,35 +22,17 @@ def test_calculate_past_date(submit_test_client):
     assert days_remaining == -20
 
 
-def test_ascii_safe_filename_with_non_ascii_characters():
-    filename = "téstfilé_2024.xlsx"
-    expected_output = "t--stfil--_2024.xlsx"
-
-    assert make_ascii_safe_filename(filename) == expected_output
-
-
-def test_ascii_safe_filename_with_trailing_non_ascii():
-    filename = "testfile_2024é.xlsx"
-    expected_output = "testfile_2024--.xlsx"
-
-    assert make_ascii_safe_filename(filename) == expected_output
-
-
-def test_ascii_safe_filename_with_empty_filename():
-    filename = ""
-    expected_output = ""
-
-    assert make_ascii_safe_filename(filename) == expected_output
-
-
-def test_ascii_safe_filename_with_invalid_ascii_characters():
-    filename = "file_2024é.xlsx"
-    expected_output = "file_2024--.xlsx"
-
-    assert make_ascii_safe_filename(filename) == expected_output
-
-
-def test_ascii_safe_filename_with_only_invalid_ascii():
-    filename = "file_2024\u2019.xlsx"
-    expected_output = "file_2024--.xlsx"
+@pytest.mark.parametrize(
+    "filename, expected_output",
+    (
+        ("téstfilé_2024.xlsx", "t--stfil--_2024.xlsx"),
+        ("testfile_2024é.xlsx", "testfile_2024--.xlsx"),
+        ("file_2024é.xlsx", "file_2024--.xlsx"),
+        ("file_2024\u2019.xlsx", "file_2024--.xlsx"),
+        ("return_2024 🎉.xlsx", "return_2024 --.xlsx"),
+        ("return_2024 こん.xlsx", "return_2024 ----.xlsx"),
+        ("return_2024 £123®.xlsx", "return_2024 --123--.xlsx"),
+    ),
+)
+def test_ascii_safe_filename(filename, expected_output):
     assert make_ascii_safe_filename(filename) == expected_output

--- a/tests/submit_tests/test_utils.py
+++ b/tests/submit_tests/test_utils.py
@@ -1,5 +1,6 @@
 import datetime
 
+from data_store.controllers.ingest import make_ascii_safe_filename
 from submit.utils import days_between_dates
 
 
@@ -17,3 +18,37 @@ def test_calculate_past_date(submit_test_client):
 
     days_remaining = days_between_dates(date_1, date_2)
     assert days_remaining == -20
+
+
+def test_ascii_safe_filename_with_non_ascii_characters():
+    filename = "téstfilé_2024.xlsx"
+    expected_output = "t--stfil--_2024.xlsx"
+
+    assert make_ascii_safe_filename(filename) == expected_output
+
+
+def test_ascii_safe_filename_with_trailing_non_ascii():
+    filename = "testfile_2024é.xlsx"
+    expected_output = "testfile_2024--.xlsx"
+
+    assert make_ascii_safe_filename(filename) == expected_output
+
+
+def test_ascii_safe_filename_with_empty_filename():
+    filename = ""
+    expected_output = ""
+
+    assert make_ascii_safe_filename(filename) == expected_output
+
+
+def test_ascii_safe_filename_with_invalid_ascii_characters():
+    filename = "file_2024é.xlsx"
+    expected_output = "file_2024--.xlsx"
+
+    assert make_ascii_safe_filename(filename) == expected_output
+
+
+def test_ascii_safe_filename_with_only_invalid_ascii():
+    filename = "file_2024\u2019.xlsx"
+    expected_output = "file_2024--.xlsx"
+    assert make_ascii_safe_filename(filename) == expected_output


### PR DESCRIPTION
When a user uploaded a file with a non-ASCII safe filename, it caused an error in our system (logged on Sentry).

To address this, I made the following updates:

When a file is uploaded, we first try to make the original filename ASCII-safe.
If for any reason the filename cannot be sanitised e.g., it contains characters that can’t be converted to ASCII, the system automatically falls back to a user-friendly, filename.
This ensures that file uploads will always work smoothly, even when the original filename contains problematic characters. Users will either get an ASCII-safe version of the original filename or a simple, readable fallback name.


- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
