### PR TITLE
FSPT-228: restore authenticator host on test and prod

### DIFF
--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -86,6 +86,7 @@ environments:
       COOKIE_DOMAIN: '.access-funding.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.access-funding.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.access-funding.levellingup.gov.uk
+      AUTHENTICATOR_HOST: https://authentictor.access-funding.levellingup.gov.uk
   test:
     http:
       alias: ["find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"]
@@ -103,6 +104,7 @@ environments:
       COOKIE_DOMAIN: '.test.access-funding.test.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.test.access-funding.test.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.test.access-funding.test.levellingup.gov.uk
+      AUTHENTICATOR_HOST: https://authenticator.test.access-funding.test.levellingup.gov.uk
     sidecars:
       nginx:
         port: 8087


### PR DESCRIPTION
### Change description
Fix after #935 

`AUTHENTICATOR_HOST` was no longer specified on test and prod leading to broken links

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Links to sign in should work


### Screenshots of UI changes (if applicable)
