### PR TITLE
Replace deprecated append with pandas concat

### DIFF
--- a/scripts/update-tf-grant-awarded.py
+++ b/scripts/update-tf-grant-awarded.py
@@ -63,7 +63,7 @@ fhsf_df.rename(
 fhsf_df["RDEL"] = 0
 fhsf_df["CDEL"] = 0
 
-combined_data = fhsf_df.append(td_df)  # type: ignore # TODO: fixme
+combined_data = pd.concat([fhsf_df, td_df])
 
 combined_data.to_csv(
     "data_store/validation/towns_fund/fund_specific_validation/resources/TF-grant-awarded.csv",


### PR DESCRIPTION
Replacing deprecated .append with pandas contact and to resolve mypy complains for type checking.


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

