### PR TITLE
Allow negative value submit for Stockton

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -115,14 +115,15 @@ def ingest(  # noqa: C901
     # Set these values for reporting sentry metrics via `core.metrics:capture_ingest_metrics`
     g.organisation_name = __get_organisation_name(fund_name, workbook_data)
 
-    if all(
-        [
-            fund_name == "Pathfinders",
-            reporting_round == 2,
-            any(substring in g.organisation_name for substring in ["Stockton-on-Tees", "Stockton on Tees"]),
-        ]
-    ):
-        ingest_dependencies = alter_validations_for_stockton(ingest_dependencies)
+    if g.organisation_name and isinstance(g.organisation_name, str):
+        if all(
+            [
+                fund_name == "Pathfinders",
+                reporting_round == 2,
+                any(substring in g.organisation_name for substring in ["Stockton-on-Tees", "Stockton on Tees"]),
+            ]
+        ):
+            ingest_dependencies = alter_validations_for_stockton(ingest_dependencies)
 
     try:
         initial_validate(workbook_data, ingest_dependencies.initial_validation_schema, auth)

--- a/data_store/controllers/ingest_dependencies.py
+++ b/data_store/controllers/ingest_dependencies.py
@@ -31,6 +31,7 @@ from data_store.validation.pathfinders.cross_table_validation.ct_validate_r1 imp
 from data_store.validation.pathfinders.cross_table_validation.ct_validate_r2 import (
     cross_table_validate as pf_r2_cross_table_validate,
 )
+from data_store.validation.pathfinders.schema_validation.columns import float_column
 from data_store.validation.towns_fund.failures.user import GenericFailure
 from data_store.validation.towns_fund.schema_validation.schemas import (
     TF_ROUND_3_VAL_SCHEMA,
@@ -155,3 +156,27 @@ def ingest_dependencies_factory(fund: str, reporting_round: int) -> IngestDepend
             )
         case _:
             return None
+
+
+def alter_validations_for_stockton(ingest_dependency: IngestDependencies) -> IngestDependencies:
+    """
+    Drop checking the column "Total cumulative actuals to date, (Up to and including Mar 2024), Actual" from the
+    PFIngestDependencies 'extract_process_validate_schema' configuration, for Stockton-on-Tees Borough Council,
+    to allow them to submit negative values in this column.
+
+    Also, do the same for the "Amount moved" column in the "Project finance changes" table.
+    """
+
+    try:
+        ingest_dependency.extract_process_validate_schema["Forecast and actual spend (capital)"].validate.columns[
+            "Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
+        ] = float_column()
+
+        ingest_dependency.extract_process_validate_schema["Project finance changes"].validate.columns[
+            "Amount moved"
+        ] = float_column()
+
+    except KeyError:
+        pass
+
+    return ingest_dependency

--- a/tests/integration_tests/test_ingest_metrics.py
+++ b/tests/integration_tests/test_ingest_metrics.py
@@ -12,7 +12,7 @@ def test_sentry_metrics_emitted_from_ingest_endpoint(
     test_client_reset,
     towns_fund_round_3_file_success,
     towns_fund_round_4_round_agnostic_failures,
-    pathfinders_round_1_file_success,
+    pathfinders_round_2_file_success,
     test_buckets,
     mock_sentry_metrics,
 ):
@@ -40,9 +40,9 @@ def test_sentry_metrics_emitted_from_ingest_endpoint(
     )
 
     ingest(
-        excel_file=FileStorage(pathfinders_round_1_file_success, content_type=EXCEL_MIMETYPE),
+        excel_file=FileStorage(pathfinders_round_2_file_success, content_type=EXCEL_MIMETYPE),
         fund_name="Pathfinders",
-        reporting_round=1,
+        reporting_round=2,
         do_load=True,
         auth={"Programme": ("Bolton Council",), "Fund Types": ("Pathfinders",)},
     )
@@ -79,12 +79,12 @@ def test_sentry_metrics_emitted_from_ingest_endpoint(
         mock.call(
             FundingMetrics.SUBMISSION,
             1,
-            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council"},
+            tags={"fund": "Pathfinders", "reporting_round": 2, "organisation": "Bolton Council"},
         ),
         mock.call(
             FundingMetrics.SUBMISSION_INGEST_RESULT,
             1,
-            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council", "result": "success"},
+            tags={"fund": "Pathfinders", "reporting_round": 2, "organisation": "Bolton Council", "result": "success"},
         ),
     ]
     assert mock_sentry_metrics.distribution.call_args_list == [
@@ -147,6 +147,6 @@ def test_sentry_metrics_emitted_from_ingest_endpoint(
         mock.call(
             FundingMetrics.SUBMISSION_VALIDATION_ERRORS_TOTAL,
             0,
-            tags={"fund": "Pathfinders", "reporting_round": 1, "organisation": "Bolton Council"},
+            tags={"fund": "Pathfinders", "reporting_round": 2, "organisation": "Bolton Council"},
         ),
     ]


### PR DESCRIPTION
**Ticket:**
https://mhclgdigital.atlassian.net/browse/FLS-909

**Description:**
PF Team requested to make an exception for Stockton-on-Tees Borough Council, to allow them submitting negative values in the spreadsheet's "Finances" tab. 

**How to test:**
1. In config.envs.development.py, to class DevelopmentConfig, add:     "Stockton-on-Tees Borough Council”   to PF_ADDITIONAL_EMAIL_LOOKUPS[domain] to be able to submit the test spreadsheet:

PF_ADDITIONAL_EMAIL_LOOKUPS = {
        domain: (("Rotherham Metropolitan Borough Council", "Bolton Council", "Wirral Council", "Test Council", 
                  **"Stockton-on-Tees Borough Council"**),)
        for domain in ("communities.gov.uk", "test.communities.gov.uk")
    }

2. Email me to send the test spreadsheet over with the negative values (can't be downloaded from the ticket, or at least I 
couldn't).

3. Submit this test file, the "regular" PF_Round_2_Success.xlsx, and also the TF_Round_6_Success.xlsx files.
All three submissions should be successful. 