### PR TITLE
Add failed deployment notifications

### DIFF
--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -95,14 +95,14 @@ jobs:
       - migrate
       - deploy
       - e2e_test
-    if: ${{ always() && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
+    if: ${{ failure() }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
     with:
       app_name: post-award
       env_name: ${{ inputs.copilot_environment }}
       github_username: ${{ github.actor }}
       workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || 'https://www.mockstatus.com/404' }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}

--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -89,3 +89,20 @@ jobs:
     with:
       copilot_environment: test
     secrets: inherit
+
+  notify_slack:
+    needs:
+      - migrate
+      - deploy
+      - e2e_test
+    if: ${{ always() && !cancelled() && inputs.copilot_environment != 'dev' && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
+    with:
+      app_name: post-award
+      env_name: ${{ inputs.copilot_environment }}
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}

--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -87,7 +87,7 @@ jobs:
     needs: [ migrate, deploy ]
     uses: ./.github/workflows/test_e2e.yml
     with:
-      copilot_environment: test
+      copilot_environment: ${{ inputs.copilot_environment || 'test' }}
     secrets: inherit
 
   notify_slack:
@@ -95,7 +95,7 @@ jobs:
       - migrate
       - deploy
       - e2e_test
-    if: ${{ always() && !cancelled() && inputs.copilot_environment != 'dev' && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
+    if: ${{ always() && !cancelled() && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
     with:
       app_name: post-award

--- a/.github/workflows/aws_copilot_deployment.yml
+++ b/.github/workflows/aws_copilot_deployment.yml
@@ -95,7 +95,7 @@ jobs:
       - migrate
       - deploy
       - e2e_test
-    if: ${{ always() && !cancelled() && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
+    if: ${{ always() && (needs.migrate.result == 'failure' || needs.deploy.result == 'failure' || needs.e2e_test.result == 'failure') }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
     with:
       app_name: post-award


### PR DESCRIPTION
### Change description
https://mhclgdigital.atlassian.net/browse/FSPT-220

Adds a slack notification if this pipeline fails.

Should not trigger if the pipeline deploy to prod is rejected by a developer, or the pipeline run is cancelled.

<img width="593" alt="image" src="https://github.com/user-attachments/assets/b3d84e86-0e5c-48d6-937b-e7ea7a5ad31b" />
