### PR TITLE
Don't call API if there are no users

### DIFF
--- a/find/scripts/extract_download_logs.py
+++ b/find/scripts/extract_download_logs.py
@@ -76,7 +76,8 @@ def get_email_addresses_for_user_ids(user_ids: List[str]) -> dict:
     args: user_ids: list of user_ids
     returns: dict of user_id: email_address
     """
-
+    if not user_ids:
+        return {}
     account_store_api_host = os.getenv("ACCOUNT_STORE_API_HOST", "http://localhost:3003")
     user_ids_str = ",".join(user_ids)
     url = f"{account_store_api_host}/bulk-accounts?account_id={user_ids_str}"


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-207

### Change description
The account-store endpoint 400s/500s if there are no account IDs to resolve, which breaks this script.

If there are no account IDs, let's shortcircuit that bit.