### PR TITLE
Change Pathfinders validation to allow negative values

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -21,7 +21,7 @@ from data_store.controllers.ingest_dependencies import (
     IngestDependencies,
     PFIngestDependencies,
     TFIngestDependencies,
-    alter_validations_for_stockton,
+    alter_validations_for_local_authorities,
     ingest_dependencies_factory,
 )
 from data_store.controllers.load_functions import (
@@ -119,11 +119,14 @@ def ingest(  # noqa: C901
         if all(
             [
                 fund_name == "Pathfinders",
-                reporting_round == 2,
-                any(substring in g.organisation_name for substring in ["Stockton-on-Tees", "Stockton on Tees"]),
+                reporting_round == 3,
+                any(
+                    substring in g.organisation_name
+                    for substring in ["Stockton-on-Tees", "Stockton on Tees", "Bolton Council"]
+                ),
             ]
         ):
-            ingest_dependencies = alter_validations_for_stockton(ingest_dependencies)
+            ingest_dependencies = alter_validations_for_local_authorities(ingest_dependencies)
 
     try:
         initial_validate(workbook_data, ingest_dependencies.initial_validation_schema, auth)

--- a/data_store/controllers/ingest_dependencies.py
+++ b/data_store/controllers/ingest_dependencies.py
@@ -179,13 +179,11 @@ def ingest_dependencies_factory(fund: str, reporting_round: int) -> IngestDepend
             return None
 
 
-def alter_validations_for_stockton(ingest_dependency: IngestDependencies) -> IngestDependencies:
+def alter_validations_for_local_authorities(ingest_dependency: IngestDependencies) -> IngestDependencies:
     """
-    Drop checking the column "Total cumulative actuals to date, (Up to and including Mar 2024), Actual" from the
-    PFIngestDependencies 'extract_process_validate_schema' configuration, for Stockton-on-Tees Borough Council,
-    to allow them to submit negative values in this column.
+    Drop checking of specific columns from the PFIngestDependencies 'extract_process_validate_schema'
+    configuration, for some local authorities, to allow them to submit negative values in this column.
 
-    Also, do the same for the "Amount moved" column in the "Project finance changes" table.
     """
 
     try:
@@ -193,8 +191,16 @@ def alter_validations_for_stockton(ingest_dependency: IngestDependencies) -> Ing
             "Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
         ] = float_column()
 
+        ingest_dependency.extract_process_validate_schema["Forecast and actual spend (capital)"].validate.columns[
+            "Financial year 2024 to 2025, (Oct to Dec), Actual"
+        ] = float_column()
+
         ingest_dependency.extract_process_validate_schema["Forecast and actual spend (revenue)"].validate.columns[
             "Total cumulative actuals to date, (Up to and including Mar 2024), Actual"
+        ] = float_column()
+
+        ingest_dependency.extract_process_validate_schema["Forecast and actual spend (revenue)"].validate.columns[
+            "Financial year 2024 to 2025, (Oct to Dec), Actual"
         ] = float_column()
 
         ingest_dependency.extract_process_validate_schema["Project finance changes"].validate.columns[


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1300

Description:
Loosen Pathfinders return validation for Bolton Council to allow submission of negative values in the Finances tab, in G37
and G51 cells.
This change removes the negative value validation for the columns of these two cells. 

How to test:
Ping me to send the file over and submit that to the portal.