### PR TITLE
Fixing failed submission handling

### DIFF
--- a/data_store/controllers/ingest.py
+++ b/data_store/controllers/ingest.py
@@ -93,6 +93,7 @@ def ingest(  # noqa: C901
     :return: A JSON Response
     :raises ValidationError: raised if the data fails validation
     """
+    g.excel_file = excel_file  # Store the excel file in the global context for use in failed submission handling
     # Set these values for reporting sentry metrics via `core.metrics:capture_ingest_metrics`
     g.fund_name = fund_name
     g.reporting_round = reporting_round


### PR DESCRIPTION
Fixing failed submission handling in the case of `OldValidationError` by setting `excel_file` on the Flask global object `g` so that it is available in the `process_internal_failures` context.

This issue was found during analysis of this Sentry error: https://funding-service-design-team-dl.sentry.io/issues/6635473778/?alert_rule_id=14533929&alert_type=issue&notification_uuid=f7d642bf-46b8-4e43-b79b-d2794824de80&project=4505390859747328&referrer=slack

However that error was actually caused by the fact that one of the project names in the "Funding Profiles" (finances) tab had been overridden by the typo "v". The issue fixed by this PR just meant that the failed submission wasn't successfully saved to the failed submission bucket in AWS S3.