### PR TITLE
Flip sentry traces sample rate

### DIFF
--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -42,6 +42,7 @@ variables:
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
   # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
   SENTRY_DSN: https://6a2623e302e641ba88eabe6675a70ddf@o1432034.ingest.sentry.io/4505390859747328
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
   AWS_S3_BUCKET_SUCCESSFUL_FILES:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-postawardsuccessfulfilesBucketName
   AWS_S3_BUCKET_FAILED_FILES:
@@ -93,6 +94,7 @@ environments:
       COOKIE_DOMAIN: '.access-funding.levellingup.gov.uk'
       SUBMIT_HOST: submit-monitoring-data.access-funding.levellingup.gov.uk
       FIND_HOST: find-monitoring-data.access-funding.levellingup.gov.uk
+      SENTRY_TRACES_SAMPLE_RATE: 1
   test:
     http:
       target_container: nginx
@@ -103,8 +105,6 @@ environments:
         interval: 6s
         timeout: 5s
         grace_period: 10s
-    variables:
-      SENTRY_TRACES_SAMPLE_RATE: 1.0
     sidecars:
       nginx:
         port: 8087
@@ -127,8 +127,6 @@ environments:
         interval: 6s
         timeout: 5s
         grace_period: 10s
-    variables:
-      SENTRY_TRACES_SAMPLE_RATE: 1.0
     sidecars:
       nginx:
         port: 8087


### PR DESCRIPTION
I originally set sentry to sample traces at high volume in dev/test/uat, but because of our regular e2e tests (and because we have a low allowance for spans) we're using up our allowance regularly, leading to gaps in our monitoring+observability.

I also don't think many of our team currently use sentry span insights in dev/test/uat in the way I'd intended, so spending our allowance here feels less useful.

Let's monitor prod at 100%, because those are likely to provide more realistic insights (and if there are errors, more information to help debug). The volume there is also significantly lower, so we should not have to worry about hitting our allowances.