### PR TITLE
FLS-807-retrieve-spreadsheet-issue

### DIFF
--- a/find/main/routes.py
+++ b/find/main/routes.py
@@ -11,7 +11,7 @@ from flask import (
 )
 
 from config import Config
-
+from urllib.parse import quote
 from data_store.aws import create_presigned_url, get_file_header
 from data_store.controllers.retrieve_submission_file import get_custom_file_name
 
@@ -195,7 +195,7 @@ def retrieve_spreadsheet(fund_code: str, submission_id: str):
 
     form = RetrieveForm()
     file_metadata = file_header["metadata"]
-    file_name = file_metadata.get("download_filename")
+    file_name = quote(file_metadata.get("download_filename"))
     programme_name = file_metadata.get("programme_name")
     submission_date = file_header["last_modified"].strftime("%d %B %Y")
     if not file_name:


### PR DESCRIPTION
We received a [support ticket](https://mhclgdigital.atlassian.net/jira/servicedesk/projects/FSDS/queues/custom/44/FSDS-636) from the Towns Fund team. They reported that they couldn't download a file from the submission of one of the Local Authorities (LA) in their Towns Fund mailbox. After looking into it, I discovered that the LA's Organisation Name had a comma (,) in it. This was causing an issue when trying to fetch the file from the server.

Even though we’re not using the original filename from the LA, we generate our own filenames by including the Organisation Name to make it more user-friendly. The problem occurred when we tried to download the file using a presigned URL from AWS S3. The comma in the organisation name was getting encoded into something like %2C in the URL, but this encoding doesn’t match the actual filename in S3. As a result, the download failed because the system couldn't find the file.

To fix this, I’m using Python's quote lib to encode the filename properly before generating the presigned URL. This ensures that any special characters, like commas, are safely handled and make the filename compatible with browsers.

This is the file name our code generated in this case.
'2024-11-20-td-bournemouth, christchurch-and-poole-council-apr2024-sep2024.xlsx'

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test

You may test it by clicking the below link and try to download the file. It will generate the presigned url but not able to download the file. 

https://find-monitoring-data.access-funding.levellingup.gov.uk/retrieve-spreadsheet/TD/fac9b013-6f7d-46cd-9dc2-9b1166bbaffe


### Screenshots of UI changes (if applicable)
