### PR TITLE
FSPT-228: Migrate to communities domain

### DIFF
--- a/copilot/post-award-celery/manifest.yml
+++ b/copilot/post-award-celery/manifest.yml
@@ -70,6 +70,6 @@ environments:
       FIND_HOST: find-monitoring-data.test.access-funding.test.levellingup.gov.uk
   dev:
     variables:
-      FIND_SERVICE_BASE_URL: https://find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-      SUBMIT_HOST: submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-      FIND_HOST: find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
+      FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk
+      SUBMIT_HOST: submit-monitoring-data.access-funding.dev.communities.gov.uk
+      FIND_HOST: find-monitoring-data.access-funding.dev.communities.gov.uk

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -131,7 +131,7 @@ environments:
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk
       COOKIE_DOMAIN: '.access-funding.dev.communities.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.access-funding.dev.communities.gov.uk
-      FIND_HOST: find-monitoring-data.dev.access-funding.dev.levellingup.gov.uk
+      FIND_HOST: find-monitoring-data.access-funding.dev.communities.gov.uk
       AUTHENTICATOR_HOST: https://authenticator.access-funding.dev.communities.gov.uk
     sidecars:
       nginx:

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -117,15 +117,7 @@ environments:
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
   dev:
     http:
-      alias:
-        - name: find-monitoring-data.access-funding.dev.communities.gov.uk
-          hosted_zone: Z07692681FIG4XS8G7GOK
-        - name: find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-          hosted_zone: Z0988423GWW2B561EM4Y
-        - name: submit-monitoring-data.access-funding.dev.communities.gov.uk
-          hosted_zone: Z07692681FIG4XS8G7GOK
-        - name: submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-          hosted_zone: Z0988423GWW2B561EM4Y
+      alias: ["find-monitoring-data.access-funding.dev.communities.gov.uk", "find-monitoring-data.dev.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.access-funding.dev.communities.gov.uk", "submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk"]
       target_container: nginx
       healthcheck:
         path: /healthcheck

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -58,7 +58,6 @@ secrets:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-postawardclusterAuroraSecret
   REDIS_URL:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-PostAwardRedisUrl
-  AUTHENTICATOR_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_AUTHENTICATOR_HOST
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_SECRET_KEY
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_RSA256_PUBLIC_KEY_BASE64
   TF_ADDITIONAL_EMAIL_LOOKUPS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_TF_ADDITIONAL_EMAIL_LOOKUPS
@@ -129,10 +128,11 @@ environments:
         grace_period: 10s
     variables:
       SENTRY_TRACES_SAMPLE_RATE: 1.0
-      FIND_SERVICE_BASE_URL: https://find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-      COOKIE_DOMAIN: '.dev.access-funding.test.levellingup.gov.uk'
-      SUBMIT_HOST: submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk
-      FIND_HOST: find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
+      FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk
+      COOKIE_DOMAIN: '.access-funding.dev.communities.gov.uk'
+      SUBMIT_HOST: submit-monitoring-data.access-funding.dev.communities.gov.uk
+      FIND_HOST: find-monitoring-data.dev.access-funding.dev.levellingup.gov.uk
+      AUTHENTICATOR_HOST: https://authenticator.access-funding.dev.communities.gov.uk
     sidecars:
       nginx:
         port: 8087

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -117,7 +117,15 @@ environments:
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
   dev:
     http:
-      alias: ["find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"]
+      alias:
+        - name: find-monitoring-data.access-funding.dev.communities.gov.uk
+          hosted_zone: Z07692681FIG4XS8G7GOK
+        - name: find-monitoring-data.dev.access-funding.test.levellingup.gov.uk
+          hosted_zone: Z0988423GWW2B561EM4Y
+        - name: submit-monitoring-data.access-funding.dev.communities.gov.uk
+          hosted_zone: Z07692681FIG4XS8G7GOK
+        - name: submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk
+          hosted_zone: Z0988423GWW2B561EM4Y
       target_container: nginx
       healthcheck:
         path: /healthcheck

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -117,7 +117,7 @@ environments:
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
   dev:
     http:
-      alias: ["find-monitoring-data.access-funding.dev.communities.gov.uk", "find-monitoring-data.dev.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.access-funding.dev.communities.gov.uk", "submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk"]
+      alias: ["find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk", "find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk", "submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"]
       target_container: nginx
       healthcheck:
         path: /healthcheck
@@ -128,11 +128,11 @@ environments:
         grace_period: 10s
     variables:
       SENTRY_TRACES_SAMPLE_RATE: 1.0
-      FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk
-      COOKIE_DOMAIN: '.access-funding.dev.communities.gov.uk'
-      SUBMIT_HOST: submit-monitoring-data.access-funding.dev.communities.gov.uk
-      FIND_HOST: find-monitoring-data.access-funding.dev.communities.gov.uk
-      AUTHENTICATOR_HOST: https://authenticator.access-funding.dev.communities.gov.uk
+      FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
+      COOKIE_DOMAIN: '.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk'
+      SUBMIT_HOST: submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
+      FIND_HOST: find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
+      AUTHENTICATOR_HOST: https://authenticator.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
     sidecars:
       nginx:
         port: 8087

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -33,10 +33,10 @@ def domains(request: FixtureRequest) -> FundingServiceDomains:
         )
     elif e2e_env == "dev":
         return FundingServiceDomains(
-            cookie=".dev.access-funding.test.levellingup.gov.uk",
-            authenticator="https://authenticator.dev.access-funding.test.levellingup.gov.uk",
-            find="https://find-monitoring-data.dev.access-funding.test.levellingup.gov.uk",
-            submit="https://submit-monitoring-data.dev.access-funding.test.levellingup.gov.uk",
+            cookie=".access-funding.dev.communities.gov.uk",
+            authenticator="https://account.access-funding.dev.communities.gov.uk",
+            find="https://find-monitoring-data.access-funding.dev.communities.gov.uk",
+            submit="https://submit-monitoring-data.access-funding.dev.communities.gov.uk",
         )
     elif e2e_env == "test":
         return FundingServiceDomains(


### PR DESCRIPTION
### Change description
Migrates dev environment to communities domain

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have deployed and E2E tests pass. https://github.com/communitiesuk/funding-service-design-post-award-data-store/actions/runs/13570984959/job/37936408422

Note Authentication won't work on new domains until pre-award authenticator is also migrated to the communities domain


### Screenshots of UI changes (if applicable)
