### PR TITLE
Update SENTRY_DSN in manifest.yml

### DIFF
--- a/copilot/post-award/manifest.yml
+++ b/copilot/post-award/manifest.yml
@@ -41,7 +41,7 @@ network:
 variables:
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
   # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
-  SENTRY_DSN: https://6a2623e302e641ba88eabe6675a70ddf@o1432034.ingest.sentry.io/4505390859747328
+  SENTRY_DSN: https://d57a9616c99832671a23110462c01c79@o4510940714041344.ingest.de.sentry.io/4511038185275472
   SENTRY_TRACES_SAMPLE_RATE: 0
   AWS_S3_BUCKET_SUCCESSFUL_FILES:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-postawardsuccessfulfilesBucketName


### PR DESCRIPTION
Update Sentry DSN to point to the new MHCLG enterprise Sentry org. We are migrating all Funding Service projects from our legacy US-region Sentry org to the new EU-region org as part of the department-wide enterprise migration. No functional changes - this just switches where error events are sent.

https://mhclgdigital.atlassian.net/browse/FSPT-1199