### PR TITLE
Pathfinders R3 fix - don't raise KeyError for nan 'Reporting period change takes place' during cross-table validation

### DIFF
--- a/data_store/validation/pathfinders/cross_table_validation/ct_validate_r2.py
+++ b/data_store/validation/pathfinders/cross_table_validation/ct_validate_r2.py
@@ -437,6 +437,8 @@ def _check_actual_forecast_reporting_period(extracted_table_dfs: dict[str, pd.Da
     pfcs_df = extracted_table_dfs["Project finance changes"]
     error_messages = []
     for idx, row in pfcs_df.iterrows():
+        if row["Reporting period change takes place"] not in PFC_REPORTING_PERIOD_LABELS_TO_DATES:
+            continue
         change_reporting_period_start_date = PFC_REPORTING_PERIOD_LABELS_TO_DATES[
             row["Reporting period change takes place"]
         ]["start"]


### PR DESCRIPTION
We saw this Sentry error: https://funding-service-design-team-dl.sentry.io/issues/6607495381/?alert_rule_id=14533929&alert_type=issue&notification_uuid=7d28f148-173a-47be-b9a2-ef75cfd1f37d&project=4505390859747328&referrer=slack

Investigation showed that this was caused by a `nan` value for "Reporting period change takes place" in the "Project finance changes" table being indexed against a dictionary during cross-table validation, causing a `KeyError`. The reason for the `nan` value was that the user had erroneously entered the value "13" for the "Change number" field in that row in the spreadsheet, which meant that during backend table processing we did not drop the row as empty after replacing the "Please select an option" default dropdown placeholder value from the "Reporting period change takes place" field with the value `np.nan`. We then passed through schema validation with an error "The cell is blank but is required." for that field for that row (see the Sentry error breadcrumbs), but because we do schema validation and cross-table validation together (to prevent situations where the user resolves all errors listed but then gets hit by a second wave of errors), we still pass through from schema validation to cross-table validation.

The general solution is just to be more vigilant during cross-table validation, don't make any assumptions about the data. This PR implements that greater carefulness in this specific case.

I have mentioned to @israr-ulhaq to tell PF team to advise user who experienced the issue to simply remove the value 13 from the "Change number" field as a quick fix while we deploy this change out. 