### PR TITLE
Alter IngestDependencies to allow submit negative values on Finances/…

### DIFF
--- a/data_store/controllers/ingest_dependencies.py
+++ b/data_store/controllers/ingest_dependencies.py
@@ -172,6 +172,10 @@ def alter_validations_for_stockton(ingest_dependency: IngestDependencies) -> Ing
             "Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
         ] = float_column()
 
+        ingest_dependency.extract_process_validate_schema["Forecast and actual spend (revenue)"].validate.columns[
+            "Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
+        ] = float_column()
+
         ingest_dependency.extract_process_validate_schema["Project finance changes"].validate.columns[
             "Amount moved"
         ] = float_column()


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net/browse/FLS-909

Description:
PF Team requested to make an exception for Stockton-on-Tees Borough Council, to allow them submitting negative values in the spreadsheet's "Finances" tab.

The below PR removed validation for 
"Forecast and actual spend (capital)""Total cumulative actuals to date, (Up to and including Mar 2024), Actual" and 
"Project finance changes""Amount moved" columns.
https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/887

This PR removes validation for one more column: 
"Forecast and actual spend (revenue)""Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
The reason for doing it is because Pathfinders Team advised that Stockton LA might enter negative values into some of the cells in this column. 

How to test:

In config.envs.development.py, to class DevelopmentConfig, add: "Stockton-on-Tees Borough Council” to PF_ADDITIONAL_EMAIL_LOOKUPS[domain] to be able to submit the test spreadsheet:
PF_ADDITIONAL_EMAIL_LOOKUPS = {
domain: (("Rotherham Metropolitan Borough Council", "Bolton Council", "Wirral Council", "Test Council",
"Stockton-on-Tees Borough Council"),)
for domain in ("communities.gov.uk", "test.communities.gov.uk")
}

Email me to send the test spreadsheet over with the negative values (can't be downloaded from the ticket, or at least I
couldn't).
Alternatively, PF_Round_2_Success.xlsx file also can be used to test this functionality, if a negative value is entered into C33 cell of "Finances" tab. 

Submit this test file, the "regular" PF_Round_2_Success.xlsx, and also the TF_Round_6_Success.xlsx files.
All three submissions should be successful.