### PR TITLE
Revert "FLS-1038: Give permissions to Pre-award and Form-Runner-Adapter logs"

### DIFF
--- a/copilot/download-report/overrides/cfn.patches.yml
+++ b/copilot/download-report/overrides/cfn.patches.yml
@@ -28,5 +28,3 @@
             - 'logs:StartQuery'
           Resource:
             - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/copilot/${AppName}-${EnvName}-post-award:*'
-            - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/copilot/${AppName}-${EnvName}-fsd-pre-award:*'
-            - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/copilot/${AppName}-${EnvName}-fsd-form-runner-adapter:*'


### PR DESCRIPTION
Reverts communitiesuk/funding-service-design-post-award-data-store#936

No need for this in the end. `pre-award` will manage it's own logs.