### PR TITLE
FSPT-228: update test config to move to communities domain

### DIFF
--- a/copilot/post-award-celery/manifest.yml
+++ b/copilot/post-award-celery/manifest.yml
@@ -49,7 +49,6 @@ secrets:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-postawardclusterAuroraSecret
   REDIS_URL:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-PostAwardRedisUrl
-  AUTHENTICATOR_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_AUTHENTICATOR_HOST
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_SECRET_KEY
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_RSA256_PUBLIC_KEY_BASE64
   TF_ADDITIONAL_EMAIL_LOOKUPS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/POST_AWARD_TF_ADDITIONAL_EMAIL_LOOKUPS
@@ -63,13 +62,16 @@ environments:
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.levellingup.gov.uk
       SUBMIT_HOST: submit-monitoring-data.access-funding.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.access-funding.levellingup.gov.uk
+      AUTHENTICATOR_HOST: https://authenticator.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
   test:
     variables:
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.test.communities.gov.uk
       SUBMIT_HOST: submit-monitoring-data.access-funding.test.communities.gov.uk
       FIND_HOST: find-monitoring-data.access-funding.test.communities.gov.uk
+      AUTHENTICATOR_HOST: https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
   dev:
     variables:
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk
       SUBMIT_HOST: submit-monitoring-data.access-funding.dev.communities.gov.uk
       FIND_HOST: find-monitoring-data.access-funding.dev.communities.gov.uk
+      AUTHENTICATOR_HOST: https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk

--- a/copilot/post-award-celery/manifest.yml
+++ b/copilot/post-award-celery/manifest.yml
@@ -65,9 +65,9 @@ environments:
       FIND_HOST: find-monitoring-data.access-funding.levellingup.gov.uk
   test:
     variables:
-      FIND_SERVICE_BASE_URL: https://find-monitoring-data.test.access-funding.test.levellingup.gov.uk
-      SUBMIT_HOST: submit-monitoring-data.test.access-funding.test.levellingup.gov.uk
-      FIND_HOST: find-monitoring-data.test.access-funding.test.levellingup.gov.uk
+      FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.test.communities.gov.uk
+      SUBMIT_HOST: submit-monitoring-data.access-funding.test.communities.gov.uk
+      FIND_HOST: find-monitoring-data.access-funding.test.communities.gov.uk
   dev:
     variables:
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.dev.communities.gov.uk

--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -82,6 +82,7 @@ environments:
         grace_period: 10s
     count: 2
     variables:
+      AUTHENTICATOR_HOST: https://authenticator.access-funding.levellingup.gov.uk
       FIND_SERVICE_BASE_URL: https://find-monitoring-data.access-funding.levellingup.gov.uk
       COOKIE_DOMAIN: '.access-funding.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.access-funding.levellingup.gov.uk
@@ -89,7 +90,7 @@ environments:
       AUTHENTICATOR_HOST: https://authentictor.access-funding.levellingup.gov.uk
   test:
     http:
-      alias: ["find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"]
+      alias: ["find-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk", "find-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "submit-monitoring-data.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk", "submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"]
       target_container: nginx
       healthcheck:
         path: /healthcheck
@@ -104,7 +105,7 @@ environments:
       COOKIE_DOMAIN: '.test.access-funding.test.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.test.access-funding.test.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.test.access-funding.test.levellingup.gov.uk
-      AUTHENTICATOR_HOST: https://authenticator.test.access-funding.test.levellingup.gov.uk
+      AUTHENTICATOR_HOST: https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk
     sidecars:
       nginx:
         port: 8087


### PR DESCRIPTION
### Change description
update test config to move to test.communities.gov.uk domain

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
after deploying services should be available on the test.communities.gov.uk domain

### Screenshots of UI changes (if applicable)
